### PR TITLE
Improve WS/SSE status streaming

### DIFF
--- a/docs/status_service.rst
+++ b/docs/status_service.rst
@@ -109,6 +109,9 @@ stay up to date without polling::
 
 Each message includes ``seq`` and ``timestamp`` fields plus an ``errors`` counter
 to help detect missed updates.
+Clients are encouraged to send periodic ``ping`` messages to keep the
+connection alive. The bundled web UI implements this automatically and
+reconnects if the stream is interrupted.
 
 ``/sse/status`` provides the same updates using `Server-Sent Events`_ for
 environments where WebSockets are unavailable::

--- a/docs/web_ui.rst
+++ b/docs/web_ui.rst
@@ -9,7 +9,9 @@ PiWardrive's main user experience is delivered through a React application under
 recent status information and logs.  When
 available the frontend connects to ``/ws/status`` to receive live updates
 without polling. If WebSockets are unavailable it falls back to the
-``/sse/status`` endpoint using Server-Sent Events.
+``/sse/status`` endpoint using Server-Sent Events. The connection
+automatically reconnects when dropped and sends a heartbeat ping every
+15&nbsp;seconds to keep the stream alive.
 
 Plugin widgets stored under ``~/.config/piwardrive/plugins`` are also
 detected.  The new ``/plugins`` route lists the discovered classes so the web UI

--- a/webui/src/App.jsx
+++ b/webui/src/App.jsx
@@ -1,32 +1,33 @@
-import { useEffect, useState } from 'react';
-import BatteryStatus from './components/BatteryStatus.jsx';
-import ServiceStatus from './components/ServiceStatus.jsx';
-import HandshakeCount from './components/HandshakeCount.jsx';
-import SignalStrength from './components/SignalStrength.jsx';
-import NetworkThroughput from './components/NetworkThroughput.jsx';
-import CPUTempGraph from './components/CPUTempGraph.jsx';
-import StatsDashboard from './components/StatsDashboard.jsx';
-import VehicleStats from './components/VehicleStats.jsx';
-import GeofenceEditor from './components/GeofenceEditor.jsx';
-import SettingsForm from './components/SettingsForm.jsx';
-import MapScreen from './components/MapScreen.jsx';
-import Orientation from './components/Orientation.jsx';
-import VehicleInfo from './components/VehicleInfo.jsx';
-import VectorTileCustomizer from './components/VectorTileCustomizer.jsx';
+import { useEffect, useState } from "react";
+import BatteryStatus from "./components/BatteryStatus.jsx";
+import ServiceStatus from "./components/ServiceStatus.jsx";
+import HandshakeCount from "./components/HandshakeCount.jsx";
+import SignalStrength from "./components/SignalStrength.jsx";
+import NetworkThroughput from "./components/NetworkThroughput.jsx";
+import CPUTempGraph from "./components/CPUTempGraph.jsx";
+import StatsDashboard from "./components/StatsDashboard.jsx";
+import VehicleStats from "./components/VehicleStats.jsx";
+import GeofenceEditor from "./components/GeofenceEditor.jsx";
+import SettingsForm from "./components/SettingsForm.jsx";
+import MapScreen from "./components/MapScreen.jsx";
+import Orientation from "./components/Orientation.jsx";
+import VehicleInfo from "./components/VehicleInfo.jsx";
+import VectorTileCustomizer from "./components/VectorTileCustomizer.jsx";
 
 export default function App() {
   const [status, setStatus] = useState([]);
   const [metrics, setMetrics] = useState(null);
-  const [logs, setLogs] = useState('');
+  const [logs, setLogs] = useState("");
   const [plugins, setPlugins] = useState([]);
   const [widgets, setWidgets] = useState([]);
   const [orientationData, setOrientationData] = useState(null);
   const [vehicleData, setVehicleData] = useState(null);
 
   useEffect(() => {
-    const proto = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+    const proto = window.location.protocol === "https:" ? "wss:" : "ws:";
     let ws;
     let es;
+    let ping;
 
     const handleData = (raw) => {
       try {
@@ -34,47 +35,75 @@ export default function App() {
         if (data.status) setStatus(data.status);
         if (data.metrics) setMetrics(data.metrics);
       } catch (e) {
-        console.error('status parse error', e);
+        console.error("status parse error", e);
       }
     };
 
     const startSse = () => {
-      es = new EventSource('/sse/status');
+      if (es) es.close();
+      es = new EventSource("/sse/status");
       es.onmessage = (ev) => handleData(ev.data);
-      es.onerror = () => es.close();
+      es.onerror = () => {
+        es.close();
+        setTimeout(startSse, 3000);
+      };
     };
 
-    if (window.WebSocket) {
+    const startWs = () => {
+      if (ws) ws.close();
       try {
         ws = new WebSocket(`${proto}//${window.location.host}/ws/status`);
+        ws.onopen = () => {
+          if (ping) clearInterval(ping);
+          ping = setInterval(() => {
+            if (ws.readyState === WebSocket.OPEN) {
+              ws.send("ping");
+            }
+          }, 15000);
+        };
         ws.onmessage = (ev) => handleData(ev.data);
-        ws.onerror = () => {
-          ws.close();
-          startSse();
+        ws.onerror = () => ws.close();
+        ws.onclose = () => {
+          if (ping) {
+            clearInterval(ping);
+            ping = null;
+          }
+          setTimeout(() => {
+            if (window.WebSocket) {
+              startWs();
+            } else {
+              startSse();
+            }
+          }, 3000);
         };
       } catch (e) {
         startSse();
       }
+    };
+
+    if (window.WebSocket) {
+      startWs();
     } else {
       startSse();
     }
 
-    fetch('/status')
-      .then(r => r.json())
+    fetch("/status")
+      .then((r) => r.json())
       .then(setStatus);
-    fetch('/widget-metrics')
-      .then(r => r.json())
+    fetch("/widget-metrics")
+      .then((r) => r.json())
       .then(setMetrics);
-    fetch('/api/plugins')
-      .then(r => r.json())
+    fetch("/api/plugins")
+      .then((r) => r.json())
       .then(setPlugins);
-    fetch('/logs?lines=20')
-      .then(r => r.json())
-      .then(d => setLogs(d.lines.join('\n')));
-    fetch('/config')
-      .then(r => r.json())
+    fetch("/logs?lines=20")
+      .then((r) => r.json())
+      .then((d) => setLogs(d.lines.join("\n")));
+    fetch("/config")
+      .then((r) => r.json())
       .then(setConfigData);
     return () => {
+      if (ping) clearInterval(ping);
       if (ws) ws.close();
       if (es) es.close();
     };
@@ -90,7 +119,7 @@ export default function App() {
       <pre>{JSON.stringify(metrics, null, 2)}</pre>
       <h2>Plugin Widgets</h2>
       <ul>
-        {plugins.map(p => (
+        {plugins.map((p) => (
           <li key={p}>{p}</li>
         ))}
       </ul>
@@ -114,12 +143,12 @@ export default function App() {
       {configData && (
         <section>
           <h2>Settings</h2>
-          {Object.keys(configData).map(k => (
+          {Object.keys(configData).map((k) => (
             <div key={k}>
               <label>{k}</label>
               <input
-                value={configData[k] ?? ''}
-                onChange={e => handleChange(k, e.target.value)}
+                value={configData[k] ?? ""}
+                onChange={(e) => handleChange(k, e.target.value)}
               />
             </div>
           ))}
@@ -129,4 +158,3 @@ export default function App() {
     </div>
   );
 }
-


### PR DESCRIPTION
## Summary
- add reconnection and heartbeat ping logic in App.jsx
- mention heartbeat + reconnection in docs

## Testing
- `npx prettier --write webui/src/App.jsx`
- `pytest tests/test_service.py::test_ws_status_stream -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685b51fe0044833382755b1ce892eea8