### PR TITLE
Reduce flake8 warnings

### DIFF
--- a/advanced_localization.py
+++ b/advanced_localization.py
@@ -80,8 +80,16 @@ def apply_kalman_filter(df: pd.DataFrame, cfg: Config) -> pd.DataFrame:
     if not cfg.kalman_enable or df.empty:
         return df
     df = df.copy()
-    df["lat"] = _kalman_1d(df["lat"].to_numpy(), cfg.kalman_process_variance, cfg.kalman_measurement_variance)
-    df["lon"] = _kalman_1d(df["lon"].to_numpy(), cfg.kalman_process_variance, cfg.kalman_measurement_variance)
+    df["lat"] = _kalman_1d(
+        df["lat"].to_numpy(),
+        cfg.kalman_process_variance,
+        cfg.kalman_measurement_variance,
+    )
+    df["lon"] = _kalman_1d(
+        df["lon"].to_numpy(),
+        cfg.kalman_process_variance,
+        cfg.kalman_measurement_variance,
+    )
     return df
 
 
@@ -89,7 +97,9 @@ def remove_outliers(df: pd.DataFrame, cfg: Config) -> pd.DataFrame:
     if df.empty:
         return df
     coords = df[["lat", "lon"]]
-    labels = DBSCAN(eps=cfg.dbscan_eps, min_samples=cfg.dbscan_min_samples).fit_predict(coords)
+    labels = DBSCAN(eps=cfg.dbscan_eps, min_samples=cfg.dbscan_min_samples).fit_predict(
+        coords
+    )
     return df[labels != -1]
 
 
@@ -102,8 +112,12 @@ def rssi_to_distance(rssi: float, reference: float, exponent: float) -> float:
 # Localization
 
 
-def estimate_ap_location_centroid(ap_data: pd.DataFrame, cfg: Config) -> Tuple[float, float]:
-    weights = ap_data["rssi"].apply(lambda r: max(0.01, 1 / ((100 - r) ** cfg.centroid_rssi_weight_power)))
+def estimate_ap_location_centroid(
+    ap_data: pd.DataFrame, cfg: Config
+) -> Tuple[float, float]:
+    weights = ap_data["rssi"].apply(
+        lambda r: max(0.01, 1 / ((100 - r) ** cfg.centroid_rssi_weight_power))
+    )
     lat = np.average(ap_data["lat"], weights=weights)
     lon = np.average(ap_data["lon"], weights=weights)
     return float(lat), float(lon)

--- a/cloud_export.py
+++ b/cloud_export.py
@@ -10,7 +10,9 @@ from typing import Optional
 logger = logging.getLogger(__name__)
 
 
-def upload_to_s3(file_path: str, bucket: str, key: str, profile: Optional[str] = None) -> None:
+def upload_to_s3(
+    file_path: str, bucket: str, key: str, profile: Optional[str] = None
+) -> None:
     """Upload ``file_path`` to the given S3 ``bucket`` using the AWS CLI."""
     if not os.path.exists(file_path):
         raise FileNotFoundError(file_path)

--- a/config.py
+++ b/config.py
@@ -116,6 +116,7 @@ ENV_OVERRIDE_MAP: Dict[str, str] = {
     f"PW_{name.upper()}": name for name in DEFAULTS.keys()
 }
 
+
 def list_env_overrides() -> Dict[str, str]:
     """Return available ``PW_`` environment variable overrides."""
     return dict(ENV_OVERRIDE_MAP)

--- a/db_browser.py
+++ b/db_browser.py
@@ -15,7 +15,10 @@ class _DBHandler(http.server.BaseHTTPRequestHandler):
         conn = sqlite3.connect(self.db_path)
         cur = conn.execute("SELECT name FROM sqlite_master WHERE type='table'")
         tables = [r[0] for r in cur.fetchall()]
-        data = {t: conn.execute(f"SELECT * FROM {t} LIMIT 100").fetchall() for t in tables}
+        data = {
+            t: conn.execute(f"SELECT * FROM {t} LIMIT 100").fetchall()
+            for t in tables
+        }
         self.send_response(200)
         self.send_header("Content-Type", "application/json")
         self.end_headers()

--- a/heatmap.py
+++ b/heatmap.py
@@ -25,7 +25,8 @@ def histogram(
 
     if bounds is None:
         if not pts:
-            return [[0 for _ in range(bins_lon)] for _ in range(bins_lat)], (0.0, 0.0), (0.0, 0.0)
+            empty = [[0 for _ in range(bins_lon)] for _ in range(bins_lat)]
+            return empty, (0.0, 0.0), (0.0, 0.0)
         lats = [p[0] for p in pts]
         lons = [p[1] for p in pts]
         min_lat = min(lats)

--- a/in-development/localization_improvement/main_localization.py
+++ b/in-development/localization_improvement/main_localization.py
@@ -1,4 +1,4 @@
-##main_localization.py
+# main_localization.py
 
 import pandas as pd
 import numpy as np
@@ -6,7 +6,6 @@ import sqlite3
 import json
 from sklearn.cluster import DBSCAN
 from folium import Map, Marker
-from folium.plugins import HeatMap
 from logger import setup_logger
 logger = setup_logger()
 
@@ -16,20 +15,26 @@ with open('calibration_config.json') as config_file:
 
 # ─────────────────────────────────────────────────────────────
 # Load Kismet SQLite3 logs and extract relevant AP data
+
+
 def load_kismet_data(kismet_db_path):
     conn = sqlite3.connect(kismet_db_path)
-    query = """
-    SELECT devices.macaddr, devices.ssid, packets.lat, packets.lon, packets.signal, packets.gpstime
-    FROM devices
-    JOIN packets ON devices.devicekey = packets.devicekey
-    WHERE devices.type = 'infrastructure' AND packets.lat != 0 AND packets.lon != 0;
-    """
+    query = (
+        "SELECT devices.macaddr, devices.ssid, packets.lat, packets.lon, "
+        "packets.signal, packets.gpstime\n"
+        "FROM devices\n"
+        "JOIN packets ON devices.devicekey = packets.devicekey\n"
+        "WHERE devices.type = 'infrastructure' AND packets.lat != 0 "
+        "AND packets.lon != 0;"
+    )
     data = pd.read_sql_query(query, conn)
     conn.close()
     return data
 
 # ─────────────────────────────────────────────────────────────
 # Apply a 1D Kalman filter to latitude and longitude to reduce GPS jitter
+
+
 def apply_kalman_filter(df):
     if not config.get("kalman_enable", False):
         return df
@@ -55,12 +60,22 @@ def apply_kalman_filter(df):
 
         return pd.Series(xhat, index=series.index)
 
-    df['lat'] = kalman_1d(df['lat'], config["kalman_process_variance"], config["kalman_measurement_variance"])
-    df['lon'] = kalman_1d(df['lon'], config["kalman_process_variance"], config["kalman_measurement_variance"])
+    df['lat'] = kalman_1d(
+        df['lat'],
+        config["kalman_process_variance"],
+        config["kalman_measurement_variance"],
+    )
+    df['lon'] = kalman_1d(
+        df['lon'],
+        config["kalman_process_variance"],
+        config["kalman_measurement_variance"],
+    )
     return df
+
 
 # ─────────────────────────────────────────────────────────────
 # Remove GPS/RSSI outliers using DBSCAN clustering
+
 def remove_outliers(df):
     coords = df[['lat', 'lon']]
     db = DBSCAN(
@@ -68,10 +83,13 @@ def remove_outliers(df):
         min_samples=config["dbscan_min_samples"]
     ).fit(coords)
     df['cluster'] = db.labels_
-    return df[df['cluster'] != -1]
+    return df[df["cluster"] != -1]
+
 
 # ─────────────────────────────────────────────────────────────
 # Convert RSSI value to estimated distance using path-loss model
+
+
 def rssi_to_distance(rssi):
     A = config["path_loss_reference_rssi"]
     n = config["path_loss_exponent"]
@@ -79,15 +97,21 @@ def rssi_to_distance(rssi):
 
 # ─────────────────────────────────────────────────────────────
 # Estimate AP location using weighted RSSI centroid method
+
+
 def estimate_ap_location_centroid(ap_data):
     weight_power = config["centroid_rssi_weight_power"]
-    weights = ap_data['signal'].apply(lambda rssi: max(0.01, 1 / ((100 - rssi) ** weight_power)))
+    weights = ap_data['signal'].apply(
+        lambda rssi: max(0.01, 1 / ((100 - rssi) ** weight_power))
+    )
     lat = np.average(ap_data['lat'], weights=weights)
     lon = np.average(ap_data['lon'], weights=weights)
     return lat, lon
 
+
 # ─────────────────────────────────────────────────────────────
 # Process all APs in dataset and estimate their coordinates
+
 def localize_aps(df):
     ap_coords = {}
     map_center = [df['lat'].mean(), df['lon'].mean()]
@@ -114,6 +138,8 @@ def localize_aps(df):
 
 # ─────────────────────────────────────────────────────────────
 # Load the fingerprint dataset if enabled in config
+
+
 def load_fingerprint_dataset():
     if not config.get("fingerprint_enabled", False):
         return None
@@ -123,12 +149,14 @@ def load_fingerprint_dataset():
 
 # ─────────────────────────────────────────────────────────────
 # Main pipeline execution
+
+
 def main():
     logger.info("[*] Loading Kismet data...")
     data = load_kismet_data('kismet_logs/Kismet-latest.kismet')
 
     logger.info("[*] Loading fingerprint dataset...")
-    fingerprint_df = load_fingerprint_dataset()
+    load_fingerprint_dataset()
 
     logger.info("[*] Localizing access points...")
     ap_coords = localize_aps(data)
@@ -136,6 +164,7 @@ def main():
     logger.info("\n📍 Estimated AP Coordinates:")
     for mac, coords in ap_coords.items():
         logger.info(f"{mac}: {coords}")
+
 
 if __name__ == '__main__':
     main()

--- a/in-development/localization_improvement/scripts/check_project_structure.py
+++ b/in-development/localization_improvement/scripts/check_project_structure.py
@@ -1,5 +1,6 @@
 import os
 
+
 def check_structure():
     required_files = [
         'calibration_config.json',
@@ -31,5 +32,6 @@ def check_structure():
             for d in missing_dirs:
                 print(f"  - {d}")
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     check_structure()

--- a/in-development/localization_improvement/scripts/logger.py
+++ b/in-development/localization_improvement/scripts/logger.py
@@ -2,6 +2,7 @@ import logging
 import os
 from datetime import datetime
 
+
 def setup_logger(name='localization', log_dir='logs', level=logging.INFO):
     """Initializes a logger that logs to both file and console."""
     os.makedirs(log_dir, exist_ok=True)

--- a/network_analytics.py
+++ b/network_analytics.py
@@ -7,7 +7,9 @@ from typing import Iterable, Mapping, Any, List
 from sigint_suite.enrichment import lookup_vendor
 
 
-def find_suspicious_aps(records: Iterable[Mapping[str, Any]]) -> List[Mapping[str, Any]]:
+def find_suspicious_aps(
+    records: Iterable[Mapping[str, Any]]
+) -> List[Mapping[str, Any]]:
     """Return Wi-Fi access points that may be suspicious.
 
     Heuristics flag open or WEP networks, duplicate BSSIDs broadcasting

--- a/scripts/localize_aps.py
+++ b/scripts/localize_aps.py
@@ -6,7 +6,7 @@ import argparse
 import json
 from pathlib import Path
 
-from advanced_localization import Config, load_config, load_kismet_data, localize_aps
+from advanced_localization import load_config, load_kismet_data, localize_aps
 
 try:
     import folium
@@ -19,17 +19,26 @@ def _save_map(coords: dict[str, tuple[float, float]], output: Path, zoom: int) -
         return
     lats = [c[0] for c in coords.values()]
     lons = [c[1] for c in coords.values()]
-    m = folium.Map(location=[sum(lats) / len(lats), sum(lons) / len(lons)], zoom_start=zoom)
+    m = folium.Map(
+        location=[sum(lats) / len(lats), sum(lons) / len(lons)],
+        zoom_start=zoom,
+    )
     for mac, (lat, lon) in coords.items():
         folium.Marker([lat, lon], popup=mac).add_to(m)
     m.save(str(output))
 
 
 def main(argv: list[str] | None = None) -> None:
-    parser = argparse.ArgumentParser(description="Estimate AP locations from a Kismet log")
+    parser = argparse.ArgumentParser(
+        description="Estimate AP locations from a Kismet log"
+    )
     parser.add_argument("database", help="Path to .kismet SQLite log")
-    parser.add_argument("--config", default="localization_config.json", help="Config JSON path")
-    parser.add_argument("--output", default="ap_locations.html", help="Output HTML map")
+    parser.add_argument(
+        "--config", default="localization_config.json", help="Config JSON path"
+    )
+    parser.add_argument(
+        "--output", default="ap_locations.html", help="Output HTML map"
+    )
     args = parser.parse_args(argv)
 
     cfg = load_config(args.config)

--- a/scripts/migrate_db.py
+++ b/scripts/migrate_db.py
@@ -9,4 +9,3 @@ def main(argv: list[str] | None = None) -> None:
 
 if __name__ == "__main__":  # pragma: no cover - manual invocation
     main()
-

--- a/sigint_suite/__init__.py
+++ b/sigint_suite/__init__.py
@@ -25,4 +25,3 @@ def __getattr__(name: str) -> Any:
         globals()[name] = mod
         return mod
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
-

--- a/sigint_suite/bluetooth/__init__.py
+++ b/sigint_suite/bluetooth/__init__.py
@@ -3,4 +3,3 @@
 from .scanner import scan_bluetooth
 
 __all__ = ["scan_bluetooth"]
-

--- a/sigint_suite/bluetooth/scanner.py
+++ b/sigint_suite/bluetooth/scanner.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 import os
 import subprocess
 from typing import Dict, List
@@ -7,6 +8,7 @@ from typing import Dict, List
 from sigint_suite.models import BluetoothDevice
 
 logger = logging.getLogger(__name__)
+
 
 def scan_bluetooth(timeout: int = 10) -> List[BluetoothDevice]:
     """Scan for nearby Bluetooth devices using ``bleak`` or ``bluetoothctl``."""
@@ -28,8 +30,6 @@ def scan_bluetooth(timeout: int = 10) -> List[BluetoothDevice]:
         return asyncio.run(_scan())
     except Exception:
         return _scan_bluetoothctl(timeout)
-
-
 
 
 async def async_scan_bluetooth(timeout: int = 10) -> List[BluetoothDevice]:

--- a/sigint_suite/cellular/tower_tracker/tracker.py
+++ b/sigint_suite/cellular/tower_tracker/tracker.py
@@ -4,7 +4,6 @@ from typing import Dict, List, Optional
 import aiosqlite
 
 
-
 class TowerTracker:
     """Maintain a database of observed cell towers."""
 

--- a/sigint_suite/dashboard/__init__.py
+++ b/sigint_suite/dashboard/__init__.py
@@ -16,6 +16,7 @@ import argparse
 import json
 import os
 from typing import Any, Dict, List, Mapping
+from sigint_suite import paths
 
 DEFAULT_EXPORT_DIR = os.path.abspath(
     os.path.join(os.path.dirname(__file__), "..", "exports")

--- a/sigint_suite/exports/__init__.py
+++ b/sigint_suite/exports/__init__.py
@@ -2,7 +2,4 @@
 
 from .exporter import export_csv, export_json, export_yaml
 
-
-from .exporter import export_csv, export_json, export_yaml
-
 __all__ = ["export_json", "export_csv", "export_yaml"]

--- a/sigint_suite/exports/exporter.py
+++ b/sigint_suite/exports/exporter.py
@@ -44,4 +44,3 @@ def export_yaml(records: Iterable[Any], path: str) -> None:
             data.append(rec)
     with open(path, "w", encoding="utf-8") as fh:
         yaml.safe_dump(data, fh, sort_keys=False)
-

--- a/sigint_suite/scripts/continuous_scan.py
+++ b/sigint_suite/scripts/continuous_scan.py
@@ -3,8 +3,11 @@ import os
 import time
 
 from sigint_suite.bluetooth import scan_bluetooth
+from sigint_suite import paths
+
 from sigint_suite.exports import export_json
 from sigint_suite.wifi import scan_wifi
+
 
 def run_once(export_dir: str) -> None:
     wifi_data = scan_wifi()

--- a/sigint_suite/wifi/scanner.py
+++ b/sigint_suite/wifi/scanner.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import os
 import shlex
@@ -6,6 +7,7 @@ import subprocess
 from typing import Dict, List, Optional
 from sigint_suite.enrichment import lookup_vendor
 from sigint_suite.hooks import apply_post_processors, register_post_processor
+from sigint_suite.models import WifiNetwork
 
 logger = logging.getLogger(__name__)
 

--- a/utils.py
+++ b/utils.py
@@ -270,7 +270,6 @@ def safe_request(
         return None
 
 
-
 def ensure_service_running(
     service: str, *, attempts: int = 3, delay: float = 1.0
 ) -> bool:

--- a/vector_tiles.py
+++ b/vector_tiles.py
@@ -22,7 +22,10 @@ class MBTiles:
         try:
             with sqlite3.connect(self.path) as db:
                 cur = db.execute(
-                    "SELECT tile_data FROM tiles WHERE zoom_level=? AND tile_column=? AND tile_row=?",
+                    (
+                        "SELECT tile_data FROM tiles WHERE zoom_level=? "
+                        "AND tile_column=? AND tile_row=?"
+                    ),
                     (z, x, y),
                 )
                 row = cur.fetchone()


### PR DESCRIPTION
## Summary
- trim long lines in advanced_localization helpers
- wrap SQL query in vector_tiles
- reformat import blocks and remove unused imports
- clean up various scripts and modules to satisfy flake8

## Testing
- `python -m flake8`
- `pytest -q` *(fails: 31 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6850aa9218c8833384004ca3be5d5674