### PR TITLE
Improve console log view

### DIFF
--- a/webui/tests/console.test.jsx
+++ b/webui/tests/console.test.jsx
@@ -1,0 +1,22 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, it, expect, vi } from 'vitest';
+import ConsoleView from '../src/components/ConsoleView.jsx';
+
+vi.stubGlobal('fetch', vi.fn());
+
+const cfgResp = { json: () => Promise.resolve({ log_paths: ['/a', '/b'] }) };
+const logResp = { json: () => Promise.resolve({ lines: ['hello'] }) };
+
+fetch.mockResolvedValueOnce(cfgResp).mockResolvedValueOnce(logResp);
+
+
+describe('console view', () => {
+  it('shows logs and path selector', async () => {
+    render(<ConsoleView />);
+    await waitFor(() => {
+      expect(screen.getByText('hello')).toBeInTheDocument();
+    });
+    expect(screen.getByRole('combobox')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- support selecting log paths in the web console view
- add tests for the ConsoleView component

## Testing
- `pre-commit run --files webui/src/components/ConsoleView.jsx webui/tests/console.test.jsx`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b52a5775483338b4a9cbf57105965