### PR TITLE
Add heatmap overlay and vector tile customizer React components

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ graph LR
 - Real-time CPU, memory and network metrics
 - Drag-and-drop dashboard widgets
 - Vector tile renderer and track playback
+- Heatmap overlay on the map screen
+- Vector tile customizer in the web UI
 - Drone-based mapping mode
 - Geofencing and cached map tiles
 - Status service with React web UI

--- a/docs/web_ui.rst
+++ b/docs/web_ui.rst
@@ -28,6 +28,12 @@ device.  The React dashboard exposes a dedicated **Settings** page mirroring the
 former Kivy interface. Configuration options are fetched from ``/config`` and
 saved back via a POST request so changes persist to ``config.json``.
 
+Heatmap overlays derived from the aggregation service can be toggled on the map
+screen. The layer uses ``leaflet.heat`` and displays points returned by the
+``/overlay`` API. A simple **Vector Tile Customizer** form lets you apply
+MapLibre style metadata to an MBTiles database via the
+``/api/vector-tiles/style`` endpoint.
+
 Build the frontend with **Node.js 18+** and npm::
 
    cd webui

--- a/webui/package-lock.json
+++ b/webui/package-lock.json
@@ -11,6 +11,7 @@
         "chart.js": "^4.5.0",
         "leaflet": "^1.9.4",
         "leaflet-draw": "^1.0.4",
+        "leaflet.heat": "^0.2.0",
         "react": "^18.2.0",
         "react-chartjs-2": "^5.2.0",
         "react-dom": "^18.2.0",
@@ -4331,6 +4332,12 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/leaflet-draw/-/leaflet-draw-1.0.4.tgz",
       "integrity": "sha512-rsQ6saQO5ST5Aj6XRFylr5zvarWgzWnrg46zQ1MEOEIHsppdC/8hnN8qMoFvACsPvTioAuysya/TVtog15tyAQ==",
+      "license": "MIT"
+    },
+    "node_modules/leaflet.heat": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/leaflet.heat/-/leaflet.heat-0.2.0.tgz",
+      "integrity": "sha512-",
       "license": "MIT"
     },
     "node_modules/leven": {

--- a/webui/package.json
+++ b/webui/package.json
@@ -11,6 +11,7 @@
     "chart.js": "^4.5.0",
     "leaflet": "^1.9.4",
     "leaflet-draw": "^1.0.4",
+    "leaflet.heat": "^0.2.0",
     "react": "^18.2.0",
     "react-chartjs-2": "^5.2.0",
     "react-dom": "^18.2.0",

--- a/webui/src/App.jsx
+++ b/webui/src/App.jsx
@@ -12,6 +12,7 @@ import SettingsForm from './components/SettingsForm.jsx';
 import MapScreen from './components/MapScreen.jsx';
 import Orientation from './components/Orientation.jsx';
 import VehicleInfo from './components/VehicleInfo.jsx';
+import VectorTileCustomizer from './components/VectorTileCustomizer.jsx';
 
 export default function App() {
   const [status, setStatus] = useState([]);
@@ -109,6 +110,7 @@ export default function App() {
       <pre>{logs}</pre>
       <h2>Geofences</h2>
       <GeofenceEditor />
+      <VectorTileCustomizer />
       {configData && (
         <section>
           <h2>Settings</h2>

--- a/webui/src/components/HeatmapLayer.jsx
+++ b/webui/src/components/HeatmapLayer.jsx
@@ -1,0 +1,26 @@
+import { useEffect } from 'react';
+import { useMap } from 'react-leaflet';
+import 'leaflet.heat';
+
+export default function HeatmapLayer({ show }) {
+  const map = useMap();
+  useEffect(() => {
+    if (!show) return undefined;
+    let layer;
+    const load = async () => {
+      try {
+        const resp = await fetch('/overlay?bins=50');
+        const data = await resp.json();
+        const pts = (data.points || []).map(([lat, lon, cnt]) => [lat, lon, cnt]);
+        layer = window.L.heatLayer(pts, { radius: 25 }).addTo(map);
+      } catch (e) {
+        console.error('heatmap load error', e);
+      }
+    };
+    load();
+    return () => {
+      if (layer) map.removeLayer(layer);
+    };
+  }, [show, map]);
+  return null;
+}

--- a/webui/src/components/MapScreen.jsx
+++ b/webui/src/components/MapScreen.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import { MapContainer, TileLayer, Marker, Popup } from 'react-leaflet';
+import HeatmapLayer from './HeatmapLayer.jsx';
 import 'leaflet/dist/leaflet.css';
 import { prefetchTiles, routePrefetch, purgeOldTiles, enforceCacheLimit } from '../tileCache.js';
 
@@ -18,6 +19,7 @@ export default function MapScreen() {
   const [follow, setFollow] = useState(true);
   const [aps, setAps] = useState([]);
   const [filter, setFilter] = useState({ ssid: '', encryption: '' });
+  const [showHeatmap, setShowHeatmap] = useState(false);
   const track = useRef([]);
 
   // fetch GPS periodically
@@ -102,6 +104,14 @@ export default function MapScreen() {
           />
           Follow GPS
         </label>
+        <label style={{ marginLeft: '1em' }}>
+          <input
+            type="checkbox"
+            checked={showHeatmap}
+            onChange={() => setShowHeatmap(!showHeatmap)}
+          />
+          Show Heatmap
+        </label>
         <button onClick={prefetchView} style={{ marginLeft: '1em' }}>
           Prefetch View
         </button>
@@ -120,6 +130,7 @@ export default function MapScreen() {
       </div>
       <MapContainer center={center} zoom={zoom} style={{ height: '80vh' }}>
         <TileLayer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png" />
+        <HeatmapLayer show={showHeatmap} />
         {filtered.map(ap => (
           <Marker key={ap.bssid} position={[ap.lat, ap.lon]}>
             <Popup>{ap.ssid || ap.bssid}</Popup>

--- a/webui/src/components/VectorTileCustomizer.jsx
+++ b/webui/src/components/VectorTileCustomizer.jsx
@@ -1,0 +1,60 @@
+import { useState } from 'react';
+
+export default function VectorTileCustomizer() {
+  const [mbtiles, setMbtiles] = useState('');
+  const [style, setStyle] = useState('');
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+  const [status, setStatus] = useState('');
+
+  const submit = () => {
+    fetch('/api/vector-tiles/style', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ mbtiles, style, name, description }),
+    })
+      .then(r => r.json())
+      .then(() => setStatus('Updated'))
+      .catch(() => setStatus('Error'));
+  };
+
+  return (
+    <section>
+      <h2>Vector Tile Customizer</h2>
+      <div>
+        <label>
+          MBTiles Path
+          <input value={mbtiles} onChange={e => setMbtiles(e.target.value)} />
+        </label>
+      </div>
+      <div>
+        <label>
+          Style JSON
+          <textarea
+            value={style}
+            onChange={e => setStyle(e.target.value)}
+            rows={4}
+            cols={40}
+          />
+        </label>
+      </div>
+      <div>
+        <label>
+          Name
+          <input value={name} onChange={e => setName(e.target.value)} />
+        </label>
+      </div>
+      <div>
+        <label>
+          Description
+          <input
+            value={description}
+            onChange={e => setDescription(e.target.value)}
+          />
+        </label>
+      </div>
+      <button onClick={submit}>Apply</button>
+      {status && <p>{status}</p>}
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- add Leaflet heatmap layer component
- enable heatmap toggle in `MapScreen`
- create simple `VectorTileCustomizer` form
- document new web UI capabilities

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'aiosqlite')*

------
https://chatgpt.com/codex/tasks/task_e_685b4edab34883338a0737be185a5b1d