### PR TITLE
Improve kiosk docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,11 @@ The command runs `piwardrive-webui` in the background and opens Chromium with
 environment. Ensure an X server is available and ``$DISPLAY`` is set.
 Headless setups can use ``Xvfb``.
 
+Combine the web UI service with the example ``kiosk.service`` unit to
+launch the browser automatically on boot. This setup fully replaces the
+on-device Kivy GUI so the Pi's touch screen displays the React dashboard
+in full‑screen mode.
+
 ### Optional C Extensions
 
 Two small C modules, `ckml` and `cgeom`, speed up geometry and KML parsing. They
@@ -375,21 +380,10 @@ WantedBy=multi-user.target
    exec sh /home/pi/kiosk.sh
    ```
 
-4. **Define `kiosk.service`**
-   ```ini
-   [Unit]
-   Description=Chromium Kiosk
-   After=graphical.target
-
-   [Service]
-   Type=simple
-   User=pi
-   Environment=DISPLAY=:0
-   ExecStart=/usr/bin/startx
-
-   [Install]
-   WantedBy=multi-user.target
-   ```
+4. **Install `kiosk.service`**
+   Copy `examples/kiosk.service` into `/etc/systemd/system/` and adjust the
+   paths if PiWardrive lives elsewhere. The unit starts `startx` which runs
+   `~/.xsession` and in turn launches Chromium in kiosk mode.
 
 5. **(Optional) `piwardrive.service`**
    ```ini

--- a/docs/web_ui.rst
+++ b/docs/web_ui.rst
@@ -84,4 +84,7 @@ kiosk mode with ``piwardrive-kiosk``::
 The command launches ``piwardrive-webui`` in the background and then executes
 ``chromium-browser --kiosk http://localhost:8000`` (falling back to
 ``chromium`` when ``chromium-browser`` is unavailable).
+Copy ``examples/kiosk.service`` alongside ``piwardrive-webui.service`` to start
+Chromium automatically on boot, replacing the on-device Kivy interface with the
+browser dashboard.
 An active X server is required; headless systems may use ``Xvfb``.

--- a/examples/kiosk.service
+++ b/examples/kiosk.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Chromium Kiosk
+After=graphical.target
+
+[Service]
+Type=simple
+User=pi
+Environment=DISPLAY=:0
+ExecStart=/usr/bin/startx
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- explain how to launch the browser on boot
- mention kiosk.service as the replacement for the Kivy GUI
- add example systemd unit file

## Testing
- `pre-commit run --files README.md docs/web_ui.rst examples/kiosk.service` *(fails: InvalidManifestError)*
- `flake8` *(fails: various F401/F403 errors)*


------
https://chatgpt.com/codex/tasks/task_e_685c7056d378833389fc54d256914e66