### PR TITLE
Port widgets to React

### DIFF
--- a/webui/src/components/DBStats.jsx
+++ b/webui/src/components/DBStats.jsx
@@ -1,0 +1,24 @@
+import { useEffect, useState } from 'react';
+
+export default function DBStats() {
+  const [info, setInfo] = useState(null);
+
+  useEffect(() => {
+    const load = () => {
+      fetch('/db-stats')
+        .then(r => r.json())
+        .then(setInfo)
+        .catch(() => setInfo(null));
+    };
+    load();
+    const id = setInterval(load, 10000);
+    return () => clearInterval(id);
+  }, []);
+
+  if (!info) return <div>DB: N/A</div>;
+  const parts = Object.entries(info.tables || {})
+    .map(([n, c]) => `${n}:${c}`)
+    .join(' ');
+  const size = info.size_kb != null ? info.size_kb.toFixed(1) + 'KB' : 'N/A';
+  return <div>DB: {size} {parts}</div>;
+}

--- a/webui/src/components/DashboardLayout.jsx
+++ b/webui/src/components/DashboardLayout.jsx
@@ -5,6 +5,15 @@ import HandshakeCount from './HandshakeCount.jsx';
 import SignalStrength from './SignalStrength.jsx';
 import NetworkThroughput from './NetworkThroughput.jsx';
 import CPUTempGraph from './CPUTempGraph.jsx';
+import GPSStatus from './GPSStatus.jsx';
+import StorageUsage from './StorageUsage.jsx';
+import DiskUsageTrend from './DiskUsageTrend.jsx';
+import VehicleSpeed from './VehicleSpeed.jsx';
+import DBStats from './DBStats.jsx';
+import HealthStatus from './HealthStatus.jsx';
+import HealthAnalysis from './HealthAnalysis.jsx';
+import LoRaScan from './LoRaScan.jsx';
+import LogViewer from './LogViewer.jsx';
 
 const COMPONENTS = {
   BatteryStatusWidget: BatteryStatus,
@@ -13,6 +22,15 @@ const COMPONENTS = {
   SignalStrengthWidget: SignalStrength,
   NetworkThroughputWidget: NetworkThroughput,
   CPUTempGraphWidget: CPUTempGraph,
+  GPSStatusWidget: GPSStatus,
+  StorageUsageWidget: StorageUsage,
+  DiskUsageTrendWidget: DiskUsageTrend,
+  VehicleSpeedWidget: VehicleSpeed,
+  DBStatsWidget: DBStats,
+  HealthStatusWidget: HealthStatus,
+  HealthAnalysisWidget: HealthAnalysis,
+  LoRaScanWidget: LoRaScan,
+  LogViewer: LogViewer,
 };
 
 export default function DashboardLayout({ metrics }) {

--- a/webui/src/components/DiskUsageTrend.jsx
+++ b/webui/src/components/DiskUsageTrend.jsx
@@ -1,0 +1,33 @@
+import { Line } from 'react-chartjs-2';
+import { Chart as ChartJS, CategoryScale, LinearScale, PointElement, LineElement } from 'chart.js';
+import { useEffect, useState } from 'react';
+
+ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement);
+
+export default function DiskUsageTrend() {
+  const [data, setData] = useState([]);
+
+  useEffect(() => {
+    const load = () => {
+      fetch('/storage')
+        .then(r => r.json())
+        .then(d => {
+          if (d.percent != null) {
+            setData(prev => [...prev.slice(-59), d.percent]);
+          }
+        })
+        .catch(() => {});
+    };
+    load();
+    const id = setInterval(load, 5000);
+    return () => clearInterval(id);
+  }, []);
+
+  const labels = data.map((_, i) => i + 1);
+  const dataset = {
+    labels,
+    datasets: [{ label: 'Disk %', data, borderColor: 'green', tension: 0.2 }],
+  };
+  const options = { animation: false, scales: { y: { beginAtZero: true, max: 100 } } };
+  return <Line data={dataset} options={options} />;
+}

--- a/webui/src/components/GPSStatus.jsx
+++ b/webui/src/components/GPSStatus.jsx
@@ -1,0 +1,23 @@
+import { useEffect, useState } from 'react';
+
+export default function GPSStatus({ metrics }) {
+  const [fix, setFix] = useState(metrics?.gps_fix ?? null);
+
+  useEffect(() => {
+    if (metrics && metrics.gps_fix != null) {
+      setFix(metrics.gps_fix);
+      return;
+    }
+    const load = () => {
+      fetch('/gps')
+        .then(r => r.json())
+        .then(d => setFix(d.fix))
+        .catch(() => setFix(null));
+    };
+    load();
+    const id = setInterval(load, 5000);
+    return () => clearInterval(id);
+  }, [metrics]);
+
+  return <div>GPS: {fix ?? 'N/A'}</div>;
+}

--- a/webui/src/components/HealthAnalysis.jsx
+++ b/webui/src/components/HealthAnalysis.jsx
@@ -1,0 +1,40 @@
+import { useEffect, useState } from 'react';
+import { Line } from 'react-chartjs-2';
+import { Chart as ChartJS, CategoryScale, LinearScale, PointElement, LineElement } from 'chart.js';
+
+ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement);
+
+export default function HealthAnalysis() {
+  const [stats, setStats] = useState(null);
+
+  useEffect(() => {
+    const load = () => {
+      fetch('/status?limit=50')
+        .then(r => r.json())
+        .then(recs => {
+          if (!recs.length) { setStats(null); return; }
+          const temps = recs.map(r => r.system.cpu_temp).filter(x => x != null);
+          const avgTemp = temps.reduce((a, b) => a + b, 0) / temps.length;
+          const mem = recs.map(r => r.system.mem_percent).filter(x => x != null);
+          const avgMem = mem.reduce((a, b) => a + b, 0) / mem.length;
+          const disk = recs.map(r => r.system.disk_percent).filter(x => x != null);
+          const avgDisk = disk.reduce((a, b) => a + b, 0) / disk.length;
+          setStats({ temps, avgTemp, avgMem, avgDisk });
+        })
+        .catch(() => setStats(null));
+    };
+    load();
+    const id = setInterval(load, 30000);
+    return () => clearInterval(id);
+  }, []);
+
+  if (!stats) return <div>Health Analysis: N/A</div>;
+  const labels = stats.temps.map((_, i) => i + 1);
+  const options = { animation: false, scales: { y: { beginAtZero: true } } };
+  return (
+    <div>
+      <div>Temp:{stats.avgTemp.toFixed(1)}°C Mem:{stats.avgMem.toFixed(0)}% Disk:{stats.avgDisk.toFixed(0)}%</div>
+      <Line data={{ labels, datasets: [{ label: 'CPU °C', data: stats.temps, borderColor: 'red', tension: 0.2 }] }} options={options} />
+    </div>
+  );
+}

--- a/webui/src/components/HealthStatus.jsx
+++ b/webui/src/components/HealthStatus.jsx
@@ -1,0 +1,27 @@
+import { useEffect, useState } from 'react';
+
+export default function HealthStatus() {
+  const [info, setInfo] = useState(null);
+
+  useEffect(() => {
+    const load = () => {
+      fetch('/status?limit=1')
+        .then(r => r.json())
+        .then(d => setInfo(d[0] || null))
+        .catch(() => setInfo(null));
+    };
+    load();
+    const id = setInterval(load, 10000);
+    return () => clearInterval(id);
+  }, []);
+
+  if (!info) return <div>Health: N/A</div>;
+  const sys = info.system || {};
+  const disk = sys.disk_percent != null ? sys.disk_percent.toFixed(0) + '%' : 'N/A';
+  const net = info.network_ok ? 'ok' : 'down';
+  const services = info.services || {};
+  const svcStr = Object.entries(services)
+    .map(([n, ok]) => `${n}:${ok ? 'ok' : 'down'}`)
+    .join(' ');
+  return <div>Net:{net} SSD:{disk} {svcStr}</div>;
+}

--- a/webui/src/components/LoRaScan.jsx
+++ b/webui/src/components/LoRaScan.jsx
@@ -1,0 +1,27 @@
+import { useEffect, useState } from 'react';
+
+export default function LoRaScan() {
+  const [count, setCount] = useState(null);
+
+  useEffect(() => {
+    const load = () => {
+      fetch('/command', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ cmd: 'lora-scan --iface lora0' }),
+      })
+        .then(r => r.json())
+        .then(d => {
+          const lines = d.output ? d.output.trim().split('\n') : [];
+          setCount(lines.length);
+        })
+        .catch(() => setCount(null));
+    };
+    load();
+    const id = setInterval(load, 30000);
+    return () => clearInterval(id);
+  }, []);
+
+  const val = count != null ? count : 'N/A';
+  return <div>LoRa Devices: {val}</div>;
+}

--- a/webui/src/components/LogViewer.jsx
+++ b/webui/src/components/LogViewer.jsx
@@ -1,0 +1,20 @@
+import { useEffect, useState } from 'react';
+
+export default function LogViewer({ path = '/var/log/syslog', lines = 200 }) {
+  const [text, setText] = useState('');
+
+  useEffect(() => {
+    const load = () => {
+      const params = new URLSearchParams({ path, lines });
+      fetch(`/logs?${params}`)
+        .then(r => r.json())
+        .then(d => setText(d.lines.join('\n')))
+        .catch(() => setText(''));
+    };
+    load();
+    const id = setInterval(load, 1000);
+    return () => clearInterval(id);
+  }, [path, lines]);
+
+  return <pre style={{ maxHeight: '200px', overflowY: 'scroll' }}>{text}</pre>;
+}

--- a/webui/src/components/StorageUsage.jsx
+++ b/webui/src/components/StorageUsage.jsx
@@ -1,0 +1,20 @@
+import { useEffect, useState } from 'react';
+
+export default function StorageUsage() {
+  const [pct, setPct] = useState(null);
+
+  useEffect(() => {
+    const load = () => {
+      fetch('/storage')
+        .then(r => r.json())
+        .then(d => setPct(d.percent))
+        .catch(() => setPct(null));
+    };
+    load();
+    const id = setInterval(load, 5000);
+    return () => clearInterval(id);
+  }, []);
+
+  const val = pct != null ? pct.toFixed(0) + '%' : 'N/A';
+  return <div>SSD: {val}</div>;
+}

--- a/webui/src/components/VehicleSpeed.jsx
+++ b/webui/src/components/VehicleSpeed.jsx
@@ -1,0 +1,5 @@
+export default function VehicleSpeed({ metrics }) {
+  const speed = metrics?.vehicle_speed;
+  const val = speed != null ? speed.toFixed(1) + ' km/h' : 'N/A';
+  return <div>Vehicle Speed: {val}</div>;
+}


### PR DESCRIPTION
## Summary
- add React widget components for DB stats, GPS status, storage usage, disk usage trend, health status, health analysis, LoRa scan, log viewer and vehicle speed
- wire new widgets into DashboardLayout so they can be used

## Testing
- `npm test`
- `pytest -q` *(fails: fastapi and other dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_685c703e33088333aca66df40aae25fe