### PR TITLE
Add JS modules mirroring backend logic

### DIFF
--- a/webui/src/towerScanner.js
+++ b/webui/src/towerScanner.js
@@ -1,0 +1,42 @@
+import { execFileSync, execFile } from 'child_process';
+
+export function parseTowerOutput(output) {
+  const records = [];
+  for (const line of output.split(/\n+/)) {
+    if (!line) continue;
+    const parts = line.split(',').map(p => p.trim());
+    if (parts.length >= 2) {
+      const [tower_id, rssi] = parts;
+      records.push({ tower_id, rssi, lat: null, lon: null });
+    }
+  }
+  return records;
+}
+
+export function scanTowers(cmd = 'tower-scan', timeout) {
+  try {
+    const out = execFileSync(cmd, {
+      encoding: 'utf-8',
+      timeout: timeout ? timeout * 1000 : undefined,
+    });
+    return parseTowerOutput(out);
+  } catch {
+    return [];
+  }
+}
+
+export function asyncScanTowers(cmd = 'tower-scan', timeout) {
+  return new Promise(resolve => {
+    execFile(
+      cmd,
+      { encoding: 'utf-8', timeout: timeout ? timeout * 1000 : undefined },
+      (err, stdout) => {
+        if (err) {
+          resolve([]);
+          return;
+        }
+        resolve(parseTowerOutput(stdout));
+      }
+    );
+  });
+}

--- a/webui/src/towerTracker.js
+++ b/webui/src/towerTracker.js
@@ -1,0 +1,75 @@
+export class TowerTracker {
+  constructor() {
+    this.towers = new Map();
+    this.towerObs = new Map();
+    this.wifiObs = new Map();
+    this.btObs = new Map();
+  }
+
+  async _record(map, key, data) {
+    if (!map.has(key)) map.set(key, []);
+    map.get(key).push(data);
+  }
+
+  async updateTower(towerId, lat, lon, lastSeen = Date.now()) {
+    this.towers.set(towerId, { tower_id: towerId, lat, lon, last_seen: lastSeen });
+  }
+
+  async getTower(towerId) {
+    return this.towers.get(towerId) || null;
+  }
+
+  async allTowers() {
+    return Array.from(this.towers.values());
+  }
+
+  async close() {}
+
+  async logTower(towerId, rssi, lat = null, lon = null, timestamp = Date.now()) {
+    await this._record(this.towerObs, towerId, {
+      tower_id: towerId,
+      rssi,
+      lat,
+      lon,
+      timestamp,
+    });
+  }
+
+  async towerHistory(towerId) {
+    return (this.towerObs.get(towerId) || [])
+      .slice()
+      .sort((a, b) => b.timestamp - a.timestamp);
+  }
+
+  async logWifi(bssid, ssid, lat = null, lon = null, timestamp = Date.now()) {
+    await this._record(this.wifiObs, bssid, {
+      bssid,
+      ssid,
+      lat,
+      lon,
+      timestamp,
+    });
+  }
+
+  async wifiHistory(bssid) {
+    return (this.wifiObs.get(bssid) || [])
+      .slice()
+      .sort((a, b) => b.timestamp - a.timestamp);
+  }
+
+  async logBluetooth(address, name, lat = null, lon = null, timestamp = Date.now()) {
+    await this._record(this.btObs, address, {
+      address,
+      name,
+      lat,
+      lon,
+      timestamp,
+    });
+  }
+
+  async bluetoothHistory(address) {
+    return (this.btObs.get(address) || [])
+      .slice()
+      .sort((a, b) => b.timestamp - a.timestamp);
+  }
+}

--- a/webui/src/utils.js
+++ b/webui/src/utils.js
@@ -1,0 +1,16 @@
+export function formatError(code, msg) {
+  const prefix = typeof code === 'string' ? code : code?.toString();
+  return `[${prefix}] ${msg}`;
+}
+
+export function pointInPolygon(point, polygon) {
+  const [x, y] = point;
+  let inside = false;
+  for (let i = 0, j = polygon.length - 1; i < polygon.length; j = i++) {
+    const xi = polygon[i][0], yi = polygon[i][1];
+    const xj = polygon[j][0], yj = polygon[j][1];
+    const intersect = yi > y !== yj > y && x < ((xj - xi) * (y - yi)) / (yj - yi) + xi;
+    if (intersect) inside = !inside;
+  }
+  return inside;
+}

--- a/webui/src/vacuumDb.js
+++ b/webui/src/vacuumDb.js
@@ -1,0 +1,9 @@
+import { execFileSync } from 'child_process';
+
+export function main(dbPath) {
+  execFileSync('sqlite3', [dbPath, 'VACUUM']);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main(process.argv[2] || 'piwardrive.db');
+}

--- a/webui/src/vectorTileCustomizer.js
+++ b/webui/src/vectorTileCustomizer.js
@@ -1,0 +1,51 @@
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { execFileSync } from 'child_process';
+
+export function applyStyle(dbPath, { stylePath, name, description } = {}) {
+  const lines = [
+    "CREATE TABLE IF NOT EXISTS metadata (name TEXT, value TEXT);",
+  ];
+  if (name != null) lines.push(`INSERT OR REPLACE INTO metadata (name,value) VALUES ('name','${name}')`);
+  if (description != null) lines.push(`INSERT OR REPLACE INTO metadata (name,value) VALUES ('description','${description}')`);
+  if (stylePath) {
+    const style = fs.readFileSync(stylePath, 'utf-8');
+    JSON.parse(style);
+    lines.push(`INSERT OR REPLACE INTO metadata (name,value) VALUES ('style','${style.replace(/'/g, "''")}')`);
+  }
+  execFileSync('sqlite3', [dbPath], { input: lines.join('\n') });
+}
+
+export function buildMbtiles(folder, output) {
+  if (!fs.existsSync(folder) || !fs.statSync(folder).isDirectory()) {
+    throw new Error('Folder not found');
+  }
+  const sql = [];
+  sql.push("CREATE TABLE IF NOT EXISTS tiles (zoom_level INTEGER, tile_column INTEGER, tile_row INTEGER, tile_data BLOB, UNIQUE (zoom_level,tile_column,tile_row));");
+  sql.push("CREATE TABLE IF NOT EXISTS metadata (name TEXT, value TEXT);");
+  for (const rootZ of fs.readdirSync(folder)) {
+    const zDir = path.join(folder, rootZ);
+    if (!fs.statSync(zDir).isDirectory()) continue;
+    for (const xEntry of fs.readdirSync(zDir)) {
+      const xDir = path.join(zDir, xEntry);
+      if (!fs.statSync(xDir).isDirectory()) continue;
+      for (const file of fs.readdirSync(xDir)) {
+        if (!file.endsWith('.pbf')) continue;
+        const yName = path.basename(file, '.pbf');
+        const z = parseInt(rootZ, 10);
+        const x = parseInt(xEntry, 10);
+        const y = parseInt(yName, 10);
+        if (Number.isNaN(z) || Number.isNaN(x) || Number.isNaN(y)) continue;
+        const tileRow = Math.pow(2, z) - 1 - y;
+        const data = fs.readFileSync(path.join(xDir, file));
+        const hex = data.toString('hex');
+        sql.push(`INSERT OR REPLACE INTO tiles (zoom_level,tile_column,tile_row,tile_data) VALUES (${z},${x},${tileRow},X'${hex}')`);
+      }
+    }
+  }
+  const tmp = path.join(os.tmpdir(), `mb-${Date.now()}.sql`);
+  fs.writeFileSync(tmp, sql.join('\n'));
+  execFileSync('sqlite3', [output], { input: fs.readFileSync(tmp) });
+  fs.unlinkSync(tmp);
+}

--- a/webui/tests/towerScanner.test.js
+++ b/webui/tests/towerScanner.test.js
@@ -1,0 +1,36 @@
+import { describe, it, expect, vi } from 'vitest';
+import { parseTowerOutput, scanTowers, asyncScanTowers } from '../src/towerScanner.js';
+import * as childProcess from 'child_process';
+
+vi.mock('child_process');
+
+describe('parseTowerOutput', () => {
+  it('parses lines', () => {
+    const out = '123,-70\n456,-80';
+    const rec = parseTowerOutput(out);
+    expect(rec).toEqual([
+      { tower_id: '123', rssi: '-70', lat: null, lon: null },
+      { tower_id: '456', rssi: '-80', lat: null, lon: null },
+    ]);
+  });
+});
+
+describe('scanTowers', () => {
+  it('executes command', () => {
+    const spy = vi.spyOn(childProcess, 'execFileSync').mockReturnValue('123,-70');
+    const res = scanTowers('dummy');
+    expect(spy).toHaveBeenCalled();
+    expect(res.length).toBe(1);
+    spy.mockRestore();
+  });
+});
+
+describe('asyncScanTowers', () => {
+  it('returns records', async () => {
+    vi.spyOn(childProcess, 'execFile').mockImplementation((cmd, opts, cb) => {
+      cb(null, '123,-70');
+    });
+    const res = await asyncScanTowers('dummy');
+    expect(res).toEqual([{ tower_id: '123', rssi: '-70', lat: null, lon: null }]);
+  });
+});

--- a/webui/tests/towerTracker.test.js
+++ b/webui/tests/towerTracker.test.js
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { TowerTracker } from '../src/towerTracker.js';
+
+describe('TowerTracker', () => {
+  it('updates and queries towers', async () => {
+    const tr = new TowerTracker();
+    await tr.updateTower('id1', 1.0, 2.0, 100);
+    const rec = await tr.getTower('id1');
+    expect(rec.lat).toBe(1.0);
+    const all = await tr.allTowers();
+    expect(all.length).toBe(1);
+  });
+
+  it('logs wifi and bluetooth', async () => {
+    const tr = new TowerTracker();
+    await tr.logWifi('AA', 'Test', 1, 2, 50);
+    await tr.logBluetooth('11', 'Phone', 3, 4, 60);
+    const wifi = await tr.wifiHistory('AA');
+    const bt = await tr.bluetoothHistory('11');
+    expect(wifi[0].ssid).toBe('Test');
+    expect(bt[0].name).toBe('Phone');
+  });
+});

--- a/webui/tests/utils.test.js
+++ b/webui/tests/utils.test.js
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import { formatError, pointInPolygon } from '../src/utils.js';
+
+describe('formatError', () => {
+  it('formats message', () => {
+    expect(formatError('E1', 'fail')).toBe('[E1] fail');
+  });
+});
+
+describe('pointInPolygon', () => {
+  it('detects containment', () => {
+    const poly = [ [0,0], [0,1], [1,1], [1,0] ];
+    expect(pointInPolygon([0.5,0.5], poly)).toBe(true);
+    expect(pointInPolygon([1.5,0.5], poly)).toBe(false);
+  });
+});

--- a/webui/tests/vectorTileCustomizer.test.js
+++ b/webui/tests/vectorTileCustomizer.test.js
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { applyStyle, buildMbtiles } from '../src/vectorTileCustomizer.js';
+import fs from 'fs';
+import path from 'path';
+import sqlite3 from 'sqlite3';
+
+sqlite3.verbose();
+
+function readMeta(dbPath) {
+  return new Promise(resolve => {
+    const db = new sqlite3.Database(dbPath);
+    db.all('SELECT name, value FROM metadata', (err, rows) => {
+      db.close();
+      resolve(Object.fromEntries(rows.map(r => [r.name, r.value])));
+    });
+  });
+}
+
+describe('vector tile customizer', () => {
+  it('applies style', async () => {
+    const tmp = path.join(process.cwd(), 'test.mbtiles');
+    fs.writeFileSync(tmp, '');
+    applyStyle(tmp, { name: 'N', description: 'D' });
+    const meta = await readMeta(tmp);
+    expect(meta.name).toBe('N');
+    expect(meta.description).toBe('D');
+    fs.unlinkSync(tmp);
+  });
+
+  it('builds mbtiles', async () => {
+    const dir = path.join(process.cwd(), 'tiles');
+    fs.mkdirSync(path.join(dir, '1/2'), { recursive: true });
+    fs.writeFileSync(path.join(dir, '1/2/3.pbf'), 'data');
+    const out = path.join(process.cwd(), 'out.mbtiles');
+    buildMbtiles(dir, out);
+    const db = new sqlite3.Database(out);
+    await new Promise(resolve => db.get('SELECT zoom_level, tile_column, tile_row, tile_data FROM tiles', (err, row) => { db.close(); resolve(row); })).then(row => {
+      expect(row.zoom_level).toBe(1);
+    });
+    fs.rmSync(dir, { recursive: true });
+    fs.unlinkSync(out);
+  });
+});


### PR DESCRIPTION
## Summary
- implement tower scanner in JS
- implement tower tracker with in-memory store
- add utility helpers
- provide vector tile customizer and vacuum script
- add accompanying unit tests

## Testing
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ca59661e88333b5a88ea6c01c4fa5