### PR TITLE
Enable live AP updates

### DIFF
--- a/docs/status_service.rst
+++ b/docs/status_service.rst
@@ -93,6 +93,14 @@ the ``log_paths`` whitelist defined in ``config.json``::
 ``/export/bt``
     Return Bluetooth scan results in the requested format.
 
+``/ws/aps`` streams newly discovered Wi-Fi access points over WebSocket::
+
+   websocat ws://localhost:8000/ws/aps
+
+``/sse/aps`` provides the same updates using Server-Sent Events::
+
+   curl http://localhost:8000/sse/aps
+
 ``/ws/status`` streams the same information over a WebSocket connection. Each
 message combines the ``/status`` and ``/widget-metrics`` responses so clients can
 stay up to date without polling::


### PR DESCRIPTION
## Summary
- stream new AP markers over WebSocket and SSE
- listen for the live stream in MapScreen
- document the new endpoints
- test the websocket/SSE streams

## Testing
- `pre-commit run --files docs/status_service.rst src/piwardrive/service.py tests/test_service.py webui/src/components/MapScreen.jsx` *(fails: InvalidManifestError)*
- `pytest -q tests/test_service.py` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685b4ebb3268833394a78e6ab3cc5066