### PR TITLE
Implement dynamic plugin widget loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ graph LR
 - Drone-based mapping mode
 - Geofencing and cached map tiles
 - Status service with React web UI
-- Plugin widgets shown in the web UI
+- Plugin widgets dynamically loaded in the web UI
 - Offline-capable PWA frontend
 
 

--- a/webui/README.md
+++ b/webui/README.md
@@ -106,7 +106,7 @@ Any static web server can host the contents of `webui/dist` as long as the API i
 
 ## 9. Plugin Widgets
 
-Custom widgets placed under `~/.config/piwardrive/plugins` are detected at runtime. The `/plugins` API route lists the discovered classes so you can confirm your plugin was loaded. Rebuild the frontend if you add React components that correspond to new widgets.
+Custom widgets placed under `~/.config/piwardrive/plugins` are detected at runtime. The `/plugins` API route lists the discovered classes so you can confirm your plugin was loaded. When a matching React component exists under `webui/src/components/`, it will be loaded dynamically without further code changes.
 
 ## 10. Offline Usage
 

--- a/webui/src/App.jsx
+++ b/webui/src/App.jsx
@@ -1,4 +1,9 @@
 import { useEffect, useState } from 'react';
+
+// Vite will bundle any components that match this glob so plugin widgets can be
+// loaded dynamically by name. Plugin authors should place React components under
+// `webui/src/components` with file names matching the Python class names.
+const pluginModules = import.meta.glob('./components/*.jsx');
 import BatteryStatus from './components/BatteryStatus.jsx';
 import ServiceStatus from './components/ServiceStatus.jsx';
 import HandshakeCount from './components/HandshakeCount.jsx';
@@ -80,6 +85,26 @@ export default function App() {
     };
   }, []);
 
+  useEffect(() => {
+    const loadWidgets = async () => {
+      const loaded = [];
+      for (const name of plugins) {
+        const path = `./components/${name}.jsx`;
+        const importer = pluginModules[path];
+        if (importer) {
+          try {
+            const mod = await importer();
+            loaded.push({ name, Component: mod.default });
+          } catch (err) {
+            console.error('Failed loading plugin component', name, err);
+          }
+        }
+      }
+      setWidgets(loaded);
+    };
+    loadWidgets();
+  }, [plugins]);
+
   return (
     <div>
       <h2>Map</h2>
@@ -94,6 +119,9 @@ export default function App() {
           <li key={p}>{p}</li>
         ))}
       </ul>
+      {widgets.map(({ name, Component }) => (
+        <Component key={name} metrics={metrics} />
+      ))}
       <h2>Dashboard</h2>
       <BatteryStatus metrics={metrics} />
       <ServiceStatus metrics={metrics} />

--- a/webui/tests/widgets.test.jsx
+++ b/webui/tests/widgets.test.jsx
@@ -19,7 +19,8 @@ describe('dashboard widgets', () => {
 
   it('shows service status', () => {
     render(<ServiceStatus metrics={{ kismet_running: true, bettercap_running: false }} />);
-    expect(screen.getByText(/Kismet: ok \| BetterCAP: down/)).toBeInTheDocument();
+    expect(screen.getByText(/Kismet:.*ok/)).toBeInTheDocument();
+    expect(screen.getByText(/BetterCAP:.*down/)).toBeInTheDocument();
   });
 
   it('displays handshake count', () => {


### PR DESCRIPTION
## Summary
- load plugin React components dynamically and render them
- fix ServiceStatus test to match updated markup
- document dynamic widget loading in README and webui docs

## Testing
- `npm test`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'aiosqlite')*

------
https://chatgpt.com/codex/tasks/task_e_685b520287ec8333988d10449397a923