### PR TITLE
Add frontend modules for sensor and network features

### DIFF
--- a/webui/src/ouiRegistry.js
+++ b/webui/src/ouiRegistry.js
@@ -1,0 +1,36 @@
+let OUI_MAP = null;
+export const DEFAULT_OUI_URL = '/oui.csv';
+
+export async function loadOuiMap(url = DEFAULT_OUI_URL) {
+  try {
+    const resp = await fetch(url);
+    const text = await resp.text();
+    const map = {};
+    text.split(/\n+/).slice(1).forEach(line => {
+      const [assign, vendor] = line.split(',');
+      if (assign && vendor) {
+        const prefix = assign.replace(/-/g, ':').toUpperCase();
+        map[prefix] = vendor.trim();
+      }
+    });
+    OUI_MAP = map;
+    return map;
+  } catch (e) {
+    console.error('OUI map load failed:', e);
+    OUI_MAP = {};
+    return OUI_MAP;
+  }
+}
+
+export function lookupVendor(bssid, map = OUI_MAP) {
+  if (!bssid || !map) return null;
+  const parts = bssid.toUpperCase().replace(/-/g, ':').split(':');
+  if (parts.length < 3) return null;
+  const prefix = parts.slice(0, 3).join(':');
+  return map[prefix] || null;
+}
+
+export async function cachedLookupVendor(bssid) {
+  if (!OUI_MAP) await loadOuiMap();
+  return lookupVendor(bssid);
+}

--- a/webui/src/vehicleSensors.js
+++ b/webui/src/vehicleSensors.js
@@ -1,0 +1,37 @@
+export let obd = null;
+
+export function readSpeedObd(port = null) {
+  if (!obd) return null;
+  try {
+    const conn = new obd.OBD(port);
+    const rsp = conn.query(obd.commands.SPEED);
+    return rsp && rsp.value != null ? Number(rsp.value.to('km/h')) : null;
+  } catch (e) {
+    console.error('OBD speed read failed:', e);
+    return null;
+  }
+}
+
+export function readRpmObd(port = null) {
+  if (!obd) return null;
+  try {
+    const conn = new obd.OBD(port);
+    const rsp = conn.query(obd.commands.RPM);
+    return rsp && rsp.value != null ? Number(rsp.value.to('rpm')) : null;
+  } catch (e) {
+    console.error('OBD RPM read failed:', e);
+    return null;
+  }
+}
+
+export function readEngineLoadObd(port = null) {
+  if (!obd) return null;
+  try {
+    const conn = new obd.OBD(port);
+    const rsp = conn.query(obd.commands.ENGINE_LOAD);
+    return rsp && rsp.value != null ? Number(rsp.value.to('percent')) : null;
+  } catch (e) {
+    console.error('OBD engine load read failed:', e);
+    return null;
+  }
+}

--- a/webui/src/webApiClient.js
+++ b/webui/src/webApiClient.js
@@ -1,0 +1,18 @@
+export async function getGps() {
+  const resp = await fetch('/api/gps');
+  return resp.json();
+}
+
+export async function getAps() {
+  const resp = await fetch('/api/aps');
+  return resp.json();
+}
+
+export async function getBt() {
+  const resp = await fetch('/api/bt');
+  return resp.json();
+}
+
+export async function toggleKismet(state) {
+  await fetch(`/api/kismet/toggle?state=${encodeURIComponent(state)}`, { method: 'POST' });
+}

--- a/webui/src/widgetPlugins.js
+++ b/webui/src/widgetPlugins.js
@@ -1,0 +1,49 @@
+import fs from 'fs';
+import path from 'path';
+
+const PLUGIN_DIR = path.join(process.env.HOME || '', '.config', 'piwardrive', 'plugins');
+let PLUGIN_STAMP = null;
+const PLUGINS = {};
+
+function loadPlugins() {
+  let stat;
+  try {
+    stat = fs.statSync(PLUGIN_DIR);
+  } catch {
+    return;
+  }
+  const stamp = stat.mtimeMs;
+  if (PLUGIN_STAMP === stamp && Object.keys(PLUGINS).length) return;
+  if (PLUGIN_STAMP !== stamp) {
+    for (const k in PLUGINS) delete PLUGINS[k];
+  }
+  for (const file of fs.readdirSync(PLUGIN_DIR)) {
+    const full = path.join(PLUGIN_DIR, file);
+    if (fs.statSync(full).isFile() && /\.(js|mjs|cjs)$/i.test(file)) {
+      try {
+        const mod = require(full);
+        for (const [name, obj] of Object.entries(mod)) {
+          if (typeof obj === 'function') {
+            PLUGINS[name] = obj;
+          }
+        }
+      } catch {}
+    }
+  }
+  PLUGIN_STAMP = stamp;
+}
+
+export function listPlugins() {
+  loadPlugins();
+  return Object.keys(PLUGINS);
+}
+
+export function getPlugin(name) {
+  loadPlugins();
+  return PLUGINS[name];
+}
+
+export function clearPluginCache() {
+  PLUGIN_STAMP = null;
+  for (const k in PLUGINS) delete PLUGINS[k];
+}

--- a/webui/src/wifiScanner.js
+++ b/webui/src/wifiScanner.js
@@ -1,0 +1,89 @@
+import { execFileSync, execFile } from 'child_process';
+import { getHeading } from './orientationSensors.js';
+import { cachedLookupVendor } from './ouiRegistry.js';
+
+export function parseIwlist(output) {
+  const records = [];
+  let current = null;
+  let encLines = [];
+  const lines = output.split(/\n+/);
+  for (const line of lines) {
+    const l = line.trim();
+    if (l.startsWith('Cell')) {
+      if (current) {
+        if (encLines.length) {
+          current.encryption = (
+            (current.encryption || '') + ' ' + encLines.join(' ')
+          ).trim();
+        }
+        records.push(current);
+      }
+      current = { cell: l };
+      const addrMatch = l.match(/Address:\s*([A-Fa-f0-9:]+)/);
+      if (addrMatch) current.bssid = addrMatch[1];
+      encLines = [];
+    } else if (l.includes('ESSID')) {
+      current.ssid = l.split(':', 2)[1].replace(/"/g, '').trim();
+    } else if (l.startsWith('Frequency')) {
+      current.frequency = l.split('Frequency:')[1].split(' ')[0];
+      const chMatch = l.match(/Channel\s*(\d+)/);
+      if (chMatch) current.channel = chMatch[1];
+    } else if (l.startsWith('Channel:')) {
+      current.channel = l.split('Channel:')[1].trim();
+    } else if (l.startsWith('Encryption key:')) {
+      current.encryption = l.split('Encryption key:')[1].trim();
+    } else if (l.startsWith('IE:')) {
+      encLines.push(l.split('IE:')[1].trim());
+    } else if (l.includes('Quality=')) {
+      current.quality = l.split('Quality=')[1].split(' ')[0];
+    }
+  }
+  if (current) {
+    if (encLines.length) {
+      current.encryption = (
+        (current.encryption || '') + ' ' + encLines.join(' ')
+      ).trim();
+    }
+    records.push(current);
+  }
+  return records.map(r => {
+    const vendor = r.bssid ? cachedLookupVendor(r.bssid) : null;
+    const heading = getHeading();
+    if (vendor) r.vendor = vendor;
+    if (heading != null) r.heading = heading;
+    return r;
+  });
+}
+
+export function scanWifi(iface = 'wlan0', iwlistCmd = 'iwlist', privCmd = 'sudo', timeout) {
+  try {
+    const args = [];
+    if (privCmd) args.push(...privCmd.split(/\s+/));
+    args.push(iwlistCmd, iface, 'scanning');
+    const out = execFileSync(args[0], args.slice(1), {
+      encoding: 'utf-8',
+      timeout: timeout ? timeout * 1000 : undefined,
+      stdio: ['ignore', 'pipe', 'ignore']
+    });
+    return parseIwlist(out);
+  } catch (e) {
+    console.error('Wi-Fi scan failed:', e);
+    return [];
+  }
+}
+
+export function asyncScanWifi(iface = 'wlan0', iwlistCmd = 'iwlist', privCmd = 'sudo', timeout) {
+  return new Promise(resolve => {
+    const args = [];
+    if (privCmd) args.push(...privCmd.split(/\s+/));
+    args.push(iwlistCmd, iface, 'scanning');
+    execFile(args[0], args.slice(1), {
+      encoding: 'utf-8',
+      timeout: timeout ? timeout * 1000 : undefined,
+      stdio: ['ignore', 'pipe', 'ignore']
+    }, (err, stdout) => {
+      if (err) { resolve([]); return; }
+      resolve(parseIwlist(stdout));
+    });
+  });
+}

--- a/webui/src/wigleIntegration.js
+++ b/webui/src/wigleIntegration.js
@@ -1,0 +1,27 @@
+export async function fetchWigleNetworks(apiName, apiKey, lat, lon, { radius = 0.01 } = {}) {
+  const params = new URLSearchParams({
+    latrange1: lat - radius,
+    latrange2: lat + radius,
+    longrange1: lon - radius,
+    longrange2: lon + radius,
+    resultsPerPage: 100
+  });
+  const creds = btoa(`${apiName}:${apiKey}`);
+  const resp = await fetch(`https://api.wigle.net/api/v2/network/search?${params.toString()}`, {
+    headers: { Authorization: `Basic ${creds}` }
+  });
+  if (!resp.ok) throw new Error('WiGLE request failed');
+  const data = await resp.json();
+  const nets = [];
+  for (const rec of data.results || []) {
+    if (rec.trilat == null || rec.trilong == null) continue;
+    nets.push({
+      bssid: rec.netid,
+      ssid: rec.ssid,
+      encryption: rec.encryption,
+      lat: rec.trilat,
+      lon: rec.trilong
+    });
+  }
+  return nets;
+}


### PR DESCRIPTION
## Summary
- add frontend stubs for vehicle sensors
- add vendor lookup helpers
- implement Wi-Fi scanning parser and wrapper
- add WiGLE API integration helper
- simple web API client helpers
- widget plugin loader for dashboard extensions

## Testing
- `npm test --prefix webui` *(fails: Failed to parse analysis.test.js and other tests)*
- `pytest -q` *(fails: 43 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_685ca5a6e1b483338a45b8c64f8c94a8