### PR TITLE
Add piwardrive-webui systemd unit

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,8 @@ npm run build
 cd ..
 python -m piwardrive.webui_server
 ```
+To autostart the dashboard on boot copy `examples/piwardrive-webui.service` into `/etc/systemd/system/` and enable it with `sudo systemctl enable --now piwardrive-webui.service`.
+
 
 Alternatively serve `webui/dist` with any webserver while running
 `piwardrive-service` for the API. During development you can run

--- a/docs/deployment.rst
+++ b/docs/deployment.rst
@@ -34,6 +34,7 @@ SD Card Image
        npm install
        npm run build
        python -m piwardrive.webui_server
+Copy `examples/piwardrive-webui.service` into `/etc/systemd/system/` and enable it with `sudo systemctl enable --now piwardrive-webui.service` to run the dashboard on boot.
 8. Power down, remove the card and duplicate it with ``dd`` or other imaging tools to deploy multiple devices.
 
 Docker Container

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -66,6 +66,8 @@ Raspberry Pi OS
       npm run build
       python -m piwardrive.webui_server
 
+Copy `examples/piwardrive-webui.service` into `/etc/systemd/system/` and enable it with `sudo systemctl enable --now piwardrive-webui.service` to start the dashboard automatically on boot.
+
 
 Generic Linux
 -------------

--- a/docs/status_service.rst
+++ b/docs/status_service.rst
@@ -26,8 +26,8 @@ Use the ``limit`` query parameter to control how many entries are returned.
 Autostart
 ---------
 
-Copy ``examples/service_api.service`` into ``/etc/systemd/system/`` and enable it
-with ``sudo systemctl enable --now service_api.service`` to run ``piwardrive-service`` on boot.
+Copy ``examples/service_api.service`` into ``/etc/systemd/system/`` and enable it with ``sudo systemctl enable --now service_api.service`` to run ``piwardrive-service`` on boot.
+Copy ``examples/piwardrive-webui.service`` for the combined API and web interface if you built the dashboard.
 
 
 Additional Routes

--- a/docs/web_ui.rst
+++ b/docs/web_ui.rst
@@ -34,6 +34,8 @@ Build the frontend with **Node.js 18+** and npm::
    npm install
    npm run build
 
+Use `examples/piwardrive-webui.service` to run `piwardrive-webui` automatically on boot after building.
+
 During development you can run ``npm run dev`` which starts a Vite server
 and proxies API requests to ``http://localhost:8000``.
 

--- a/examples/piwardrive-webui.service
+++ b/examples/piwardrive-webui.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=PiWardrive API and Web UI
+After=network.target
+
+[Service]
+Type=simple
+User=pi
+WorkingDirectory=/home/pi/piwardrive
+Environment=PW_WEBUI_DIST=/home/pi/piwardrive/webui/dist
+ExecStart=/home/pi/piwardrive/gui-env/bin/piwardrive-webui
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- add `piwardrive-webui.service` example to autostart API + dashboard
- document new service in README and docs

## Testing
- `pre-commit run --files README.md docs/deployment.rst docs/installation.rst docs/status_service.rst docs/web_ui.rst examples/piwardrive-webui.service` *(fails: InvalidManifestError)*
- `pytest -q` *(fails: 67 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_685b4eafcf8483338dbb8e639898b390