### PR TITLE
Add service control API

### DIFF
--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -606,3 +606,30 @@ def test_gps_endpoint(monkeypatch) -> None:
         assert data["accuracy"] == 5.0
         assert data["fix"] == "3D"
 
+
+def test_service_control_endpoint_success() -> None:
+    with (
+        mock.patch("service.run_service_cmd", return_value=(True, "", "")),
+        mock.patch("piwardrive.service.run_service_cmd", return_value=(True, "", "")),
+    ):
+        client = TestClient(service.app)
+        resp = client.post("/service/kismet/start")
+        assert resp.status_code == 200
+        assert resp.json()["success"] is True
+
+
+def test_service_control_endpoint_failure() -> None:
+    with (
+        mock.patch("service.run_service_cmd", return_value=(False, "", "boom")),
+        mock.patch("piwardrive.service.run_service_cmd", return_value=(False, "", "boom")),
+    ):
+        client = TestClient(service.app)
+        resp = client.post("/service/kismet/start")
+        assert resp.status_code == 500
+
+
+def test_service_control_endpoint_invalid_action() -> None:
+    client = TestClient(service.app)
+    resp = client.post("/service/kismet/invalid")
+    assert resp.status_code == 400
+

--- a/webui/src/components/ServiceStatus.jsx
+++ b/webui/src/components/ServiceStatus.jsx
@@ -1,9 +1,25 @@
 export default function ServiceStatus({ metrics }) {
   if (!metrics) return <div>Services: N/A</div>;
   const { kismet_running, bettercap_running } = metrics;
+
+  const control = (svc, action) => {
+    fetch(`/service/${svc}/${action}`, { method: 'POST' }).catch(() => {});
+  };
+
   return (
     <div>
-      Kismet: {kismet_running ? 'ok' : 'down'} | BetterCAP: {bettercap_running ? 'ok' : 'down'}
+      <div>
+        Kismet: {kismet_running ? 'ok' : 'down'}{' '}
+        <button onClick={() => control('kismet', kismet_running ? 'stop' : 'start')}>
+          {kismet_running ? 'Stop' : 'Start'}
+        </button>
+      </div>
+      <div>
+        BetterCAP: {bettercap_running ? 'ok' : 'down'}{' '}
+        <button onClick={() => control('bettercap', bettercap_running ? 'stop' : 'start')}>
+          {bettercap_running ? 'Stop' : 'Start'}
+        </button>
+      </div>
     </div>
   );
 }

--- a/webui/vite.config.js
+++ b/webui/vite.config.js
@@ -33,6 +33,7 @@ export default defineConfig({
       '/api/plugins': 'http://localhost:8000',
       '/api/widgets': 'http://localhost:8000',
       '/dashboard-settings': 'http://localhost:8000',
+      '/service': 'http://localhost:8000',
       '/ws': {
         target: 'ws://localhost:8000',
         ws: true


### PR DESCRIPTION
## Summary
- implement `/service/{name}/{action}` endpoint for systemd control
- expose service control buttons in the web UI
- proxy new endpoint in Vite config
- test the new API behaviour

## Testing
- `pytest -q` *(fails: FileNotFoundError due to missing environment)*

------
https://chatgpt.com/codex/tasks/task_e_685b4ecfaaa08333bbb38851c524772d