### PR TITLE
Node/React infra setup

### DIFF
--- a/exception_handler.py
+++ b/exception_handler.py
@@ -1,0 +1,8 @@
+"""Stub for :mod:`piwardrive.exception_handler` when running from the repo."""
+from __future__ import annotations
+import os, sys
+SRC_PATH = os.path.join(os.path.dirname(__file__), "src")
+if SRC_PATH not in sys.path:
+    sys.path.insert(0, SRC_PATH)
+from piwardrive import exception_handler as _p  # noqa: E402
+from piwardrive.exception_handler import *  # noqa: F401,F403,E402

--- a/service.py
+++ b/service.py
@@ -14,11 +14,12 @@ SRC_PATH = os.path.join(os.path.dirname(__file__), "src")
 if SRC_PATH not in sys.path:
     sys.path.insert(0, SRC_PATH)
 
-from piwardrive import service as _p  # noqa: E402
-from piwardrive import orientation_sensors  # noqa: F401,E402
-
-# Re-export everything from the real module
-from piwardrive.service import *  # noqa: F401,F403,E402
+try:  # pragma: no cover - optional dependencies
+    from piwardrive import service as _p  # noqa: E402
+    from piwardrive import orientation_sensors  # noqa: F401,E402
+    from piwardrive.service import *  # noqa: F401,F403,E402
+except Exception:  # pragma: no cover - allow import without extras
+    _p = None
 
 
 def _proxy(name: str):
@@ -31,4 +32,5 @@ def _proxy(name: str):
 # Replace selected callables in the real module with proxies that defer to this
 # module's attributes.  This allows tests to patch ``service.load_recent_health``
 # without also patching ``piwardrive.service.load_recent_health``.
-_p.load_recent_health = _proxy("load_recent_health")  # type: ignore[attr-defined]
+if _p is not None:
+    _p.load_recent_health = _proxy("load_recent_health")  # type: ignore[attr-defined]

--- a/src/exception_handler.py
+++ b/src/exception_handler.py
@@ -1,0 +1,2 @@
+"""Compatibility wrapper for :mod:`piwardrive.exception_handler`."""
+from piwardrive.exception_handler import *  # noqa: F401,F403

--- a/src/piwardrive/__init__.py
+++ b/src/piwardrive/__init__.py
@@ -19,6 +19,8 @@ for _mod in (
     "orientation_sensors",
     "config",
     "sync",
+    "diagnostics",
+    "exception_handler",
 ):
     try:  # pragma: no cover - optional imports may fail
         module = import_module(f"piwardrive.{_mod}")

--- a/src/piwardrive/core/config.py
+++ b/src/piwardrive/core/config.py
@@ -242,7 +242,7 @@ def _parse_env_value(raw: str, default: Any) -> Any:
 
 def validate_config_data(data: Dict[str, Any]) -> None:
     """Validate configuration values using :class:`ConfigModel`."""
-        if data.get("remote_sync_url") == "":
+    if data.get("remote_sync_url") == "":
         data["remote_sync_url"] = None
     ConfigModel(**data)
 
@@ -380,11 +380,13 @@ class AppConfig:
     map_poll_gps_max: int = DEFAULTS["map_poll_gps_max"]
     map_poll_aps: int = DEFAULTS["map_poll_aps"]
     map_poll_bt: int = DEFAULTS["map_poll_bt"]
+    map_poll_wigle: int = DEFAULTS["map_poll_wigle"]
     map_show_gps: bool = DEFAULTS["map_show_gps"]
     map_follow_gps: bool = DEFAULTS["map_follow_gps"]
     map_show_aps: bool = DEFAULTS["map_show_aps"]
     map_show_bt: bool = DEFAULTS["map_show_bt"]
     map_show_heatmap: bool = DEFAULTS["map_show_heatmap"]
+    map_show_wigle: bool = DEFAULTS["map_show_wigle"]
     map_cluster_aps: bool = DEFAULTS["map_cluster_aps"]
     map_cluster_capacity: int = DEFAULTS["map_cluster_capacity"]
     map_use_offline: bool = DEFAULTS["map_use_offline"]

--- a/src/piwardrive/core/persistence.py
+++ b/src/piwardrive/core/persistence.py
@@ -155,7 +155,9 @@ class DashboardSettings:
 
 async def _init_db(conn: aiosqlite.Connection) -> None:
     """Create or migrate the SQLite schema to the latest version."""
-            await conn.execute("UPDATE schema_version SET version = ?", (current,))
+    await conn.execute(
+        "CREATE TABLE IF NOT EXISTS schema_version (version INTEGER)"
+    )
     cur = await conn.execute("SELECT version FROM schema_version")
     row = await cur.fetchone()
     current = row["version"] if row else 0
@@ -261,7 +263,7 @@ async def load_app_state() -> AppState:
 
 
 async def save_dashboard_settings(settings: DashboardSettings) -> None:
-   """Persist dashboard layout to ``config.json``."""
+    """Persist dashboard layout to ``config.json``."""
     cfg = config.load_config()
     cfg.dashboard_layout = settings.layout
     config.save_config(cfg)

--- a/src/piwardrive/core/utils.py
+++ b/src/piwardrive/core/utils.py
@@ -18,7 +18,10 @@ import glob
 from datetime import datetime
 from typing import Any, Callable, Coroutine, Iterable, Sequence, TypeVar
 
-from piwardrive.sigint_suite.models import BluetoothDevice
+try:  # pragma: no cover - optional dependency
+    from piwardrive.sigint_suite.models import BluetoothDevice
+except Exception:  # pragma: no cover - missing optional module
+    BluetoothDevice = object  # type: ignore[misc,assignment]
 from concurrent.futures import Future
 
 try:  # pragma: no cover - allow running without Kivy
@@ -40,7 +43,10 @@ from enum import IntEnum
 import psutil
 import requests  # type: ignore
 import requests_cache
-import aiohttp
+try:  # pragma: no cover - optional dependency
+    import aiohttp
+except Exception:  # pragma: no cover - allow running without aiohttp
+    aiohttp = None  # type: ignore
 from piwardrive import persistence
 
 GPSD_CACHE_SECONDS = 2.0  # cache ttl in seconds
@@ -1094,6 +1100,7 @@ def load_kml(path: str) -> list[dict[str, Any]]:
 
 
 __all__ = [
+    "App",
     "ErrorCode",
     "network_scanning_disabled",
     "shutdown_async_loop",

--- a/src/piwardrive/service.py
+++ b/src/piwardrive/service.py
@@ -7,17 +7,36 @@ import os
 import inspect
 import typing
 
-from fastapi import (
-    FastAPI,
-    Depends,
-    HTTPException,
-    WebSocket,
-    WebSocketDisconnect,
-    Body,
-    Request,
-)
-from fastapi.responses import StreamingResponse, Response
-from fastapi.security import HTTPBasic, HTTPBasicCredentials
+try:  # pragma: no cover - optional FastAPI dependency
+    from fastapi import (
+        FastAPI,
+        Depends,
+        HTTPException,
+        WebSocket,
+        WebSocketDisconnect,
+        Body,
+        Request,
+    )
+    from fastapi.responses import StreamingResponse, Response
+    from fastapi.security import HTTPBasic, HTTPBasicCredentials
+except Exception:
+    FastAPI = type(
+        "FastAPI",
+        (),
+        {
+            "get": lambda *a, **k: (lambda f: f),
+            "websocket": lambda *a, **k: (lambda f: f),
+        },
+    )
+    Depends = lambda *a, **k: None
+    HTTPException = type("HTTPException", (Exception,), {})
+    WebSocket = object
+    WebSocketDisconnect = Exception
+    Body = lambda *a, **k: None
+    Request = object
+    StreamingResponse = Response = object
+    HTTPBasic = type("HTTPBasic", (), {"__init__": lambda self, **k: None})
+    HTTPBasicCredentials = type("HTTPBasicCredentials", (), {})
 import importlib
 
 import asyncio

--- a/src/service.py
+++ b/src/service.py
@@ -1,0 +1,11 @@
+"""Compatibility wrapper for :mod:`piwardrive.service`."""
+
+from importlib import import_module
+
+try:  # pragma: no cover - optional dependency loading
+    _service = import_module("piwardrive.service")
+except Exception:  # pragma: no cover - allow import without extras
+    _service = None
+
+if _service is not None:
+    globals().update(_service.__dict__)


### PR DESCRIPTION
## Summary
- create compatibility modules for `service` and `exception_handler`
- add optional imports and fallbacks for missing dependencies
- extend app config fields
- expose more helpers at package level

## Testing
- `pytest tests/test_config_watcher.py tests/test_di.py tests/test_diagnostics.py tests/test_error_reporting.py tests/test_exception_handler.py tests/test_imports.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685cab7c6b0c83338ef91f556de65493