### PR TITLE
Update docs for restructured scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ graph LR
 ## Project Layout
 
 - All source code resides under `src/piwardrive/`.
-- Top-level scripts and modules are legacy wrappers slated for removal.
+- Command-line helper scripts live in the top-level `scripts/` directory.
 - Import from `piwardrive` directly when running tools or tests.
 
 ## Data Inputs
@@ -133,7 +133,7 @@ sudo apt install -y r-base r-base-dev
 
 ```
 
-You can run `src/piwardrive/scripts/quickstart.sh` to install system packages and create the virtual environment automatically.
+You can run `scripts/quickstart.sh` to install system packages and create the virtual environment automatically.
 
 #### Step-by-Step Setup
 
@@ -267,7 +267,7 @@ docker run --device=/dev/ttyUSB0 --rm piwardrive
 
 #### Manual Steps
 
-* **Installation** – run `src/piwardrive/scripts/quickstart.sh` or follow the manual steps to clone the repo, create a virtualenv and install dependencies.
+* **Installation** – run `scripts/quickstart.sh` or follow the manual steps to clone the repo, create a virtualenv and install dependencies.
 * **Launching the App** – activate the environment and start PiWardrive with `python -m piwardrive.main`.
 * **Systemd Service Setup** – copy `examples/piwardrive.service` to `/etc/systemd/system/` and enable it with `sudo systemctl enable --now piwardrive.service` to launch the backend on boot.
 * **Running the Status API** – start the FastAPI service manually with `piwardrive-service` to expose remote metrics.
@@ -301,11 +301,11 @@ WantedBy=multi-user.target
 
 ## Mobile Builds
 
-Scripts under `src/piwardrive/scripts/` create Android or iOS builds:
+Scripts under `scripts/` create Android or iOS builds:
 
 ```bash
-./src/piwardrive/scripts/build_android.sh  # Android APK
-./src/piwardrive/scripts/build_ios.sh      # iOS project
+./scripts/build_android.sh  # Android APK
+./scripts/build_ios.sh      # iOS project
 ```
 
 ## Configuration

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -73,7 +73,7 @@ The application polls `gpsd` at a configurable interval, increasing the delay wh
 
 ## Mobile Builds
 
-Helper scripts `src/piwardrive/scripts/build_android.sh` and `src/piwardrive/scripts/build_ios.sh` package PiWardrive for Android or iOS. Android builds rely on Buildozer while iOS builds require `kivy-ios`. Some diagnostics and service management features are disabled on mobile platforms.
+Helper scripts `scripts/build_android.sh` and `scripts/build_ios.sh` package PiWardrive for Android or iOS. Android builds rely on Buildozer while iOS builds require `kivy-ios`. Some diagnostics and service management features are disabled on mobile platforms.
 
 ## Building the CKML Extension
 
@@ -87,10 +87,10 @@ See `docs/ckml_build.rst` for troubleshooting compiler issues.
 
 ## R Integration
 
-`src/piwardrive/scripts/health_summary.R` can analyse exported `HealthRecord` data. Install `rpy2`, `r-base` and the `ggplot2`/`jsonlite` R packages to enable `r_integration.health_summary`.
-`src/piwardrive/scripts/health_export.py` dumps recent metrics to JSON or CSV while
-`src/piwardrive/scripts/health_import.py` loads such files back into the tracking database.
-`src/piwardrive/scripts/service_status.py` prints the active state of common services.
+`scripts/health_summary.R` can analyse exported `HealthRecord` data. Install `rpy2`, `r-base` and the `ggplot2`/`jsonlite` R packages to enable `r_integration.health_summary`.
+`scripts/health_export.py` dumps recent metrics to JSON or CSV while
+`scripts/health_import.py` loads such files back into the tracking database.
+`scripts/service_status.py` prints the active state of common services.
 
 Additional optional features use `pandas`, `orjson` and `pyprof2calltree` which can be installed via:
 

--- a/docs/aggregation_service.rst
+++ b/docs/aggregation_service.rst
@@ -18,7 +18,7 @@ By default data is stored under ``~/piwardrive-aggregation``.  Set the
 Installation
 ------------
 
-Run ``src/piwardrive/scripts/install_aggregation_service.sh`` on the target server.  The
+Run ``scripts/install_aggregation_service.sh`` on the target server.  The
 script creates an ``agg-env`` virtual environment, installs the required Python
 packages and writes ``/etc/systemd/system/piwardrive-aggregation.service``.
 Enable the unit with::

--- a/docs/diagnostics.rst
+++ b/docs/diagnostics.rst
@@ -28,7 +28,7 @@ environment variables ``PW_HEALTH_EXPORT_INTERVAL``, ``PW_HEALTH_EXPORT_DIR``,
 ``PW_COMPRESS_HEALTH_EXPORTS`` and ``PW_HEALTH_EXPORT_RETENTION`` mirror these
 options.
 
-``src/piwardrive/scripts/service_status.py`` provides a small command-line interface to
+``scripts/service_status.py`` provides a small command-line interface to
 ``diagnostics.get_service_statuses`` for quick checks outside the GUI. The same
 information is exposed in the browser interface via the status service.
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -9,7 +9,7 @@ distributions. The recommended interface is the browser-based dashboard built
 with React. It requires Node.js 18 or newer to compile. A Kivy-based touch UI
 remains available as an alternative.
 
-You can also run ``src/piwardrive/scripts/quickstart.sh`` from the repository
+You can also run ``scripts/quickstart.sh`` from the repository
 root to automatically install the required packages, create ``gui-env/`` and
 install the Python dependencies.
 

--- a/docs/mobile_build.rst
+++ b/docs/mobile_build.rst
@@ -19,7 +19,7 @@ Android
 
 Use the helper script to build the debug APK::
 
-    ./src/piwardrive/scripts/build_android.sh
+    ./scripts/build_android.sh
 
 The first run downloads the Android toolchain and may take time. The
 APK is placed under ``bin/``. Adjust ``buildozer.spec`` to change the
@@ -30,7 +30,7 @@ iOS
 
 To generate an Xcode project run::
 
-    ./src/piwardrive/scripts/build_ios.sh
+    ./scripts/build_ios.sh
 
 Open the created project in Xcode to build and sign the app.
 

--- a/docs/web_ui.rst
+++ b/docs/web_ui.rst
@@ -57,9 +57,9 @@ Launching in Kiosk Mode
 -----------------------
 
 After building the frontend you can start the API server and open Chromium in
-kiosk mode with ``src/piwardrive/scripts/start_kiosk.sh``::
+kiosk mode with ``scripts/start_kiosk.sh``::
 
-   src/piwardrive/scripts/start_kiosk.sh
+   scripts/start_kiosk.sh
 
 The script runs ``piwardrive-service`` in the background and then executes
 ``chromium-browser --kiosk http://localhost:8000`` (falling back to

--- a/tests/test_start_kiosk_script.py
+++ b/tests/test_start_kiosk_script.py
@@ -10,7 +10,13 @@ def test_start_kiosk_launches_browser(tmp_path):
 
     server_script = bin_dir / "piwardrive-webui"
     server_script.write_text(
-        "#!/bin/sh\necho server_started >> \"%s\"\ntrap 'exit 0' TERM\nwhile true; do sleep 0.1; done\n" % log
+        (
+            "#!/bin/sh\n"
+            "echo server_started >> \"%s\"\n"
+            "trap 'exit 0' TERM\n"
+            "while true; do sleep 0.1; done\n"
+        )
+        % log
     )
     browser_script = bin_dir / "chromium-browser"
     browser_script.write_text(
@@ -24,7 +30,7 @@ def test_start_kiosk_launches_browser(tmp_path):
     env = os.environ.copy()
     env["PATH"] = f"{bin_dir}:{env['PATH']}"
 
-    script = Path("src/piwardrive/scripts/start_kiosk.sh")
+    script = Path("scripts/start_kiosk.sh")
     subprocess.run(["bash", str(script)], env=env, check=True)
 
     assert "server_started" in log.read_text()

--- a/webui/README.md
+++ b/webui/README.md
@@ -88,7 +88,7 @@ The dev server watches the source files and automatically reloads the page. API 
 For a dedicated dashboard device you can automate the startup process with the helper script:
 
 ```bash
-src/piwardrive/scripts/start_kiosk.sh
+scripts/start_kiosk.sh
 ```
 
 The script runs `piwardrive-service` in the background and then opens Chromium in kiosk mode pointing to the local web UI. If `chromium-browser` is not installed it falls back to `chromium`. An X server must be available; headless environments may use `Xvfb`.


### PR DESCRIPTION
## Summary
- update README project layout and script paths
- update docs and Reference for scripts/ location
- adjust kiosk script test for new path

## Testing
- `flake8 tests/test_start_kiosk_script.py`
- `mypy tests/test_start_kiosk_script.py`
- `pytest tests/test_start_kiosk_script.py -q`
- `pre-commit` failed due to InvalidManifestError

------
https://chatgpt.com/codex/tasks/task_e_685b45c2bfc88333a2ce4d9dd6800610