### PR TITLE
Add obd_check CLI tool

### DIFF
--- a/docs/cli_tools.rst
+++ b/docs/cli_tools.rst
@@ -24,4 +24,11 @@ Several helper scripts are installed alongside the GUI. They can be invoked dire
 
         piwardrive-service
 
+``obd-check``
+    Attempt a connection to an OBD-II adapter and print sample readings::
+
+        obd-check
+
+    Reports the connection status along with speed, RPM and engine load values.
+
 See ``--help`` on each command for additional options.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ piwardrive-migrate = "piwardrive.scripts.migrate_db:main"
 uav-record = "piwardrive.scripts.uav_record:main"
 uav-track-playback = "piwardrive.scripts.uav_track_playback:main"
 piwardrive-mbtiles = "piwardrive.scripts.vector_tile_customizer_cli:main"
+obd-check = "piwardrive.scripts.obd_check:main"
 
 
 

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,3 +1,4 @@
-from importlib import import_module, sys
+from importlib import import_module
+import sys
 module = import_module("piwardrive.scripts")
 sys.modules[__name__] = module

--- a/src/piwardrive/scripts/obd_check.py
+++ b/src/piwardrive/scripts/obd_check.py
@@ -1,0 +1,48 @@
+"""Attempt basic OBD-II queries and print the results."""
+
+from __future__ import annotations
+
+import argparse
+
+try:
+    import obd  # type: ignore  # pragma: no cover - optional dependency
+except Exception:  # pragma: no cover - library not available
+    obd = None  # type: ignore
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Connect to an OBD-II adapter and print sample readings."""
+    parser = argparse.ArgumentParser(description="Check OBD-II connectivity")
+    parser.add_argument("--port", help="serial port for the adapter", default=None)
+    args = parser.parse_args(argv)
+
+    if obd is None:
+        print("python-OBD library not installed")
+        return
+
+    try:
+        conn = obd.OBD(args.port)  # pragma: no cover - runtime
+    except Exception as exc:  # pragma: no cover - runtime
+        print(f"Connection failed: {exc}")
+        return
+
+    status = "connected" if conn.is_connected() else "disconnected"
+    port_name = getattr(conn, "port_name", lambda: args.port)
+    print(f"{status} on {port_name()}")
+
+    if not conn.is_connected():
+        return
+
+    try:
+        speed = conn.query(obd.commands.SPEED)
+        rpm = conn.query(obd.commands.RPM)
+        load = conn.query(obd.commands.ENGINE_LOAD)
+        print(f"Speed: {speed.value}")
+        print(f"RPM: {rpm.value}")
+        print(f"Engine load: {load.value}")
+    except Exception as exc:  # pragma: no cover - runtime
+        print(f"Query failed: {exc}")
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation
+    main()

--- a/tests/test_obd_check_script.py
+++ b/tests/test_obd_check_script.py
@@ -1,0 +1,44 @@
+import os
+import sys
+import types
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+
+def test_obd_check_script(monkeypatch, capsys):
+    class DummyResp:
+        def __init__(self, value):
+            self.value = value
+
+    class DummyConn:
+        def __init__(self):
+            self.queries = []
+
+        def is_connected(self):
+            return True
+
+        def port_name(self):
+            return "/dev/mock"
+
+        def query(self, cmd):
+            self.queries.append(cmd)
+            return DummyResp(cmd + "_val")
+
+    dummy_conn = DummyConn()
+    dummy_obd = types.SimpleNamespace(
+        OBD=lambda port=None: dummy_conn,
+        commands=types.SimpleNamespace(SPEED="SPEED", RPM="RPM", ENGINE_LOAD="LOAD"),
+    )
+
+    if "scripts.obd_check" in sys.modules:
+        del sys.modules["scripts.obd_check"]
+    import scripts.obd_check as oc
+
+    monkeypatch.setattr(oc, "obd", dummy_obd)
+
+    oc.main(["--port", "/dev/mock"])
+    out_lines = capsys.readouterr().out.strip().splitlines()
+    assert "connected" in out_lines[0]
+    assert "SPEED_val" in out_lines[1]
+    assert "RPM_val" in out_lines[2]
+    assert "LOAD_val" in out_lines[3]


### PR DESCRIPTION
## Summary
- implement `obd_check` CLI for simple OBD‑II verification
- document the tool in the CLI docs
- expose the new command in `pyproject.toml`
- fix mypy issue in `scripts/__init__.py`
- test the new script

## Testing
- `flake8 src/piwardrive/scripts/obd_check.py tests/test_obd_check_script.py`
- `mypy --ignore-missing-imports src/piwardrive/scripts/obd_check.py tests/test_obd_check_script.py`
- `pytest -q tests/test_obd_check_script.py`
- ❌ `pre-commit run --files src/piwardrive/scripts/obd_check.py docs/cli_tools.rst pyproject.toml tests/test_obd_check_script.py` (failed to download hooks)

------
https://chatgpt.com/codex/tasks/task_e_6851f82e72f483339360762d51b5ac09