### PR TITLE
Fix dashboard widget loading

### DIFF
--- a/webui/src/App.jsx
+++ b/webui/src/App.jsx
@@ -1,27 +1,15 @@
 import { useEffect, useState } from 'react';
-import BatteryStatus from './components/BatteryStatus.jsx';
-import ServiceStatus from './components/ServiceStatus.jsx';
-import HandshakeCount from './components/HandshakeCount.jsx';
-import SignalStrength from './components/SignalStrength.jsx';
-import NetworkThroughput from './components/NetworkThroughput.jsx';
-import CPUTempGraph from './components/CPUTempGraph.jsx';
-import StatsDashboard from './components/StatsDashboard.jsx';
-import VehicleStats from './components/VehicleStats.jsx';
 import GeofenceEditor from './components/GeofenceEditor.jsx';
 import SettingsForm from './components/SettingsForm.jsx';
 import MapScreen from './components/MapScreen.jsx';
-import Orientation from './components/Orientation.jsx';
-import VehicleInfo from './components/VehicleInfo.jsx';
 import VectorTileCustomizer from './components/VectorTileCustomizer.jsx';
+import Dashboard from './components/Dashboard.jsx';
 
 export default function App() {
   const [status, setStatus] = useState([]);
   const [metrics, setMetrics] = useState(null);
   const [logs, setLogs] = useState('');
   const [plugins, setPlugins] = useState([]);
-  const [widgets, setWidgets] = useState([]);
-  const [orientationData, setOrientationData] = useState(null);
-  const [vehicleData, setVehicleData] = useState(null);
 
   useEffect(() => {
     const proto = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
@@ -95,16 +83,7 @@ export default function App() {
         ))}
       </ul>
       <h2>Dashboard</h2>
-      <BatteryStatus metrics={metrics} />
-      <ServiceStatus metrics={metrics} />
-      <HandshakeCount metrics={metrics} />
-      <SignalStrength metrics={metrics} />
-      <VehicleStats metrics={metrics} />
-      <Orientation data={orientationData} />
-      <VehicleInfo data={vehicleData} />
-      <NetworkThroughput metrics={metrics} />
-      <CPUTempGraph metrics={metrics} />
-      <StatsDashboard />
+      <Dashboard metrics={metrics} />
 
       <h2>Logs</h2>
       <pre>{logs}</pre>

--- a/webui/src/components/Dashboard.jsx
+++ b/webui/src/components/Dashboard.jsx
@@ -1,0 +1,57 @@
+import { useEffect, useState } from 'react';
+import BatteryStatus from './BatteryStatus.jsx';
+import ServiceStatus from './ServiceStatus.jsx';
+import HandshakeCount from './HandshakeCount.jsx';
+import SignalStrength from './SignalStrength.jsx';
+import NetworkThroughput from './NetworkThroughput.jsx';
+import CPUTempGraph from './CPUTempGraph.jsx';
+import StatsDashboard from './StatsDashboard.jsx';
+import VehicleStats from './VehicleStats.jsx';
+import Orientation from './Orientation.jsx';
+import VehicleInfo from './VehicleInfo.jsx';
+
+const COMPONENTS = {
+  BatteryStatusWidget: BatteryStatus,
+  ServiceStatusWidget: ServiceStatus,
+  HandshakeCounterWidget: HandshakeCount,
+  SignalStrengthWidget: SignalStrength,
+  NetworkThroughputWidget: NetworkThroughput,
+  CPUTempGraphWidget: CPUTempGraph,
+  OrientationWidget: Orientation,
+  VehicleSpeedWidget: VehicleStats,
+  VehicleInfoWidget: VehicleInfo,
+  StatsDashboard: StatsDashboard,
+};
+
+export default function Dashboard({ metrics }) {
+  const [names, setNames] = useState([]);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const resp = await fetch('/dashboard-settings');
+        const data = await resp.json();
+        if (data.widgets && data.widgets.length) {
+          setNames(data.widgets);
+          return;
+        }
+      } catch (_) {}
+      try {
+        const resp = await fetch('/api/widgets');
+        const data = await resp.json();
+        setNames(data.widgets || []);
+      } catch (_) {}
+    }
+    load();
+  }, []);
+
+  return (
+    <div>
+      {names.map((name) => {
+        const Comp = COMPONENTS[name];
+        if (Comp) return <Comp key={name} metrics={metrics} />;
+        return <div key={name}>Unknown widget: {name}</div>;
+      })}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- load dashboard widgets dynamically from the widgets package
- register widgets loaded from saved layouts and defaults

## Testing
- `pytest tests/test_dashboard_persistence.py::test_save_and_load_layout -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_685b52c9e7bc83338fd06f0f9cf399b4