### PR TITLE
Add React equivalents for Python tests

### DIFF
--- a/webui/src/imsiScanner.js
+++ b/webui/src/imsiScanner.js
@@ -1,0 +1,34 @@
+export const _postProcessors = {};
+
+export function registerPostProcessor(type, fn) {
+  if (!_postProcessors[type]) _postProcessors[type] = [];
+  _postProcessors[type].push(fn);
+}
+
+export function clearPostProcessors(type) {
+  _postProcessors[type] = [];
+}
+
+function applyPostProcessors(type, records) {
+  const procs = _postProcessors[type] || [];
+  return procs.reduce((recs, fn) => fn(recs), records);
+}
+
+import { execSync as _execSync } from 'child_process';
+
+export function scanImsis(cmd, { execSync = _execSync, getPosition = () => null } = {}) {
+  const output = execSync(cmd, { encoding: 'utf8' });
+  const records = output.trim().split('\n').filter(Boolean).map(line => {
+    const [imsi='', mcc='', mnc='', rssi=''] = line.split(',').map(p => p.trim());
+    return { imsi, mcc, mnc, rssi };
+  });
+  const pos = getPosition();
+  if (pos) {
+    const [lat, lon] = pos;
+    records.forEach(r => {
+      r.lat = lat;
+      r.lon = lon;
+    });
+  }
+  return applyPostProcessors('imsi', records);
+}

--- a/webui/src/kalman.js
+++ b/webui/src/kalman.js
@@ -1,0 +1,11 @@
+export function kalman1d(series, q, r) {
+  const arr = series.map(Number);
+  if (arr.length === 0) return [];
+  const P = (-q + Math.sqrt(q * q + 4 * q * r)) / 2;
+  const K = (P + q) / (P + q + r);
+  const res = [arr[0]];
+  for (let i = 1; i < arr.length; i++) {
+    res[i] = res[i - 1] * (1 - K) + K * arr[i];
+  }
+  return res;
+}

--- a/webui/src/kiosk.js
+++ b/webui/src/kiosk.js
@@ -1,0 +1,27 @@
+import { spawn as _spawn } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+
+function which(cmd) {
+  const dirs = process.env.PATH.split(path.delimiter);
+  for (const d of dirs) {
+    const p = path.join(d, cmd);
+    try {
+      fs.accessSync(p, fs.constants.X_OK);
+      return p;
+    } catch (e) {}
+  }
+  return null;
+}
+
+export async function runKiosk({ url = 'http://localhost:8000', delay = 2000, spawnFn = _spawn, whichFn = which } = {}) {
+  const server = spawnFn('piwardrive-webui', []);
+  try {
+    await new Promise(r => setTimeout(r, delay));
+    const browser = whichFn('chromium-browser') || whichFn('chromium');
+    if (!browser) throw new Error('Chromium browser not found');
+    spawnFn(browser, ['--kiosk', url]);
+  } finally {
+    if (server && server.kill) server.kill();
+  }
+}

--- a/webui/src/logconfig.js
+++ b/webui/src/logconfig.js
@@ -1,0 +1,32 @@
+import fs from 'fs';
+
+const LEVELS = { DEBUG: 10, INFO: 20, WARNING: 30, ERROR: 40 };
+
+export function setupLogging({ logFile, level = 'INFO', stdout = false } = {}) {
+  const env = process.env.PW_LOG_LEVEL;
+  if (env) {
+    if (/^\d+$/.test(env)) {
+      const num = parseInt(env, 10);
+      level = Object.keys(LEVELS).find(k => LEVELS[k] === num) || level;
+    } else if (LEVELS[env.toUpperCase()]) {
+      level = env.toUpperCase();
+    }
+  }
+  const current = LEVELS[level.toUpperCase()] || LEVELS.INFO;
+
+  function log(levelName, message) {
+    if (LEVELS[levelName] >= current) {
+      const line = JSON.stringify({ level: levelName, message }) + '\n';
+      fs.appendFileSync(logFile, line);
+      if (stdout) process.stdout.write(line);
+    }
+  }
+
+  return {
+    level: current,
+    debug: msg => log('DEBUG', msg),
+    info: msg => log('INFO', msg),
+    warning: msg => log('WARNING', msg),
+    error: msg => log('ERROR', msg)
+  };
+}

--- a/webui/tests/imsiScanner.test.js
+++ b/webui/tests/imsiScanner.test.js
@@ -1,0 +1,26 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { scanImsis, registerPostProcessor, clearPostProcessors } from '../src/imsiScanner.js';
+
+describe('scanImsis', () => {
+  afterEach(() => {
+    clearPostProcessors('imsi');
+  });
+
+  it('parses output and tags location', () => {
+    const execSync = vi.fn(() => '12345,310,260,-50\n67890,311,480,-60');
+    const getPosition = vi.fn(() => [1.0, 2.0]);
+    const records = scanImsis('dummy', { execSync, getPosition });
+    expect(records).toEqual([
+      { imsi: '12345', mcc: '310', mnc: '260', rssi: '-50', lat: 1.0, lon: 2.0 },
+      { imsi: '67890', mcc: '311', mnc: '480', rssi: '-60', lat: 1.0, lon: 2.0 },
+    ]);
+  });
+
+  it('applies custom hook', () => {
+    const execSync = vi.fn(() => '12345,310,260,-50');
+    const getPosition = vi.fn(() => null);
+    registerPostProcessor('imsi', recs => recs.map(r => ({ ...r, op: 'test' })));
+    const records = scanImsis('dummy', { execSync, getPosition });
+    expect(records[0].op).toBe('test');
+  });
+});

--- a/webui/tests/kalman.test.js
+++ b/webui/tests/kalman.test.js
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { kalman1d } from '../src/kalman.js';
+
+function variance(arr) {
+  const mean = arr.reduce((a, b) => a + b, 0) / arr.length;
+  return arr.reduce((s, x) => s + (x - mean) ** 2, 0) / arr.length;
+}
+
+function randomSeries(n, seed = 1) {
+  let x = seed;
+  const arr = [];
+  for (let i = 0; i < n; i++) {
+    x = (x * 16807) % 2147483647;
+    arr.push((x / 2147483646) - 0.5);
+  }
+  return arr;
+}
+
+describe('kalman1d', () => {
+  it('reduces variance', () => {
+    const data = randomSeries(100, 1);
+    const filtered = kalman1d(data, 0.0001, 0.01);
+    expect(filtered.length).toBe(data.length);
+    expect(Math.abs(filtered[0] - data[0]) < 1e-9).toBe(true);
+    expect(variance(filtered)).toBeLessThan(variance(data));
+  });
+});

--- a/webui/tests/kiosk.test.js
+++ b/webui/tests/kiosk.test.js
@@ -1,0 +1,16 @@
+import { describe, it, expect, vi } from 'vitest';
+import { runKiosk } from '../src/kiosk.js';
+
+describe('runKiosk', () => {
+  it('launches server and browser', async () => {
+    const calls = [];
+    const spawn = vi.fn((cmd, args) => {
+      calls.push(cmd);
+      return { kill: vi.fn() };
+    });
+    const whichFn = vi.fn(cmd => `/bin/${cmd}`);
+    await runKiosk({ delay: 0, spawnFn: spawn, whichFn });
+    expect(calls).toContain('piwardrive-webui');
+    expect(calls).toContain('/bin/chromium-browser');
+  });
+});

--- a/webui/tests/logViewer.test.jsx
+++ b/webui/tests/logViewer.test.jsx
@@ -1,0 +1,45 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import LogViewer from '../src/components/LogViewer.jsx';
+
+vi.useFakeTimers();
+let origInterval;
+let origClear;
+let intervalFn;
+
+describe('LogViewer', () => {
+  beforeEach(() => {
+    origInterval = global.setInterval;
+    origClear = global.clearInterval;
+    global.setInterval = (fn) => { intervalFn = fn; fn(); return 1; };
+    global.clearInterval = () => { intervalFn = null; };
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.restoreAllMocks();
+    global.setInterval = origInterval;
+    global.clearInterval = origClear;
+  });
+
+  it('calls fetch with params', async () => {
+    global.fetch = vi.fn(() => Promise.resolve({ json: () => Promise.resolve({ lines: ['A', 'B'] }) }));
+    const { unmount } = render(<LogViewer path="/a.log" lines={10} />);
+    await Promise.resolve();
+    expect(global.fetch).toHaveBeenCalledWith('/logs?path=%2Fa.log&lines=10');
+    unmount();
+  });
+
+  it('polls periodically', async () => {
+    let count = 0;
+    global.fetch = vi.fn(() => Promise.resolve({ json: () => Promise.resolve({ lines: [`L${++count}`] }) }));
+    const { unmount } = render(<LogViewer />);
+    await Promise.resolve();
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+    intervalFn();
+    await Promise.resolve();
+    expect(global.fetch).toHaveBeenCalledTimes(3);
+    unmount();
+  });
+});

--- a/webui/tests/logconfig.test.js
+++ b/webui/tests/logconfig.test.js
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import fs from 'fs';
+import { setupLogging } from '../src/logconfig.js';
+import path from 'path';
+
+function tmpFile(name) {
+  return path.join(process.cwd(), name);
+}
+
+describe('setupLogging', () => {
+  afterEach(() => {
+    delete process.env.PW_LOG_LEVEL;
+  });
+
+  it('writes JSON', () => {
+    const file = tmpFile('log.json');
+    if (fs.existsSync(file)) fs.unlinkSync(file);
+    const logger = setupLogging({ logFile: file });
+    logger.info('hello');
+    const data = JSON.parse(fs.readFileSync(file, 'utf8'));
+    expect(data.message).toBe('hello');
+    expect(data.level).toBe('INFO');
+    fs.unlinkSync(file);
+  });
+
+  it('respects env', () => {
+    process.env.PW_LOG_LEVEL = 'DEBUG';
+    const file = tmpFile('log_env.json');
+    if (fs.existsSync(file)) fs.unlinkSync(file);
+    const logger = setupLogging({ logFile: file });
+    logger.debug('hi');
+    const data = JSON.parse(fs.readFileSync(file, 'utf8'));
+    expect(data.level).toBe('DEBUG');
+    expect(logger.level).toBe(10);
+    fs.unlinkSync(file);
+  });
+
+  it('writes to stdout', () => {
+    const file = tmpFile('log_out.json');
+    if (fs.existsSync(file)) fs.unlinkSync(file);
+    const write = vi.spyOn(process.stdout, 'write').mockImplementation(() => {});
+    const logger = setupLogging({ logFile: file, stdout: true });
+    logger.warning('stream me');
+    const data = JSON.parse(fs.readFileSync(file, 'utf8'));
+    expect(data.message).toBe('stream me');
+    expect(write).toHaveBeenCalled();
+    write.mockRestore();
+    fs.unlinkSync(file);
+  });
+});


### PR DESCRIPTION
## Summary
- add JavaScript implementations mirroring Python utilities
- port IMSI catcher tests to vitest
- port Kalman filter test
- port kiosk CLI launch test
- port log viewer tests
- port logging configuration tests

## Testing
- `npm run test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685ca53f7b00833397e2bd198560c182