### PR TITLE
Remove unused Kivy entry point

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,6 @@ license = {file = "LICENSE"}
 authors = [{name = "PiWardrive contributors"}]
 
 [project.scripts]
-piwardrive = "piwardrive.main:main"
 piwardrive-service = "piwardrive.service:main"
 piwardrive-webui = "piwardrive.webui_server:main"
 health-export = "piwardrive.scripts.health_export:main"


### PR DESCRIPTION
## Summary
- drop the deprecated `piwardrive` console script

## Testing
- `pre-commit run --files pyproject.toml` *(fails: command not found)*
- `pytest -q` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685b4ee3bc0c8333a474743e6ce960c1