### PR TITLE
Enhance dynamic GPS polling

### DIFF
--- a/docs/gps_polling.rst
+++ b/docs/gps_polling.rst
@@ -13,8 +13,8 @@ power at the cost of stale position data. The client connects to
 
 PiWardrive adapts its polling rate automatically. When movement is
 detected the map polls at ``map_poll_gps`` seconds. If the location
-remains nearly constant the interval is increased up to
-``map_poll_gps_max``. These values can be tweaked in
+remains nearly constant the interval doubles each time until it
+reaches ``map_poll_gps_max``. These values can be tweaked in
 ``config.json`` or via ``PW_MAP_POLL_GPS`` and
 ``PW_MAP_POLL_GPS_MAX`` environment variables.
 

--- a/src/piwardrive/screens/map_screen.py
+++ b/src/piwardrive/screens/map_screen.py
@@ -694,7 +694,12 @@ class MapScreen(Screen):  # pylint: disable=too-many-instance-attributes
         self._last_gps = (lat, lon)
         self._last_time = now
         threshold = getattr(app, "gps_movement_threshold", 1.0)
-        interval = app.map_poll_gps if speed > threshold else app.map_poll_gps_max
+        current = self._gps_interval or app.map_poll_gps
+        if speed > threshold:
+            interval = app.map_poll_gps
+        else:
+            interval = min(app.map_poll_gps_max, max(app.map_poll_gps, current * 2))
+
         if interval != self._gps_interval:
             self._gps_interval = interval
             Clock.schedule_once(

--- a/tests/test_dynamic_polling.py
+++ b/tests/test_dynamic_polling.py
@@ -93,7 +93,7 @@ class DummyApp:
 @pytest.mark.parametrize(
     "moves,expected",
     [
-        ([(0.0, 0.0), (0.0, 0.00005), (0.001, 0.00005)], [20, 20, 5]),
+        ([(0.0, 0.0), (0.0, 0.00005), (0.001, 0.00005)], [10, 20, 5]),
     ],
 )
 def test_dynamic_polling(monkeypatch, moves, expected):


### PR DESCRIPTION
## Summary
- implement progressive adjustment of GPS polling interval
- document polling behaviour in gps_polling docs
- update dynamic polling tests for the new ramping logic

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'aiosqlite')*

------
https://chatgpt.com/codex/tasks/task_e_685b525f2b6483339cf22a0dd9820eba