### PR TITLE
Fix logging import

### DIFF
--- a/sigint_suite/bluetooth/scanner.py
+++ b/sigint_suite/bluetooth/scanner.py
@@ -1,3 +1,4 @@
+import logging
 import asyncio
 import os
 import subprocess


### PR DESCRIPTION
## Summary
- add missing logging import for Bluetooth scanner

## Testing
- `flake8 sigint_suite/bluetooth/scanner.py`

------
https://chatgpt.com/codex/tasks/task_e_6850aa8f6ab08333a9e5e6cfcdd6c139