### PR TITLE
Implement backup and restore utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ PiWardrive is a headless Raspberry Pi 5 application that combines war-driving to
 * **Optional Profiling**: Set `PW_PROFILE=1` to log performance stats on exit.
 * **Health Monitoring**: Background widget shows service status, disk usage and network connectivity.
 * **Battery Widget**: Optional dashboard tile showing battery percentage if available.
+* **Scheduled Backups**: Periodically archive configuration and logs for easy restore.
 * **Unified Error Reporting**: Consistent alerts and logs when operations fail.
 * **Env Overrides**: configure any option via `PW_<KEY>` environment variables.
 

--- a/backup.py
+++ b/backup.py
@@ -1,0 +1,62 @@
+import os
+import tarfile
+from datetime import datetime
+
+import config
+from config import AppConfig
+from scheduler import PollScheduler
+
+DEFAULT_BACKUP_DIR = os.path.join(os.path.expanduser("~"), ".config", "piwardrive", "backups")
+
+
+def _backup_items(cfg: AppConfig) -> list[tuple[str, str]]:
+    """Return (path, arcname) pairs for files/dirs to backup."""
+    items = []
+    if os.path.exists(config.CONFIG_PATH):
+        items.append((config.CONFIG_PATH, 'config.json'))
+    if os.path.isdir(cfg.kismet_logdir):
+        items.append((cfg.kismet_logdir, 'kismet_logs'))
+    return items
+
+
+def create_backup(backup_dir: str | None = None, cfg: AppConfig | None = None) -> str:
+    """Create a ``.tar.gz`` archive of configuration and logs."""
+    cfg = cfg or AppConfig.load()
+    backup_dir = backup_dir or cfg.backup_dir
+    os.makedirs(backup_dir, exist_ok=True)
+    timestamp = datetime.now().strftime('%Y%m%d%H%M%S')
+    archive = os.path.join(backup_dir, f'backup-{timestamp}.tar.gz')
+    with tarfile.open(archive, 'w:gz') as tar:
+        for path, name in _backup_items(cfg):
+            tar.add(path, arcname=name)
+    return archive
+
+
+def restore_backup(archive_path: str, cfg: AppConfig | None = None) -> None:
+    """Restore configuration and logs from ``archive_path``."""
+    cfg = cfg or AppConfig.load()
+    with tarfile.open(archive_path, 'r:gz') as tar:
+        for member in tar.getmembers():
+            if member.name == 'config.json':
+                os.makedirs(os.path.dirname(config.CONFIG_PATH), exist_ok=True)
+                tar.extract(member, os.path.dirname(config.CONFIG_PATH))
+                os.replace(
+                    os.path.join(os.path.dirname(config.CONFIG_PATH), 'config.json'),
+                    config.CONFIG_PATH,
+                )
+            elif member.name.startswith('kismet_logs'):
+                if os.path.exists(cfg.kismet_logdir):
+                    import shutil
+                    shutil.rmtree(cfg.kismet_logdir, ignore_errors=True)
+                base = os.path.dirname(cfg.kismet_logdir)
+                os.makedirs(base, exist_ok=True)
+                tar.extract(member, base)
+                extracted = os.path.join(base, 'kismet_logs')
+                if os.path.exists(extracted) and extracted != cfg.kismet_logdir:
+                    os.replace(extracted, cfg.kismet_logdir)
+
+
+def schedule_backups(sched: PollScheduler, cfg: AppConfig | None = None) -> None:
+    """Schedule periodic backups using ``sched``."""
+    cfg = cfg or AppConfig.load()
+    sched.schedule('backup', lambda _dt: create_backup(cfg.backup_dir, cfg), cfg.backup_interval)

--- a/config.py
+++ b/config.py
@@ -29,6 +29,8 @@ CONFIG_SCHEMA = {
         "log_rotate_interval": {"type": "integer"},
         "log_rotate_archives": {"type": "integer"},
         "widget_battery_status": {"type": "boolean"},
+        "backup_dir": {"type": "string"},
+        "backup_interval": {"type": "integer"},
     },
     "additionalProperties": False,
 }
@@ -54,6 +56,8 @@ class Config:
     log_rotate_interval: int = 3600
     log_rotate_archives: int = 3
     widget_battery_status: bool = False
+    backup_dir: str = os.path.join(CONFIG_DIR, "backups")
+    backup_interval: int = 86400
 
 
 DEFAULT_CONFIG = Config()
@@ -128,6 +132,8 @@ class AppConfig:
     log_rotate_interval: int = DEFAULTS["log_rotate_interval"]
     log_rotate_archives: int = DEFAULTS["log_rotate_archives"]
     widget_battery_status: bool = DEFAULTS["widget_battery_status"]
+    backup_dir: str = DEFAULTS["backup_dir"]
+    backup_interval: int = DEFAULTS["backup_interval"]
 
     @classmethod
     def load(cls) -> "AppConfig":

--- a/docs/backups.rst
+++ b/docs/backups.rst
@@ -1,0 +1,14 @@
+Backups
+-------
+
+The :mod:`backup` module provides helpers to snapshot configuration
+and collected logs. Backups are written as ``.tar.gz`` archives in
+``~/.config/piwardrive/backups`` by default. Each archive contains the
+current ``config.json`` and the contents of the configured Kismet log
+directory.
+
+Use :func:`backup.create_backup` to create a snapshot and
+:func:`backup.restore_backup` to revert the configuration and logs to a
+previous state. :func:`backup.schedule_backups` registers a periodic
+task with :class:`scheduler.PollScheduler` using the ``backup_interval``
+setting from :class:`config.AppConfig`.

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -11,3 +11,4 @@ To enable the optional battery widget set ``widget_battery_status`` to ``true``:
    PW_WIDGET_BATTERY_STATUS=1 python main.py
 
 See :mod:`config` for defaults and helpers.
+Backups are stored in ``backup_dir`` and run every ``backup_interval`` seconds.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,3 +7,4 @@ PiWardrive Documentation
    configuration
    widgets
    diagnostics
+   backups

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -1,0 +1,56 @@
+import os
+import os
+import sys
+import tarfile
+from pathlib import Path
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import backup
+import config
+
+
+class DummyScheduler:
+    def __init__(self) -> None:
+        self.scheduled: list[tuple[str, float]] = []
+
+    def schedule(self, name: str, cb, interval: float) -> None:
+        self.scheduled.append((name, interval))
+        cb(0)
+
+    def cancel(self, name: str) -> None:
+        pass
+
+
+def setup_cfg(tmp_path: Path) -> config.AppConfig:
+    config.CONFIG_DIR = str(tmp_path / 'cfg')
+    config.CONFIG_PATH = str(Path(config.CONFIG_DIR) / 'config.json')
+    cfg = config.AppConfig.load()
+    cfg.kismet_logdir = str(tmp_path / 'logs')
+    cfg.backup_dir = str(tmp_path / 'backups')
+    cfg.backup_interval = 1
+    os.makedirs(cfg.kismet_logdir, exist_ok=True)
+    Path(cfg.kismet_logdir, 'dummy.txt').write_text('data')
+    config.save_config(config.Config())
+    return cfg
+
+
+def test_create_and_restore_backup(tmp_path: Path) -> None:
+    cfg = setup_cfg(tmp_path)
+    archive = backup.create_backup(cfg.backup_dir, cfg)
+    assert os.path.isfile(archive)
+    # modify
+    Path(config.CONFIG_PATH).write_text('changed')
+    Path(cfg.kismet_logdir, 'dummy.txt').write_text('new')
+    backup.restore_backup(archive, cfg)
+    assert Path(config.CONFIG_PATH).read_text().startswith('{')
+    assert Path(cfg.kismet_logdir, 'dummy.txt').read_text() == 'data'
+
+
+def test_schedule_backups_calls_scheduler(tmp_path: Path) -> None:
+    cfg = setup_cfg(tmp_path)
+    sched = DummyScheduler()
+    backup.schedule_backups(sched, cfg)
+    assert sched.scheduled and sched.scheduled[0][0] == 'backup'
+    assert sched.scheduled[0][1] == cfg.backup_interval
+


### PR DESCRIPTION
## Summary
- add scheduled backup/restore helpers
- support backup settings in configuration
- document backup usage
- add tests for backup module

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d7d531ed88333802fa7937124d0b0