### PR TITLE
Enable route tile prefetch in web UI

### DIFF
--- a/docs/tile_cache.rst
+++ b/docs/tile_cache.rst
@@ -63,6 +63,9 @@ from the two most recent points and extrapolates future positions using
 great‑circle math. ``route_prefetch_lookahead`` controls how far ahead of the
 current location tiles are fetched.
 
+The browser-based dashboard honors these options and prefetches route tiles
+with the same logic when installed as a progressive web app.
+
 
 Paths
 -----

--- a/docs/web_ui.rst
+++ b/docs/web_ui.rst
@@ -53,6 +53,10 @@ a service worker that caches the compiled assets and ``index.html`` for offline
 use. After visiting the site once, the UI will continue to load even without
 network connectivity. New versions are picked up automatically on reload.
 
+When GPS data is available the web interface predicts future positions using the
+two most recent fixes. It then downloads tiles along the anticipated path based
+on the ``route_prefetch_interval`` and ``route_prefetch_lookahead`` settings.
+
 Authentication
 --------------
 

--- a/webui/src/components/MapScreen.jsx
+++ b/webui/src/components/MapScreen.jsx
@@ -21,6 +21,15 @@ export default function MapScreen() {
   const [filter, setFilter] = useState({ ssid: '', encryption: '' });
   const [showHeatmap, setShowHeatmap] = useState(false);
   const track = useRef([]);
+  const [config, setConfig] = useState(null);
+
+  // load configuration
+  useEffect(() => {
+    fetch('/config')
+      .then(r => r.json())
+      .then(setConfig)
+      .catch(e => console.error('config fetch failed', e));
+  }, []);
 
   // fetch GPS periodically
   useEffect(() => {
@@ -117,13 +126,16 @@ export default function MapScreen() {
     return () => clearInterval(id);
   }, []);
 
-  // route prefetch hourly
+  // route prefetch on interval from config
   useEffect(() => {
+    if (!config) return;
+    const intervalMs = (config.route_prefetch_interval || 3600) * 1000;
+    const lookahead = config.route_prefetch_lookahead || 5;
     const id = setInterval(() => {
-      routePrefetch(track.current, 5, 0.01, zoom);
-    }, 3600000);
+      routePrefetch(track.current, lookahead, 0.01, zoom);
+    }, intervalMs);
     return () => clearInterval(id);
-  }, [zoom]);
+  }, [zoom, config]);
 
   const filtered = aps.filter(ap => {
     if (filter.ssid && !(ap.ssid || '').includes(filter.ssid)) return false;

--- a/webui/src/components/SettingsForm.jsx
+++ b/webui/src/components/SettingsForm.jsx
@@ -41,6 +41,7 @@ export default function SettingsForm() {
     ['map_use_offline', 'Use Offline Tiles', 'checkbox'],
     ['map_auto_prefetch', 'Auto Prefetch Tiles', 'checkbox'],
     ['route_prefetch_interval', 'Route Prefetch Interval', 'number'],
+    ['route_prefetch_lookahead', 'Route Prefetch Lookahead', 'number'],
     ['map_show_gps', 'Show GPS', 'checkbox'],
     ['map_show_aps', 'Show APs', 'checkbox'],
     ['map_show_bt', 'Show Bluetooth', 'checkbox'],


### PR DESCRIPTION
## Summary
- allow the web interface to prefetch tiles on a schedule using config values
- expose `route_prefetch_lookahead` in the settings form
- document browser support for scheduled route prediction

## Testing
- `pytest -q` *(fails: FileNotFoundError during collection)*

------
https://chatgpt.com/codex/tasks/task_e_685b5263b490833389285c407c7b8cda