### PR TITLE
Add system stats polling for web UI

### DIFF
--- a/webui/src/App.jsx
+++ b/webui/src/App.jsx
@@ -6,6 +6,7 @@ import SignalStrength from './components/SignalStrength.jsx';
 import NetworkThroughput from './components/NetworkThroughput.jsx';
 import CPUTempGraph from './components/CPUTempGraph.jsx';
 import StatsDashboard from './components/StatsDashboard.jsx';
+import SystemStats from './components/SystemStats.jsx';
 import VehicleStats from './components/VehicleStats.jsx';
 import GeofenceEditor from './components/GeofenceEditor.jsx';
 import SettingsForm from './components/SettingsForm.jsx';
@@ -84,6 +85,7 @@ export default function App() {
     <div>
       <h2>Map</h2>
       <MapScreen />
+      <SystemStats />
       <h2>Status</h2>
       <pre>{JSON.stringify(status, null, 2)}</pre>
       <h2>Widget Metrics</h2>

--- a/webui/src/components/SystemStats.jsx
+++ b/webui/src/components/SystemStats.jsx
@@ -1,0 +1,35 @@
+import { useEffect, useState } from 'react';
+
+export default function SystemStats() {
+  const [stats, setStats] = useState({ temp: null, mem: null, disk: null });
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const [cpuRes, ramRes, diskRes] = await Promise.all([
+          fetch('/cpu').then(r => r.json()).catch(() => null),
+          fetch('/ram').then(r => r.json()).catch(() => null),
+          fetch('/storage').then(r => r.json()).catch(() => null)
+        ]);
+        setStats({
+          temp: cpuRes && cpuRes.temp != null ? cpuRes.temp : null,
+          mem: ramRes && ramRes.percent != null ? ramRes.percent : null,
+          disk: diskRes && diskRes.percent != null ? diskRes.percent : null
+        });
+      } catch (_) {}
+    };
+    load();
+    const id = setInterval(load, 2000);
+    return () => clearInterval(id);
+  }, []);
+
+  const cpu = stats.temp != null ? `${stats.temp.toFixed(1)}\u00B0C` : 'N/A';
+  const mem = stats.mem != null ? `${stats.mem.toFixed(0)}%` : 'N/A';
+  const disk = stats.disk != null ? `${stats.disk.toFixed(0)}%` : 'N/A';
+
+  return (
+    <div>
+      CPU: {cpu} | RAM: {mem} | Disk: {disk}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- display CPU, RAM and disk metrics in React UI
- fetch metrics every 2 seconds like the Kivy Stats screen

## Testing
- `pytest -q` *(fails: FileNotFoundError during collection)*
- `npx vitest run` *(fails: needs network to install vitest)*

------
https://chatgpt.com/codex/tasks/task_e_685b52874f60833381336e79cd09fe9d