### PR TITLE
Fix imports in MapScreen

### DIFF
--- a/screens/map_screen.py
+++ b/screens/map_screen.py
@@ -16,7 +16,6 @@ import time
 
 import requests
 
-import pandas as pd
 
 import math
 


### PR DESCRIPTION
## Summary
- remove unused pandas import
- keep only one requests import

## Testing
- `pytest tests/test_map_screen.py tests/test_tile_cache.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684d73f726488333be11f11b3d93c96d