### PR TITLE
Add React tests mirroring Python functionality

### DIFF
--- a/webui/src/components/LoRaScan.jsx
+++ b/webui/src/components/LoRaScan.jsx
@@ -1,7 +1,9 @@
-export default function LoRaScan({ metrics }) {
+import { useEffect, useState } from 'react';
+
+export function LoRaScanStatic({ metrics }) {
   const count = metrics?.lora_devices;
   return <div>LoRa: {count != null ? count : 'N/A'}</div>;
-import { useEffect, useState } from 'react';
+}
 
 export default function LoRaScan() {
   const [count, setCount] = useState(null);

--- a/webui/tests/exportLogs.test.jsx
+++ b/webui/tests/exportLogs.test.jsx
@@ -1,0 +1,24 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import LogViewer from '../src/components/LogViewer.jsx';
+
+describe('LogViewer', () => {
+  let origFetch;
+  beforeEach(() => {
+    origFetch = global.fetch;
+    global.fetch = vi.fn(() => Promise.resolve({
+      json: () => Promise.resolve({ lines: ['line1', 'line2'] })
+    }));
+  });
+  afterEach(() => {
+    global.fetch = origFetch;
+  });
+
+  it('loads logs for given path and lines', async () => {
+    render(<LogViewer path="/tmp/test.log" lines={10} />);
+    expect(global.fetch).toHaveBeenCalledWith('/logs?path=%2Ftmp%2Ftest.log&lines=10');
+    const pre = await screen.findByText((content, el) => el.tagName === 'PRE');
+    expect(pre.textContent).toBe('line1\nline2');
+  });
+});

--- a/webui/tests/extraWidgets.test.jsx
+++ b/webui/tests/extraWidgets.test.jsx
@@ -1,0 +1,33 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import Orientation from '../src/components/Orientation.jsx';
+import VehicleSpeed from '../src/components/VehicleSpeed.jsx';
+import LoRaScan, { LoRaScanStatic } from '../src/components/LoRaScan.jsx';
+
+describe('extra widgets', () => {
+  it('shows orientation text', () => {
+    render(<Orientation data={{ orientation: 'right-up', angle: 90 }} />);
+    expect(screen.getByText('Orientation: right-up (90\u00B0)')).toBeInTheDocument();
+  });
+
+  it('shows vehicle speed', () => {
+    render(<VehicleSpeed metrics={{ vehicle_speed: 42.5 }} />);
+    expect(screen.getByText('Vehicle Speed: 42.5 km/h')).toBeInTheDocument();
+  });
+
+  it('renders LoRa count from metrics', () => {
+    render(<LoRaScanStatic metrics={{ lora_devices: 3 }} />);
+    expect(screen.getByText('LoRa: 3')).toBeInTheDocument();
+  });
+
+  it('fetches LoRa scan results', async () => {
+    let origFetch = global.fetch;
+    global.fetch = vi.fn(() => Promise.resolve({
+      json: () => Promise.resolve({ output: 'a\nb\nc' })
+    }));
+    render(<LoRaScan />);
+    expect(await screen.findByText('LoRa Devices: 3')).toBeInTheDocument();
+    global.fetch = origFetch;
+  });
+});

--- a/webui/tests/gpsClient.test.jsx
+++ b/webui/tests/gpsClient.test.jsx
@@ -1,0 +1,29 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import GPSStatus from '../src/components/GPSStatus.jsx';
+
+describe('GPSStatus', () => {
+  it('uses metrics when provided', () => {
+    render(<GPSStatus metrics={{ gps_fix: '3D' }} />);
+    expect(screen.getByText('GPS: 3D')).toBeInTheDocument();
+  });
+
+  it('fetches fix quality', async () => {
+    let origFetch = global.fetch;
+    global.fetch = vi.fn(() => Promise.resolve({
+      json: () => Promise.resolve({ fix: '2D' })
+    }));
+    render(<GPSStatus />);
+    expect(await screen.findByText('GPS: 2D')).toBeInTheDocument();
+    global.fetch = origFetch;
+  });
+
+  it('handles fetch failure', async () => {
+    let origFetch = global.fetch;
+    global.fetch = vi.fn(() => Promise.reject('fail'));
+    render(<GPSStatus />);
+    expect(await screen.findByText('GPS: N/A')).toBeInTheDocument();
+    global.fetch = origFetch;
+  });
+});

--- a/webui/tests/gpsClientAsync.test.jsx
+++ b/webui/tests/gpsClientAsync.test.jsx
@@ -1,0 +1,14 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, it, expect, vi } from 'vitest';
+import GPSStatus from '../src/components/GPSStatus.jsx';
+
+describe('GPSStatus async failure', () => {
+  it('shows Unknown/N/A when fetch fails', async () => {
+    let origFetch = global.fetch;
+    global.fetch = vi.fn(() => Promise.reject('fail'));
+    render(<GPSStatus />);
+    expect(await screen.findByText('GPS: N/A')).toBeInTheDocument();
+    global.fetch = origFetch;
+  });
+});

--- a/webui/tests/healthExport.test.jsx
+++ b/webui/tests/healthExport.test.jsx
@@ -1,0 +1,26 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import HealthAnalysis from '../src/components/HealthAnalysis.jsx';
+vi.mock('react-chartjs-2', () => ({ Line: () => <canvas></canvas> }));
+
+describe('HealthAnalysis', () => {
+  let origFetch;
+  beforeEach(() => {
+    origFetch = global.fetch;
+    global.fetch = vi.fn(() => Promise.resolve({
+      json: () => Promise.resolve([
+        { system: { cpu_temp: 40, mem_percent: 20, disk_percent: 10 } },
+        { system: { cpu_temp: 60, mem_percent: 40, disk_percent: 20 } }
+      ])
+    }));
+  });
+  afterEach(() => {
+    global.fetch = origFetch;
+  });
+
+  it('shows averaged health stats', async () => {
+    render(<HealthAnalysis />);
+    expect(await screen.findByText('Temp:50.0°C Mem:30% Disk:15%')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- fix LoRaScan component syntax
- add vitest tests mirroring export log, widget, GPS and health script tests

## Testing
- `npm --prefix webui test`
- `pre-commit run --files webui/src/components/LoRaScan.jsx webui/tests/exportLogs.test.jsx webui/tests/extraWidgets.test.jsx webui/tests/gpsClient.test.jsx webui/tests/gpsClientAsync.test.jsx webui/tests/healthExport.test.jsx` *(fails: InvalidManifestError)*

------
https://chatgpt.com/codex/tasks/task_e_685ca5257e1c8333a7eb19478a4291c0