### PR TITLE
Remove Kivy packages

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,5 @@
 ##requirements
 
-kivy==2.3.1
-kivymd==1.1.1
-kivy_garden.mapview==1.0.6
-kivy_garden.graph==0.4.0
 requests==2.32.4
 requests-cache==1.2.1
 psutil==5.9.6


### PR DESCRIPTION
## Summary
- drop Kivy/KivyMD and kivygarden packages from requirements.txt

## Testing
- `flake8` *(fails: imported names unused)*
- `pytest -q` *(fails: missing dependencies)*
- `pre-commit run --files requirements.txt` *(fails: InvalidManifestError)*

------
https://chatgpt.com/codex/tasks/task_e_685b4898df948333ac810900e746a741