### PR TITLE
Add React test equivalents

### DIFF
--- a/webui/src/analysis.js
+++ b/webui/src/analysis.js
@@ -1,0 +1,14 @@
+export function computeHealthStats(records) {
+  if (!records || records.length === 0) return {};
+  const temps = records.map(r => r.cpu_temp).filter(x => x != null);
+  const cpu = records.map(r => r.cpu_percent);
+  const mem = records.map(r => r.memory_percent);
+  const disk = records.map(r => r.disk_percent);
+  const avg = arr => arr.reduce((a, b) => a + b, 0) / arr.length;
+  return {
+    temp_avg: temps.length ? avg(temps) : Number.NaN,
+    cpu_avg: avg(cpu),
+    mem_avg: avg(mem),
+    disk_avg: avg(disk),
+  };
+}

--- a/webui/src/bandScanner.js
+++ b/webui/src/bandScanner.js
@@ -1,0 +1,31 @@
+import { execFileSync, execFile } from 'child_process';
+
+export function parseBandOutput(output) {
+  const records = [];
+  output.split(/\n+/).forEach(line => {
+    const parts = line.split(',').map(p => p.trim());
+    if (parts.length >= 3) {
+      const [band, channel, rssi] = parts;
+      records.push({ band, channel, rssi });
+    }
+  });
+  return records;
+}
+
+export function scanBands(cmd = 'celltrack', timeout) {
+  try {
+    const out = execFileSync(cmd, { encoding: 'utf-8', timeout: timeout ? timeout * 1000 : undefined });
+    return parseBandOutput(out);
+  } catch (err) {
+    return [];
+  }
+}
+
+export function asyncScanBands(cmd = 'celltrack', timeout) {
+  return new Promise(resolve => {
+    execFile(cmd, { encoding: 'utf-8', timeout: timeout ? timeout * 1000 : undefined }, (err, stdout) => {
+      if (err) { resolve([]); return; }
+      resolve(parseBandOutput(stdout));
+    });
+  });
+}

--- a/webui/src/scheduler.js
+++ b/webui/src/scheduler.js
@@ -1,0 +1,102 @@
+export class PollScheduler {
+  constructor() {
+    this.intervals = new Map();
+    this.metrics = new Map();
+  }
+
+  schedule(name, cb, interval) {
+    this.cancel(name);
+    const run = () => {
+      const start = performance.now();
+      Promise.resolve(cb((Date.now() - (this.metrics.get(name)?.lastRun || Date.now())) / 1000))
+        .finally(() => {
+          const m = this.metrics.get(name);
+          if (m) {
+            m.lastDuration = (performance.now() - start) / 1000;
+            m.nextRun = Date.now() + interval * 1000;
+            m.lastRun = Date.now();
+          }
+        });
+    };
+    this.metrics.set(name, { nextRun: Date.now() + interval * 1000, lastDuration: NaN, lastRun: Date.now() });
+    this.intervals.set(name, setInterval(run, interval * 1000));
+  }
+
+  registerWidget(widget, name = null) {
+    const interval = widget.update_interval;
+    const cbName = name || widget.constructor.name;
+    this.schedule(cbName, dt => widget.update(dt), interval);
+  }
+
+  cancel(name) {
+    const id = this.intervals.get(name);
+    if (id) clearInterval(id);
+    this.intervals.delete(name);
+    this.metrics.delete(name);
+  }
+
+  cancelAll() {
+    Array.from(this.intervals.keys()).forEach(name => this.cancel(name));
+  }
+
+  getMetrics() {
+    const out = {};
+    for (const [k, v] of this.metrics.entries()) {
+      out[k] = { next_run: v.nextRun, last_duration: v.lastDuration };
+    }
+    return out;
+  }
+}
+
+export class AsyncScheduler {
+  constructor() {
+    this.timers = new Map();
+    this.metrics = new Map();
+  }
+
+  schedule(name, cb, interval) {
+    this.cancel(name);
+    const run = async () => {
+      const start = performance.now();
+      try {
+        await cb();
+      } finally {
+        const m = this.metrics.get(name);
+        if (m) {
+          m.lastDuration = (performance.now() - start) / 1000;
+          m.nextRun = Date.now() + interval * 1000;
+          this.timers.set(name, setTimeout(run, interval * 1000));
+        }
+      }
+    };
+    this.metrics.set(name, { nextRun: Date.now() + interval * 1000, lastDuration: NaN });
+    this.timers.set(name, setTimeout(run, interval * 1000));
+  }
+
+  registerWidget(widget, name = null) {
+    const interval = widget.update_interval;
+    const cbName = name || widget.constructor.name;
+    this.schedule(cbName, () => widget.update(), interval);
+  }
+
+  cancel(name) {
+    const id = this.timers.get(name);
+    if (id) clearTimeout(id);
+    this.timers.delete(name);
+    this.metrics.delete(name);
+  }
+
+  async cancelAll() {
+    for (const name of Array.from(this.timers.keys())) {
+      this.cancel(name);
+    }
+  }
+
+  getMetrics() {
+    const out = {};
+    for (const [k, v] of this.metrics.entries()) {
+      out[k] = { next_run: v.nextRun, last_duration: v.lastDuration };
+    }
+    return out;
+  }
+}

--- a/webui/tests/analysis.test.js
+++ b/webui/tests/analysis.test.js
@@ -1,0 +1,36 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { computeHealthStats } from '../src/analysis.js';
+import CPUTempGraph from '../src/components/CPUTempGraph.jsx';
+
+vi.mock('react-chartjs-2', () => ({
+  Line: vi.fn(() => <div>chart</div>)
+}));
+import { Line } from 'react-chartjs-2';
+
+describe('computeHealthStats', () => {
+  it('computes averages', () => {
+    const records = [
+      { cpu_temp: 40.0, cpu_percent: 10.0, memory_percent: 50.0, disk_percent: 20.0 },
+      { cpu_temp: 50.0, cpu_percent: 20.0, memory_percent: 40.0, disk_percent: 30.0 },
+    ];
+    const stats = computeHealthStats(records);
+    expect(stats.temp_avg).toBeCloseTo(45.0, 1);
+    expect(stats.cpu_avg).toBe(15.0);
+  });
+});
+
+describe('CPUTempGraph', () => {
+  it('renders chart data', () => {
+    const { rerender } = render(<CPUTempGraph metrics={{ cpu_temp: 40 }} />);
+    expect(Line).toHaveBeenCalled();
+    const firstCall = Line.mock.calls[0][0];
+    expect(firstCall.data.datasets[0].data).toEqual([40]);
+    Line.mockClear();
+    rerender(<CPUTempGraph metrics={{ cpu_temp: 50 }} />);
+    expect(Line).toHaveBeenCalled();
+    const secondCall = Line.mock.calls[0][0];
+    expect(secondCall.data.datasets[0].data).toEqual([40, 50]);
+  });
+});

--- a/webui/tests/asyncScheduler.test.js
+++ b/webui/tests/asyncScheduler.test.js
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { PollScheduler, AsyncScheduler } from '../src/scheduler.js';
+
+vi.useFakeTimers();
+
+describe('PollScheduler', () => {
+  afterEach(() => { vi.clearAllTimers(); });
+
+  it('accepts async widget', async () => {
+    const scheduler = new PollScheduler();
+    const widget = { update_interval: 1, update: vi.fn().mockResolvedValue() };
+    scheduler.registerWidget(widget, 'w');
+    await vi.runOnlyPendingTimersAsync();
+    expect(widget.update).toHaveBeenCalled();
+    scheduler.cancelAll();
+  });
+
+  it('handles async callback', async () => {
+    const scheduler = new PollScheduler();
+    const cb = vi.fn().mockResolvedValue();
+    scheduler.schedule('job', cb, 1);
+    await vi.runOnlyPendingTimersAsync();
+    expect(cb).toHaveBeenCalled();
+    scheduler.cancelAll();
+  });
+
+  it('metrics contain jobs', () => {
+    const scheduler = new PollScheduler();
+    const cb = () => {};
+    scheduler.schedule('job', cb, 1);
+    const metrics = scheduler.getMetrics();
+    expect(metrics.job).toBeDefined();
+    scheduler.cancelAll();
+  });
+});
+
+describe('AsyncScheduler', () => {
+  afterEach(() => { vi.clearAllTimers(); });
+
+  it('runs tasks', async () => {
+    const scheduler = new AsyncScheduler();
+    const cb = vi.fn().mockResolvedValue();
+    scheduler.schedule('job', cb, 1);
+    await vi.runOnlyPendingTimersAsync();
+    expect(cb).toHaveBeenCalled();
+    await scheduler.cancelAll();
+  });
+
+  it('cancelAll clears metrics', async () => {
+    const scheduler = new AsyncScheduler();
+    const done = vi.fn().mockResolvedValue();
+    scheduler.schedule('job', done, 1);
+    await vi.runOnlyPendingTimersAsync();
+    await scheduler.cancelAll();
+    expect(scheduler.getMetrics()).toEqual({});
+  });
+
+  it('metrics contain jobs', async () => {
+    const scheduler = new AsyncScheduler();
+    const cb = vi.fn().mockResolvedValue();
+    scheduler.schedule('job', cb, 1);
+    await vi.runOnlyPendingTimersAsync();
+    const metrics = scheduler.getMetrics();
+    expect(metrics.job).toBeDefined();
+    await scheduler.cancelAll();
+  });
+});

--- a/webui/tests/bandScanner.test.js
+++ b/webui/tests/bandScanner.test.js
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi } from 'vitest';
+import { parseBandOutput, scanBands, asyncScanBands } from '../src/bandScanner.js';
+import * as childProcess from 'child_process';
+
+vi.mock('child_process');
+
+describe('parseBandOutput', () => {
+  it('parses output', () => {
+    const output = 'LTE,100,-60\n5G,200,-70';
+    const records = parseBandOutput(output);
+    expect(records).toEqual([
+      { band: 'LTE', channel: '100', rssi: '-60' },
+      { band: '5G', channel: '200', rssi: '-70' }
+    ]);
+  });
+});
+
+describe('scanBands', () => {
+  it('passes timeout', () => {
+    const spy = vi.spyOn(childProcess, 'execFileSync').mockReturnValue('');
+    scanBands('dummy', 5);
+    expect(spy).toHaveBeenCalledWith('dummy', expect.objectContaining({ timeout: 5000, encoding: 'utf-8' }));
+    spy.mockRestore();
+  });
+});
+
+describe('asyncScanBands', () => {
+  it('parses records', async () => {
+    vi.spyOn(childProcess, 'execFile').mockImplementation((cmd, opts, cb) => {
+      cb(null, 'LTE,100,-60\n5G,200,-70');
+    });
+    const records = await asyncScanBands('dummy');
+    expect(records).toEqual([
+      { band: 'LTE', channel: '100', rssi: '-60' },
+      { band: '5G', channel: '200', rssi: '-70' }
+    ]);
+  });
+});

--- a/webui/tests/batteryWidget.test.jsx
+++ b/webui/tests/batteryWidget.test.jsx
@@ -1,0 +1,13 @@
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, it, expect } from 'vitest';
+import BatteryStatus from '../src/components/BatteryStatus.jsx';
+
+describe('BatteryStatus widget', () => {
+  it('updates when metrics change', () => {
+    const { rerender, getByText } = render(<BatteryStatus metrics={{ battery_percent: 50, battery_plugged: false }} />);
+    expect(getByText('Battery: 50% discharging')).toBeInTheDocument();
+    rerender(<BatteryStatus metrics={{ battery_percent: 75, battery_plugged: true }} />);
+    expect(getByText('Battery: 75% charging')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add computeHealthStats and scheduler utilities
- add band scanner parser in JS
- add React tests for analysis, scheduler, band scanner, and battery widget

## Testing
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ca4eee774833381d8b1a1b74176c0