### PR TITLE
Migrate settings to React

### DIFF
--- a/docs/web_ui.rst
+++ b/docs/web_ui.rst
@@ -23,8 +23,9 @@ columns.
 
 
 The ``/config`` endpoint now allows the web UI to modify settings on the
-device.  Each option is rendered as a simple form field and saved back to
-``config.json`` via a POST request.  Changes take effect on the next reload.
+device.  The React dashboard exposes a dedicated **Settings** page mirroring the
+former Kivy interface. Configuration options are fetched from ``/config`` and
+saved back via a POST request so changes persist to ``config.json``.
 
 Build the frontend with **Node.js 18+** and npm::
 

--- a/webui/src/App.jsx
+++ b/webui/src/App.jsx
@@ -6,12 +6,12 @@ import SignalStrength from './components/SignalStrength.jsx';
 import NetworkThroughput from './components/NetworkThroughput.jsx';
 import CPUTempGraph from './components/CPUTempGraph.jsx';
 import VehicleStats from './components/VehicleStats.jsx';
+import SettingsForm from './components/SettingsForm.jsx';
 
 export default function App() {
   const [status, setStatus] = useState([]);
   const [metrics, setMetrics] = useState(null);
   const [logs, setLogs] = useState('');
-  const [configData, setConfigData] = useState(null);
   const [plugins, setPlugins] = useState([]);
 
   useEffect(() => {
@@ -37,32 +37,11 @@ export default function App() {
     fetch('/plugins')
       .then(r => r.json())
       .then(setPlugins);
-    fetch('/api/widgets')
-      .then(r => r.json())
-      .then(d => setWidgets(d.widgets));
     fetch('/logs?lines=20')
       .then(r => r.json())
       .then(d => setLogs(d.lines.join('\n')));
-    fetch('/config')
-      .then(r => r.json())
-      .then(setConfigData);
     return () => ws.close();
   }, []);
-
-  const handleChange = (k, v) => {
-    setConfigData({ ...configData, [k]: v });
-  };
-
-  const saveConfig = () => {
-    fetch('/config', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(configData),
-    })
-      .then(r => r.json())
-      .then(setConfigData)
-      .catch(e => console.error('save failed', e));
-  };
 
   return (
     <div>
@@ -83,21 +62,7 @@ export default function App() {
 
       <h2>Logs</h2>
       <pre>{logs}</pre>
-      {configData && (
-        <section>
-          <h2>Settings</h2>
-          {Object.keys(configData).map(k => (
-            <div key={k}>
-              <label>{k}</label>
-              <input
-                value={configData[k] ?? ''}
-                onChange={e => handleChange(k, e.target.value)}
-              />
-            </div>
-          ))}
-          <button onClick={saveConfig}>Save</button>
-        </section>
-      )}
+      <SettingsForm />
     </div>
   );
 }

--- a/webui/src/components/SettingsForm.jsx
+++ b/webui/src/components/SettingsForm.jsx
@@ -1,0 +1,84 @@
+import { useEffect, useState } from 'react';
+
+export default function SettingsForm() {
+  const [config, setConfig] = useState(null);
+
+  useEffect(() => {
+    fetch('/config')
+      .then(r => r.json())
+      .then(setConfig);
+  }, []);
+
+  const handleChange = (key, value) => {
+    setConfig({ ...config, [key]: value });
+  };
+
+  const save = () => {
+    fetch('/config', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(config),
+    })
+      .then(r => r.json())
+      .then(setConfig);
+  };
+
+  if (!config) return null;
+
+  const fields = [
+    ['kismet_logdir', 'Kismet Log Directory', 'text'],
+    ['bettercap_caplet', 'BetterCAP Caplet', 'text'],
+    ['map_poll_gps', 'GPS Poll Interval', 'number'],
+    ['map_poll_gps_max', 'GPS Poll Max', 'number'],
+    ['map_poll_aps', 'AP Poll Interval', 'number'],
+    ['map_poll_bt', 'BT Poll Interval', 'number'],
+    ['health_poll_interval', 'Health Poll Interval', 'number'],
+    ['log_rotate_interval', 'Log Rotate Interval', 'number'],
+    ['log_rotate_archives', 'Log Rotate Archives', 'number'],
+    ['cleanup_rotated_logs', 'Cleanup Rotated Logs', 'checkbox'],
+    ['offline_tile_path', 'Offline Tile Path', 'text'],
+    ['map_use_offline', 'Use Offline Tiles', 'checkbox'],
+    ['map_auto_prefetch', 'Auto Prefetch Tiles', 'checkbox'],
+    ['map_show_gps', 'Show GPS', 'checkbox'],
+    ['map_show_aps', 'Show APs', 'checkbox'],
+    ['map_show_bt', 'Show Bluetooth', 'checkbox'],
+    ['map_cluster_aps', 'Cluster APs', 'checkbox'],
+    ['map_cluster_capacity', 'Cluster Capacity', 'number'],
+    ['debug_mode', 'Debug Mode', 'checkbox'],
+    ['widget_battery_status', 'Battery Widget', 'checkbox'],
+    ['ui_font_size', 'Font Size', 'number'],
+    ['theme', 'Theme', 'text'],
+  ];
+
+  return (
+    <section>
+      <h2>Settings</h2>
+      {fields.map(([key, label, type]) => (
+        <div key={key}>
+          <label>
+            {label}{' '}
+            {type === 'checkbox' ? (
+              <input
+                type="checkbox"
+                checked={!!config[key]}
+                onChange={e => handleChange(key, e.target.checked)}
+              />
+            ) : (
+              <input
+                type={type}
+                value={config[key] ?? ''}
+                onChange={e =>
+                  handleChange(
+                    key,
+                    type === 'number' ? Number(e.target.value) : e.target.value
+                  )
+                }
+              />
+            )}
+          </label>
+        </div>
+      ))}
+      <button onClick={save}>Save</button>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- expose dedicated SettingsForm React component
- load and save configuration via `/config`
- hook new form into dashboard
- document the new settings page

## Testing
- `pre-commit` *(fails: InvalidManifestError)*
- `pytest -k settings_screen -q` *(fails: ModuleNotFoundError: No module named 'aiosqlite')*

------
https://chatgpt.com/codex/tasks/task_e_685b486c9aac8333a494ced034abc755