### PR TITLE
Add SQLite history database

### DIFF
--- a/database.py
+++ b/database.py
@@ -1,0 +1,111 @@
+import os
+import sqlite3
+from typing import Iterable, Mapping, Any
+
+from utils import now_timestamp
+
+DEFAULT_DB_PATH = os.path.join(os.path.expanduser("~"), ".piwardrive", "history.db")
+
+
+def get_connection(path: str = DEFAULT_DB_PATH) -> sqlite3.Connection:
+    """Return a SQLite connection with :class:`sqlite3.Row` rows."""
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    conn = sqlite3.connect(path)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def init_db(conn: sqlite3.Connection) -> None:
+    """Create history tables if missing."""
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS ap_data (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            ts TEXT NOT NULL,
+            bssid TEXT,
+            ssid TEXT,
+            lat REAL,
+            lon REAL,
+            rssi INTEGER
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS metrics (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            ts TEXT NOT NULL,
+            cpu_temp REAL,
+            mem_pct REAL,
+            disk_pct REAL,
+            handshake_count INTEGER,
+            lat REAL,
+            lon REAL
+        )
+        """
+    )
+    conn.commit()
+
+
+def ingest_ap_data(conn: sqlite3.Connection, aps: Iterable[Mapping[str, Any]]) -> None:
+    """Insert access point records into ``ap_data``."""
+    for ap in aps:
+        gps = ap.get("gps-info")
+        lat = gps[0] if gps and len(gps) >= 2 else None
+        lon = gps[1] if gps and len(gps) >= 2 else None
+        conn.execute(
+            """
+            INSERT INTO ap_data (ts, bssid, ssid, lat, lon, rssi)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (
+                now_timestamp(),
+                ap.get("bssid"),
+                ap.get("ssid"),
+                lat,
+                lon,
+                ap.get("signal"),
+            ),
+        )
+    conn.commit()
+
+
+def ingest_metrics(conn: sqlite3.Connection, data: Mapping[str, Any]) -> None:
+    """Insert a metrics snapshot into ``metrics``."""
+    conn.execute(
+        """
+        INSERT INTO metrics (
+            ts, cpu_temp, mem_pct, disk_pct, handshake_count, lat, lon
+        ) VALUES (?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            now_timestamp(),
+            data.get("cpu_temp"),
+            data.get("mem_pct"),
+            data.get("disk_pct"),
+            data.get("handshake_count"),
+            data.get("lat"),
+            data.get("lon"),
+        ),
+    )
+    conn.commit()
+
+
+def query_recent_aps(conn: sqlite3.Connection, limit: int = 100) -> list[sqlite3.Row]:
+    """Return recent access point entries ordered by newest first."""
+    cur = conn.execute(
+        "SELECT * FROM ap_data ORDER BY id DESC LIMIT ?",
+        (limit,),
+    )
+    return cur.fetchall()
+
+
+def query_recent_metrics(
+    conn: sqlite3.Connection, limit: int = 100
+) -> list[sqlite3.Row]:
+    """Return recent metrics entries ordered by newest first."""
+    cur = conn.execute(
+        "SELECT * FROM metrics ORDER BY id DESC LIMIT ?",
+        (limit,),
+    )
+    return cur.fetchall()

--- a/docs/database.rst
+++ b/docs/database.rst
@@ -1,0 +1,10 @@
+Database Integration
+--------------------
+
+The :mod:`database` module uses SQLite to store historical access-point
+and metrics data. Call :func:`database.init_db` on a connection from
+:func:`database.get_connection` to create tables. Use
+:func:`database.ingest_ap_data` and :func:`database.ingest_metrics`
+to persist new records. Query recent entries with
+:func:`database.query_recent_aps` and
+:func:`database.query_recent_metrics`.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,3 +7,4 @@ PiWardrive Documentation
    configuration
    widgets
    diagnostics
+   database

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1,0 +1,44 @@
+import os
+import sys
+from typing import Any
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import database
+
+
+def test_init_db_creates_tables(tmp_path: Any) -> None:
+    db_path = tmp_path / "test.db"
+    conn = database.get_connection(str(db_path))
+    database.init_db(conn)
+    rows = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table'"
+    ).fetchall()
+    names = {row[0] for row in rows}
+    assert {"ap_data", "metrics"}.issubset(names)
+
+
+def test_ingest_and_query(tmp_path: Any) -> None:
+    db_path = tmp_path / "test.db"
+    conn = database.get_connection(str(db_path))
+    database.init_db(conn)
+
+    aps = [
+        {"bssid": "AA:BB", "ssid": "Test", "gps-info": (1.0, 2.0), "signal": -50}
+    ]
+    database.ingest_ap_data(conn, aps)
+    ap_rows = database.query_recent_aps(conn)
+    assert len(ap_rows) == 1
+    assert ap_rows[0]["bssid"] == "AA:BB"
+
+    metrics = {
+        "cpu_temp": 42.0,
+        "mem_pct": 12.0,
+        "disk_pct": 33.0,
+        "handshake_count": 2,
+        "lat": 1.0,
+        "lon": 2.0,
+    }
+    database.ingest_metrics(conn, metrics)
+    metric_rows = database.query_recent_metrics(conn)
+    assert len(metric_rows) == 1
+    assert metric_rows[0]["cpu_temp"] == 42.0


### PR DESCRIPTION
## Summary
- add `database` module for SQLite history
- document database usage in `docs/database.rst`
- hook up docs index
- cover DB helpers with unit tests

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d7d796b80833380b2334a8e1cf266