### PR TITLE
Implement periodic polling for vehicle/orientation widgets

### DIFF
--- a/webui/src/components/Orientation.jsx
+++ b/webui/src/components/Orientation.jsx
@@ -4,12 +4,21 @@ export default function Orientation({ data }) {
   const [info, setInfo] = useState(data);
 
   useEffect(() => {
-    if (!data) {
+    if (data) {
+      setInfo(data);
+      return;
+    }
+
+    const load = () => {
       fetch('/orientation')
         .then(r => r.json())
         .then(setInfo)
         .catch(() => setInfo(null));
-    }
+    };
+
+    load();
+    const id = setInterval(load, 5000);
+    return () => clearInterval(id);
   }, [data]);
 
   if (!info) return <div>Orientation: N/A</div>;

--- a/webui/src/components/VehicleInfo.jsx
+++ b/webui/src/components/VehicleInfo.jsx
@@ -4,12 +4,21 @@ export default function VehicleInfo({ data }) {
   const [info, setInfo] = useState(data);
 
   useEffect(() => {
-    if (!data) {
+    if (data) {
+      setInfo(data);
+      return;
+    }
+
+    const load = () => {
       fetch('/vehicle')
         .then(r => r.json())
         .then(setInfo)
         .catch(() => setInfo(null));
-    }
+    };
+
+    load();
+    const id = setInterval(load, 5000);
+    return () => clearInterval(id);
   }, [data]);
 
   if (!info) return <div>Vehicle: N/A</div>;


### PR DESCRIPTION
## Summary
- poll `/orientation` and `/vehicle` every 5 seconds when no prop is supplied
- display latest sensor data in the Orientation and VehicleInfo widgets

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'aiosqlite')*
- `npm test --silent` *(fails: TestingLibraryElementError in widgets.test.jsx)*

------
https://chatgpt.com/codex/tasks/task_e_685b5220a1c883338e1256a7dab4c1c4