### PR TITLE
Add orientation & vehicle web components

### DIFF
--- a/docs/status_service.rst
+++ b/docs/status_service.rst
@@ -64,6 +64,11 @@ current orientation string, rotation angle and raw accelerometer/gyroscope data:
 
    curl http://localhost:8000/orientation
 
+``/vehicle`` reports vehicle speed, RPM and engine load obtained via
+``vehicle_sensors``::
+
+   curl http://localhost:8000/vehicle
+
 ``/gps`` exposes latitude, longitude, accuracy and fix quality from ``gpsd``::
 
    curl http://localhost:8000/gps

--- a/src/piwardrive/service.py
+++ b/src/piwardrive/service.py
@@ -194,6 +194,16 @@ async def get_orientation_endpoint(
     }
 
 
+@app.get("/vehicle")
+async def get_vehicle_endpoint(_auth: None = Depends(_check_auth)) -> dict:
+    """Return vehicle metrics from OBD-II sensors."""
+    return {
+        "speed": vehicle_sensors.read_speed_obd(),
+        "rpm": vehicle_sensors.read_rpm_obd(),
+        "engine_load": vehicle_sensors.read_engine_load_obd(),
+    }
+
+
 @app.get("/gps")
 async def get_gps_endpoint(_auth: None = Depends(_check_auth)) -> dict:
     """Return current GPS position."""

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -528,6 +528,34 @@ def test_orientation_endpoint_mpu(monkeypatch) -> None:
         assert data["gyroscope"] == {"y": 2}
 
 
+def test_vehicle_endpoint(monkeypatch) -> None:
+    with (
+        mock.patch("service.vehicle_sensors.read_speed_obd", return_value=55.0),
+        mock.patch(
+            "piwardrive.service.vehicle_sensors.read_speed_obd", return_value=55.0
+        ),
+        mock.patch("service.vehicle_sensors.read_rpm_obd", return_value=1800.0),
+        mock.patch(
+            "piwardrive.service.vehicle_sensors.read_rpm_obd", return_value=1800.0
+        ),
+        mock.patch(
+            "service.vehicle_sensors.read_engine_load_obd", return_value=40.0
+        ),
+        mock.patch(
+            "piwardrive.service.vehicle_sensors.read_engine_load_obd",
+            return_value=40.0,
+        ),
+    ):
+        client = TestClient(service.app)
+        resp = client.get("/vehicle")
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "speed": 55.0,
+            "rpm": 1800.0,
+            "engine_load": 40.0,
+        }
+
+
 def test_gps_endpoint(monkeypatch) -> None:
     with (
         mock.patch("service.gps_client.get_position", return_value=(1.0, 2.0)),

--- a/webui/src/App.jsx
+++ b/webui/src/App.jsx
@@ -6,6 +6,8 @@ import SignalStrength from './components/SignalStrength.jsx';
 import NetworkThroughput from './components/NetworkThroughput.jsx';
 import CPUTempGraph from './components/CPUTempGraph.jsx';
 import VehicleStats from './components/VehicleStats.jsx';
+import Orientation from './components/Orientation.jsx';
+import VehicleInfo from './components/VehicleInfo.jsx';
 
 export default function App() {
   const [status, setStatus] = useState([]);
@@ -13,6 +15,8 @@ export default function App() {
   const [logs, setLogs] = useState('');
   const [configData, setConfigData] = useState(null);
   const [plugins, setPlugins] = useState([]);
+  const [orientationData, setOrientationData] = useState(null);
+  const [vehicleData, setVehicleData] = useState(null);
 
   useEffect(() => {
     const proto = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
@@ -46,6 +50,14 @@ export default function App() {
     fetch('/config')
       .then(r => r.json())
       .then(setConfigData);
+    fetch('/orientation')
+      .then(r => r.json())
+      .then(setOrientationData)
+      .catch(() => setOrientationData(null));
+    fetch('/vehicle')
+      .then(r => r.json())
+      .then(setVehicleData)
+      .catch(() => setVehicleData(null));
     return () => ws.close();
   }, []);
 
@@ -78,6 +90,8 @@ export default function App() {
       <HandshakeCount metrics={metrics} />
       <SignalStrength metrics={metrics} />
       <VehicleStats metrics={metrics} />
+      <Orientation data={orientationData} />
+      <VehicleInfo data={vehicleData} />
       <NetworkThroughput metrics={metrics} />
       <CPUTempGraph metrics={metrics} />
 

--- a/webui/src/components/Orientation.jsx
+++ b/webui/src/components/Orientation.jsx
@@ -1,0 +1,19 @@
+import { useEffect, useState } from 'react';
+
+export default function Orientation({ data }) {
+  const [info, setInfo] = useState(data);
+
+  useEffect(() => {
+    if (!data) {
+      fetch('/orientation')
+        .then(r => r.json())
+        .then(setInfo)
+        .catch(() => setInfo(null));
+    }
+  }, [data]);
+
+  if (!info) return <div>Orientation: N/A</div>;
+  const angle = info.angle != null ? ` (${info.angle.toFixed(0)}°)` : '';
+  const orient = info.orientation != null ? info.orientation : 'N/A';
+  return <div>Orientation: {orient}{angle}</div>;
+}

--- a/webui/src/components/VehicleInfo.jsx
+++ b/webui/src/components/VehicleInfo.jsx
@@ -1,0 +1,20 @@
+import { useEffect, useState } from 'react';
+
+export default function VehicleInfo({ data }) {
+  const [info, setInfo] = useState(data);
+
+  useEffect(() => {
+    if (!data) {
+      fetch('/vehicle')
+        .then(r => r.json())
+        .then(setInfo)
+        .catch(() => setInfo(null));
+    }
+  }, [data]);
+
+  if (!info) return <div>Vehicle: N/A</div>;
+  const speed = info.speed != null ? info.speed.toFixed(1) + ' km/h' : 'N/A';
+  const rpm = info.rpm != null ? info.rpm.toFixed(0) : 'N/A';
+  const load = info.engine_load != null ? info.engine_load.toFixed(0) + '%' : 'N/A';
+  return <div>Speed: {speed} | RPM: {rpm} | Load: {load}</div>;
+}


### PR DESCRIPTION
## Summary
- implement `/vehicle` API endpoint
- document the new endpoint in the status service docs
- add Orientation and VehicleInfo React widgets
- show these widgets from the demo `App`
- test new `/vehicle` endpoint

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'aiosqlite')*

------
https://chatgpt.com/codex/tasks/task_e_685b487997748333af02853c1197977d