### PR TITLE
docs: set React dashboard as default UI

### DIFF
--- a/In development/README.md
+++ b/In development/README.md
@@ -1,6 +1,6 @@
 # Browser-based Setup (Experimental)
 
-This directory contains prototypes for running PiWardrive in a self-hosted browser environment in place of the Kivy GUI.
+PiWardrive's default interface is a React dashboard served by ``piwardrive.webui_server``. This directory holds early prototypes for running PiWardrive in a self-hosted browser environment that replaced the original Kivy GUI.
 
 Two approaches are provided:
 
@@ -35,7 +35,7 @@ This uses a small React application built with Vite.
 
 ## MapLibre Prototype
 
-This lightweight framework mirrors the Kivy dashboard using plain HTML, Tailwind and MapLibre. Static files live in `web_gui/` and the FastAPI backend is defined in `web_api.py`.
+This lightweight framework mirrors the former Kivy dashboard using plain HTML, Tailwind and MapLibre. Static files live in `web_gui/` and the FastAPI backend is defined in `web_api.py`.
 
 Start it with:
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # PiWardrive
 
-PiWardrive is a headless mapping and diagnostic suite for Raspberry Pi 5. It merges war-driving tools such as Kismet and BetterCAP with a lightweight command line SIGINT suite for scanning. A browser-based dashboard provides an optional GUI when the React frontend is built.
+PiWardrive is a headless mapping and diagnostic suite for Raspberry Pi 5. It merges war-driving tools such as Kismet and BetterCAP with a lightweight command line SIGINT suite for scanning. The primary interface is a browser-based dashboard built with React. Launch it after building the frontend with:
+
+```bash
+python -m piwardrive.webui_server
+```
 
 For a full index of guides see [REFERENCE.md](REFERENCE.md) and the `docs/` directory.
 
@@ -327,7 +331,7 @@ docker run --device=/dev/ttyUSB0 --rm piwardrive
 * **Systemd Service Setup** – copy `examples/piwardrive.service` to `/etc/systemd/system/` and enable it with `sudo systemctl enable --now piwardrive.service` to launch the backend on boot.
 * **Running the Status API** – start the FastAPI service manually with `piwardrive-service` to expose remote metrics.
 * **Browser Kiosk Mode** – build the React frontend (see above) and launch it with `piwardrive-kiosk` to start the server and open Chromium automatically.
-* **Map Tile Prefetch** – use `piwardrive-prefetch` to download map tiles without the GUI.
+* **Map Tile Prefetch** – use `piwardrive-prefetch` to download map tiles without launching the dashboard.
 * **Syncing Data** – set `remote_sync_url` (and optionally `remote_sync_interval`)
   in `~/.config/piwardrive/config.json` and trigger uploads via `/sync` or call
   `remote_sync.sync_database_to_server` directly.

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -4,7 +4,7 @@ This document consolidates the key information from `README.md`, the `piwardrive
 
 ## Overview
 
-PiWardrive provides a headless mapping and diagnostic interface built with Kivy/KivyMD. It manages Wi‑Fi and Bluetooth scanning via Kismet and BetterCAP while polling GPS data and system metrics. Structured logs default to `~/.config/piwardrive/app.log` but `logconfig.setup_logging` can also output to `stdout` or additional handlers. A lightweight SIGINT suite for command-line scanning lives under `src/piwardrive/sigint_suite/`.
+PiWardrive provides a headless mapping and diagnostic interface delivered through a React dashboard. Kivy/KivyMD remains available for touchscreen deployments but the web UI is now the default. Start it with ``python -m piwardrive.webui_server`` after building the frontend. PiWardrive manages Wi‑Fi and Bluetooth scanning via Kismet and BetterCAP while polling GPS data and system metrics. Structured logs default to `~/.config/piwardrive/app.log` but `logconfig.setup_logging` can also output to `stdout` or additional handlers. A lightweight SIGINT suite for command-line scanning lives under `src/piwardrive/sigint_suite/`.
 
 ## Hardware and OS Requirements
 

--- a/docs/cli_tools.rst
+++ b/docs/cli_tools.rst
@@ -3,7 +3,7 @@ CLI Tools
 .. note::
    Please read the legal notice in the project `README.md` before using PiWardrive.
 
-Several helper scripts are installed alongside the GUI and web interface. They can be invoked directly from the command line after installing the project:
+Several helper scripts are installed alongside the React dashboard and optional touch interface. They can be invoked directly from the command line after installing the project:
 
 ``piwardrive-prefetch``
     Prefetch map tiles for an area without launching the interface::

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -33,8 +33,8 @@ See :mod:`config` for defaults and helpers.
 Environment variables are parsed on startup. Any option in ``Config`` can be
 specified as ``PW_<OPTION>``. Boolean variables accept ``1`` or ``0`` while
 strings and integers are used verbatim. Invalid values trigger an early
-``ValueError`` so configuration mistakes are detected before either the touch
-GUI or browser interface launches.
+``ValueError`` so configuration mistakes are detected before the React dashboard
+or optional touch interface launches.
 
 Configuration Profiles
 ----------------------

--- a/docs/diagnostics.rst
+++ b/docs/diagnostics.rst
@@ -29,8 +29,7 @@ environment variables ``PW_HEALTH_EXPORT_INTERVAL``, ``PW_HEALTH_EXPORT_DIR``,
 options.
 
 ``scripts/service_status.py`` provides a small command-line interface to
-``diagnostics.get_service_statuses`` for quick checks outside the GUI. The same
-information is exposed in the browser interface via the status service.
+``diagnostics.get_service_statuses`` for quick checks outside the React dashboard or touch interface. The same information is visible in the dashboard via the status service.
 
 Use :func:`utils.report_error` to surface exceptions consistently. It logs the
 message and displays a dialog via the running application if available.

--- a/docs/geofencing.rst
+++ b/docs/geofencing.rst
@@ -38,4 +38,4 @@ draw polygons and press "Finish" to save them. Existing geofences can be
 renamed or removed, entry/exit messages edited and the current status
 (inside/outside) is shown next to each polygon. All operations are performed
 through the ``/geofences`` REST API and saved to the same ``geofences.json``
-file used by the on-device editor.
+file used by the optional on-device editor.

--- a/docs/persistence.rst
+++ b/docs/persistence.rst
@@ -10,7 +10,7 @@ this location. Health monitor metrics are stored as
 :class:`HealthRecord` rows and can be queried with ``load_recent_health``.
 The same file stores ``AppState`` which remembers the last active screen and
 the start time of the previous session. When PiWardrive launches these values
-are restored so the GUI (or browser interface) picks up where it left off.
+are restored so the React dashboard (or optional Kivy interface) picks up where it left off.
 Database connections are
 cached so repeated calls do not reinitialise the schema, reducing disk I/O.
 The connection is placed into write-ahead logging mode using

--- a/docs/status_service.rst
+++ b/docs/status_service.rst
@@ -79,7 +79,7 @@ current orientation string, rotation angle and raw accelerometer/gyroscope data:
 This allows external dashboards to load widgets dynamically.
 
 ``/dashboard-settings`` loads and saves the drag-and-drop widget layout used by
-the on-device GUI and browser dashboard. The POST body accepts ``layout`` which
+the React dashboard and optional touch interface. The POST body accepts ``layout`` which
 is persisted to ``config.json``::
 
    curl http://localhost:8000/dashboard-settings

--- a/docs/tile_cache.rst
+++ b/docs/tile_cache.rst
@@ -21,7 +21,7 @@ current GPS location whenever it updates.
 Command Line
 ------------
 
-Tiles can also be prefetched without launching the on-device GUI using the
+Tiles can also be prefetched without launching the dashboard using the
 ``piwardrive-prefetch`` entry point::
 
    piwardrive-prefetch 37.7 -122.5 37.8 -122.4 --zoom 15


### PR DESCRIPTION
## Summary
- mention `piwardrive.webui_server` in README and docs
- update docs to reflect React dashboard as the primary interface
- note dashboard in developer prototype README

## Testing
- `pre-commit run --files README.md REFERENCE.md docs/configuration.rst docs/cli_tools.rst docs/tile_cache.rst docs/persistence.rst docs/diagnostics.rst docs/status_service.rst docs/geofencing.rst "In development/README.md"` *(fails: InvalidManifestError)*
- `pip install -r requirements.txt -r requirements-dev.txt` *(fails: error installing dbus-python)*
- `pytest -q` *(fails: 43 errors during collection due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685c705029f483339ac33805ddcbfd86