### PR TITLE
Add kiosk launch helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,13 +216,15 @@ Alternatively serve `webui/dist` with any webserver while running
 `http://localhost:8000`.
 
 This starts a FastAPI server on `http://0.0.0.0:8000` with the API under `/api`.
-Launch Chromium in kiosk mode to display the dashboard:
+Launch Chromium in kiosk mode with the helper command:
 
 ```bash
-chromium-browser --kiosk http://localhost:8000
+piwardrive-kiosk
 ```
-Chromium must run inside a graphical environment. Ensure an X server is
-available and ``$DISPLAY`` is set. Headless setups can use ``Xvfb``.
+The command runs `piwardrive-webui` in the background and opens Chromium with
+`--kiosk` pointing to the dashboard. Chromium must run inside a graphical
+environment. Ensure an X server is available and ``$DISPLAY`` is set.
+Headless setups can use ``Xvfb``.
 
 #### Touch Interface (optional)
 
@@ -271,7 +273,7 @@ docker run --device=/dev/ttyUSB0 --rm piwardrive
 * **Launching the App** – activate the environment and start PiWardrive with `python -m piwardrive.main`.
 * **Systemd Service Setup** – copy `examples/piwardrive.service` to `/etc/systemd/system/` and enable it with `sudo systemctl enable --now piwardrive.service` to launch the backend on boot.
 * **Running the Status API** – start the FastAPI service manually with `piwardrive-service` to expose remote metrics.
-* **Browser Kiosk Mode** – build the React frontend (see above), then run `python -m piwardrive.webui_server` from the repository root and open Chromium with `--kiosk http://localhost:8000`.
+* **Browser Kiosk Mode** – build the React frontend (see above) and launch it with `piwardrive-kiosk` to start the server and open Chromium automatically.
 * **Map Tile Prefetch** – use `piwardrive-prefetch` to download map tiles without the GUI.
 * **Syncing Data** – set `remote_sync_url` (and optionally `remote_sync_interval`)
   in `~/.config/piwardrive/config.json` and trigger uploads via `/sync` or call

--- a/docs/web_ui.rst
+++ b/docs/web_ui.rst
@@ -57,11 +57,11 @@ Launching in Kiosk Mode
 -----------------------
 
 After building the frontend you can start the API server and open Chromium in
-kiosk mode with ``scripts/start_kiosk.sh``::
+kiosk mode with ``piwardrive-kiosk``::
 
-   scripts/start_kiosk.sh
+   piwardrive-kiosk
 
-The script runs ``piwardrive-service`` in the background and then executes
+The command launches ``piwardrive-webui`` in the background and then executes
 ``chromium-browser --kiosk http://localhost:8000`` (falling back to
 ``chromium`` when ``chromium-browser`` is unavailable).
 An active X server is required; headless systems may use ``Xvfb``.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ piwardrive-prefetch-batch = "piwardrive.scripts.prefetch_batch:main"
 log-follow = "piwardrive.scripts.log_follow:main"
 config-cli = "piwardrive.scripts.config_cli:main"
 calibrate-orientation = "piwardrive.scripts.calibrate_orientation:main"
+piwardrive-kiosk = "piwardrive.scripts.kiosk:main"
 
 
 

--- a/scripts/kiosk.py
+++ b/scripts/kiosk.py
@@ -1,0 +1,36 @@
+"""Launch the web UI and open Chromium in kiosk mode."""
+import argparse
+import shutil
+import subprocess
+import time
+from typing import Sequence
+
+DEFAULT_URL = "http://localhost:8000"
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    """Start ``piwardrive-webui`` and open Chromium in kiosk mode."""
+    parser = argparse.ArgumentParser(
+        description="Start the API server and open Chromium in kiosk mode"
+    )
+    parser.add_argument(
+        "--url", default=DEFAULT_URL, help="dashboard URL to open"
+    )
+    parser.add_argument(
+        "--delay", type=float, default=2.0, help="seconds to wait for the server"
+    )
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    proc = subprocess.Popen(["piwardrive-webui"])
+    try:
+        time.sleep(args.delay)
+        browser = shutil.which("chromium-browser") or shutil.which("chromium")
+        if browser is None:
+            raise FileNotFoundError("Chromium browser not found")
+        subprocess.run([browser, "--kiosk", args.url], check=True)
+    finally:
+        proc.terminate()
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation
+    main()

--- a/scripts/start_kiosk.sh
+++ b/scripts/start_kiosk.sh
@@ -2,22 +2,4 @@
 # Start the web UI and API server then open Chromium in kiosk mode.
 set -euo pipefail
 
-URL="http://localhost:8000"
-
-piwardrive-webui &
-PID=$!
-
-# Give the server a moment to start
-sleep 2
-
-# Prefer chromium-browser but fall back to chromium
-if command -v chromium-browser >/dev/null 2>&1; then
-    BROWSER=chromium-browser
-else
-    BROWSER=chromium
-fi
-
-"$BROWSER" --kiosk "$URL"
-
-# Stop the API when the browser exits
-kill "$PID"
+piwardrive-kiosk "$@"

--- a/tests/test_kiosk_cli.py
+++ b/tests/test_kiosk_cli.py
@@ -1,0 +1,36 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_kiosk_cli_launches_browser(tmp_path):
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    log = tmp_path / "log.txt"
+
+    server_script = bin_dir / "piwardrive-webui"
+    server_script.write_text(
+        (
+            "#!/bin/sh\n"
+            "echo server_started >> \"%s\"\n"
+            "trap 'exit 0' TERM\n"
+            "while true; do sleep 0.1; done\n"
+        )
+        % log
+    )
+    browser_script = bin_dir / "chromium-browser"
+    browser_script.write_text(
+        "#!/bin/sh\necho browser_called >> \"%s\"\n" % log
+    )
+    for p in (server_script, browser_script):
+        p.chmod(0o755)
+
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}:{env['PATH']}"
+
+    script = Path("scripts/kiosk.py")
+    subprocess.run([sys.executable, str(script), "--delay", "0"], env=env, check=True)
+
+    assert "server_started" in log.read_text()
+    assert "browser_called" in log.read_text()

--- a/webui/README.md
+++ b/webui/README.md
@@ -85,13 +85,13 @@ The dev server watches the source files and automatically reloads the page. API 
 
 ## 7. Kiosk Launch Helper
 
-For a dedicated dashboard device you can automate the startup process with the helper script:
+For a dedicated dashboard device you can automate the startup process with the helper command:
 
 ```bash
-scripts/start_kiosk.sh
+piwardrive-kiosk
 ```
 
-The script runs `piwardrive-service` in the background and then opens Chromium in kiosk mode pointing to the local web UI. If `chromium-browser` is not installed it falls back to `chromium`. An X server must be available; headless environments may use `Xvfb`.
+The command runs `piwardrive-webui` in the background and then opens Chromium in kiosk mode pointing to the local web UI. If `chromium-browser` is not installed it falls back to `chromium`. An X server must be available; headless environments may use `Xvfb`.
 
 ## 8. Serving the Build Elsewhere
 


### PR DESCRIPTION
## Summary
- provide a `piwardrive-kiosk` helper for running the dashboard in Chromium kiosk mode
- document the helper command in README and docs
- make `scripts/start_kiosk.sh` delegate to the new command
- expose the helper as an entry point in `pyproject.toml`
- add tests for the Python launcher

## Testing
- `pytest tests/test_kiosk_cli.py -q`
- `pre-commit run --files README.md docs/web_ui.rst pyproject.toml scripts/start_kiosk.sh scripts/kiosk.py webui/README.md tests/test_kiosk_cli.py` *(fails: InvalidManifestError)*

------
https://chatgpt.com/codex/tasks/task_e_685b484980208333854ba090ecff8e5c