### PR TITLE
Add React components for backend features

### DIFF
--- a/webui/src/backendService.js
+++ b/webui/src/backendService.js
@@ -1,0 +1,21 @@
+export async function fetchServiceStatuses(services) {
+  const entries = await Promise.all(
+    services.map(svc =>
+      fetch(`/service/${svc}`)
+        .then(r => r.json())
+        .then(d => [svc, !!d.active])
+    )
+  );
+  return Object.fromEntries(entries);
+}
+
+export async function syncHealthRecords(limit = 100) {
+  const resp = await fetch(`/sync?limit=${limit}`, { method: 'POST' });
+  if (!resp.ok) throw new Error('sync failed');
+  return await resp.json();
+}
+
+export async function fetchSigintData(type) {
+  const resp = await fetch(`/export/${type}?fmt=json`);
+  return await resp.json();
+}

--- a/webui/src/components/ServiceStatusFetcher.jsx
+++ b/webui/src/components/ServiceStatusFetcher.jsx
@@ -1,0 +1,20 @@
+import { useEffect, useState } from 'react';
+import { fetchServiceStatuses } from '../backendService.js';
+
+export default function ServiceStatusFetcher({ services = ['kismet', 'gpsd'] }) {
+  const [status, setStatus] = useState(null);
+  useEffect(() => {
+    fetchServiceStatuses(services).then(setStatus).catch(() => {});
+  }, [services]);
+
+  if (!status) return <div>Loading...</div>;
+  return (
+    <ul>
+      {services.map(svc => (
+        <li key={svc} data-testid={svc}>
+          {svc}: {status[svc] ? 'active' : 'inactive'}
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/webui/src/components/SigintExportList.jsx
+++ b/webui/src/components/SigintExportList.jsx
@@ -1,0 +1,12 @@
+import { useEffect, useState } from 'react';
+import { fetchSigintData } from '../backendService.js';
+
+export default function SigintExportList({ type = 'aps' }) {
+  const [records, setRecords] = useState(null);
+  useEffect(() => {
+    fetchSigintData(type).then(setRecords).catch(() => {});
+  }, [type]);
+
+  if (!records) return <div>Loading...</div>;
+  return <div data-testid="count">count {records.length}</div>;
+}

--- a/webui/src/components/SyncButton.jsx
+++ b/webui/src/components/SyncButton.jsx
@@ -1,0 +1,17 @@
+import { useState } from 'react';
+import { syncHealthRecords } from '../backendService.js';
+
+export default function SyncButton({ limit = 100 }) {
+  const [result, setResult] = useState(null);
+  const run = () => {
+    syncHealthRecords(limit)
+      .then(r => setResult(`uploaded ${r.uploaded}`))
+      .catch(() => setResult('failed'));
+  };
+  return (
+    <div>
+      <button onClick={run}>Sync</button>
+      {result && <span data-testid="result">{result}</span>}
+    </div>
+  );
+}

--- a/webui/src/sigintExporter.js
+++ b/webui/src/sigintExporter.js
@@ -1,0 +1,20 @@
+import fs from 'fs';
+
+export function exportJson(records, path) {
+  fs.writeFileSync(path, JSON.stringify(records, null, 2));
+}
+
+export function exportCsv(records, path) {
+  if (!records.length) { fs.writeFileSync(path, ''); return; }
+  const keys = Object.keys(records[0]);
+  const lines = [keys.join(',')];
+  for (const rec of records) {
+    lines.push(keys.map(k => String(rec[k])).join(','));
+  }
+  fs.writeFileSync(path, lines.join('\n'));
+}
+
+export function exportYaml(records, path) {
+  const lines = records.map(r => '-\n' + Object.entries(r).map(([k,v]) => `  ${k}: ${v}`).join('\n')); 
+  fs.writeFileSync(path, lines.join('\n'));
+}

--- a/webui/src/sigintPaths.js
+++ b/webui/src/sigintPaths.js
@@ -1,0 +1,2 @@
+const DEFAULT_EXPORT_DIR = '/exports';
+export const EXPORT_DIR = process.env.EXPORT_DIR || DEFAULT_EXPORT_DIR;

--- a/webui/tests/serviceStatusFetcher.test.jsx
+++ b/webui/tests/serviceStatusFetcher.test.jsx
@@ -1,0 +1,17 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { vi, describe, it, beforeEach, afterEach } from 'vitest';
+import ServiceStatusFetcher from '../src/components/ServiceStatusFetcher.jsx';
+
+describe('ServiceStatusFetcher', () => {
+  let origFetch;
+  beforeEach(() => { origFetch = global.fetch; });
+  afterEach(() => { global.fetch = origFetch; });
+
+  it('fetches statuses', async () => {
+    global.fetch = vi.fn(url => Promise.resolve({ json: () => Promise.resolve({ active: url.includes('kismet') }) }));
+    render(<ServiceStatusFetcher services={['kismet', 'gpsd']} />);
+    expect(await screen.findByTestId('kismet')).toHaveTextContent('kismet: active');
+    expect(await screen.findByTestId('gpsd')).toHaveTextContent('gpsd: inactive');
+  });
+});

--- a/webui/tests/sigintExportList.test.jsx
+++ b/webui/tests/sigintExportList.test.jsx
@@ -1,0 +1,16 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { vi, describe, it, beforeEach, afterEach } from 'vitest';
+import SigintExportList from '../src/components/SigintExportList.jsx';
+
+describe('SigintExportList', () => {
+  let origFetch;
+  beforeEach(() => { origFetch = global.fetch; });
+  afterEach(() => { global.fetch = origFetch; });
+
+  it('shows record count', async () => {
+    global.fetch = vi.fn(() => Promise.resolve({ json: () => Promise.resolve([{a:1},{a:2}]) }));
+    render(<SigintExportList type="aps" />);
+    expect(await screen.findByTestId('count')).toHaveTextContent('count 2');
+  });
+});

--- a/webui/tests/sigintExporter.test.js
+++ b/webui/tests/sigintExporter.test.js
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import { exportJson, exportCsv, exportYaml } from '../src/sigintExporter.js';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+describe('sigint exporter', () => {
+  it('writes json', () => {
+    const path = join(tmpdir(), 'data.json');
+    const records = [{ a: 1 }];
+    exportJson(records, path);
+    const data = JSON.parse(fs.readFileSync(path, 'utf-8'));
+    expect(data).toEqual(records);
+    fs.unlinkSync(path);
+  });
+
+  it('writes csv', () => {
+    const path = join(tmpdir(), 'data.csv');
+    const records = [{ a: '1', b: '2' }];
+    exportCsv(records, path);
+    const text = fs.readFileSync(path, 'utf-8').trim();
+    expect(text).toBe('a,b\n1,2');
+    fs.unlinkSync(path);
+  });
+
+  it('writes yaml', () => {
+    const path = join(tmpdir(), 'data.yaml');
+    const records = [{ a: 1 }];
+    exportYaml(records, path);
+    const text = fs.readFileSync(path, 'utf-8');
+    expect(text).toContain('a: 1');
+    fs.unlinkSync(path);
+  });
+});

--- a/webui/tests/sigintPaths.test.js
+++ b/webui/tests/sigintPaths.test.js
@@ -1,0 +1,8 @@
+import { describe, it, expect } from 'vitest';
+
+it('EXPORT_DIR env override', async () => {
+  process.env.EXPORT_DIR = '/tmp/x';
+  const { EXPORT_DIR } = await import('../src/sigintPaths.js');
+  expect(EXPORT_DIR).toBe('/tmp/x');
+  delete process.env.EXPORT_DIR;
+});

--- a/webui/tests/syncButton.test.jsx
+++ b/webui/tests/syncButton.test.jsx
@@ -1,0 +1,24 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { vi, describe, it, beforeEach, afterEach } from 'vitest';
+import SyncButton from '../src/components/SyncButton.jsx';
+
+describe('SyncButton', () => {
+  let origFetch;
+  beforeEach(() => { origFetch = global.fetch; });
+  afterEach(() => { global.fetch = origFetch; });
+
+  it('shows success', async () => {
+    global.fetch = vi.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve({ uploaded: 2 }) }));
+    render(<SyncButton limit={2} />);
+    fireEvent.click(screen.getByText('Sync'));
+    expect(await screen.findByTestId('result')).toHaveTextContent('uploaded 2');
+  });
+
+  it('shows failure', async () => {
+    global.fetch = vi.fn(() => Promise.resolve({ ok: false }));
+    render(<SyncButton />);
+    fireEvent.click(screen.getByText('Sync'));
+    expect(await screen.findByTestId('result')).toHaveTextContent('failed');
+  });
+});


### PR DESCRIPTION
## Summary
- add helper functions to call backend APIs
- add components for service status, sync, and SIGINT exports
- provide SIGINT exporter utilities and env path helper
- test new components and utilities

## Testing
- `pytest -q` *(fails: 43 errors during collection)*
- `npm install --legacy-peer-deps`
- `npx vitest run tests/serviceStatusFetcher.test.jsx tests/syncButton.test.jsx tests/sigintExportList.test.jsx tests/sigintPaths.test.js tests/sigintExporter.test.js`

------
https://chatgpt.com/codex/tasks/task_e_685ca57848bc83338188d109710507ae