### PR TITLE
Add frontend utilities and service control fixes

### DIFF
--- a/webui/src/components/DBStats.jsx
+++ b/webui/src/components/DBStats.jsx
@@ -1,6 +1,3 @@
-export default function DBStats({ metrics }) {
-  const text = metrics?.db_stats || 'N/A';
-  return <div>DB: {text}</div>;
 import { useEffect, useState } from 'react';
 
 export default function DBStats() {

--- a/webui/src/components/ServiceStatus.jsx
+++ b/webui/src/components/ServiceStatus.jsx
@@ -1,22 +1,24 @@
+import { controlService } from '../serviceControl.js';
+
 export default function ServiceStatus({ metrics }) {
   if (!metrics) return <div>Services: N/A</div>;
   const { kismet_running, bettercap_running } = metrics;
 
-  const control = (svc, action) => {
-    fetch(`/service/${svc}/${action}`, { method: 'POST' }).catch(() => {});
+  const control = (svc, running) => {
+    controlService(svc, running ? 'stop' : 'start');
   };
 
   return (
     <div>
       <div>
         Kismet: {kismet_running ? 'ok' : 'down'}{' '}
-        <button onClick={() => control('kismet', kismet_running ? 'stop' : 'start')}>
+        <button onClick={() => control('kismet', kismet_running)}>
           {kismet_running ? 'Stop' : 'Start'}
         </button>
       </div>
       <div>
         BetterCAP: {bettercap_running ? 'ok' : 'down'}{' '}
-        <button onClick={() => control('bettercap', bettercap_running ? 'stop' : 'start')}>
+        <button onClick={() => control('bettercap', bettercap_running)}>
           {bettercap_running ? 'Stop' : 'Start'}
         </button>
       </div>

--- a/webui/src/configWatcher.js
+++ b/webui/src/configWatcher.js
@@ -1,0 +1,20 @@
+export function watchConfig(url = '/config', onChange, interval = 2000) {
+  let last = null;
+  const load = async () => {
+    try {
+      const resp = await fetch(url);
+      if (!resp.ok) return;
+      const cfg = await resp.json();
+      const j = JSON.stringify(cfg);
+      if (j !== last) {
+        last = j;
+        onChange(cfg);
+      }
+    } catch (_) {
+      /* ignore */
+    }
+  };
+  load();
+  const id = setInterval(load, interval);
+  return () => clearInterval(id);
+}

--- a/webui/src/continuousScan.js
+++ b/webui/src/continuousScan.js
@@ -1,0 +1,25 @@
+export async function scanOnce() {
+  const [wifi, bluetooth] = await Promise.all([
+    fetch('/scan/wifi').then(r => r.json()).catch(() => []),
+    fetch('/scan/bluetooth').then(r => r.json()).catch(() => []),
+  ]);
+  return { wifi, bluetooth };
+}
+
+export function runContinuousScan({ interval = 60, iterations = 0, onResult } = {}) {
+  let count = 0;
+  let active = true;
+
+  const run = async () => {
+    if (!active) return;
+    const result = await scanOnce();
+    if (onResult) onResult(result);
+    count += 1;
+    if (!active) return;
+    if (iterations && count >= iterations) return;
+    setTimeout(run, interval * 1000);
+  };
+
+  run();
+  return () => { active = false; };
+}

--- a/webui/src/di.js
+++ b/webui/src/di.js
@@ -1,0 +1,30 @@
+export class Container {
+  constructor() {
+    this.instances = new Map();
+    this.factories = new Map();
+  }
+
+  registerInstance(key, instance) {
+    this.instances.set(key, instance);
+  }
+
+  registerFactory(key, factory) {
+    this.factories.set(key, factory);
+  }
+
+  has(key) {
+    return this.instances.has(key) || this.factories.has(key);
+  }
+
+  resolve(key) {
+    if (this.instances.has(key)) {
+      return this.instances.get(key);
+    }
+    if (this.factories.has(key)) {
+      const inst = this.factories.get(key)();
+      this.instances.set(key, inst);
+      return inst;
+    }
+    throw new Error(`No provider for ${key}`);
+  }
+}

--- a/webui/src/serviceControl.js
+++ b/webui/src/serviceControl.js
@@ -1,0 +1,24 @@
+export async function controlService(service, action) {
+  let password = sessionStorage.getItem('adminPassword') || null;
+  const headers = {};
+  if (password) headers['X-Admin-Password'] = password;
+
+  let resp;
+  try {
+    resp = await fetch(`/service/${service}/${action}`, { method: 'POST', headers });
+  } catch (e) {
+    alert(`Failed to ${action} ${service}`);
+    return false;
+  }
+  if (resp.status === 401) {
+    password = window.prompt('Admin password');
+    if (!password) return false;
+    sessionStorage.setItem('adminPassword', password);
+    resp = await fetch(`/service/${service}/${action}`, { method: 'POST', headers: { 'X-Admin-Password': password } });
+  }
+  if (!resp.ok) {
+    alert(`Failed to ${action} ${service}`);
+    return false;
+  }
+  return true;
+}


### PR DESCRIPTION
## Summary
- add `watchConfig` helper for polling configuration changes
- add continuous scanning helpers
- implement a small DI container for React usage
- add service control helper and use it in `ServiceStatus`
- clean up `DBStats` component

## Testing
- `npm test` *(fails: Failed to parse test files; other unit tests failing)*

------
https://chatgpt.com/codex/tasks/task_e_685ca509485883339713d08ede76dee4