### PR TITLE
Add optional integrations

### DIFF
--- a/src/piwardrive/__init__.py
+++ b/src/piwardrive/__init__.py
@@ -8,6 +8,7 @@ import sys
 try:  # pragma: no cover - optional dependency
     sigint_suite = import_module("piwardrive.integrations.sigint_suite")
     sys.modules.setdefault("sigint_suite", sigint_suite)
+    sys.modules.setdefault(__name__ + ".sigint_suite", sigint_suite)
 except Exception:  # pragma: no cover - missing optional modules
     sigint_suite = None
 

--- a/src/piwardrive/integrations/sigint_suite/enrichment/oui.py
+++ b/src/piwardrive/integrations/sigint_suite/enrichment/oui.py
@@ -7,7 +7,14 @@ import time
 from functools import lru_cache
 from typing import Dict, Optional
 
-from piwardrive.utils import HTTP_SESSION
+try:  # pragma: no cover - optional dependency
+    from piwardrive.utils import HTTP_SESSION
+except Exception:  # pragma: no cover - minimal fallback
+    class _DummySession:
+        def get(self, *_a, **_k):  # pragma: no cover - simple stub
+            raise RuntimeError("HTTP session unavailable")
+
+    HTTP_SESSION = _DummySession()
 
 from sigint_suite import paths
 

--- a/src/piwardrive/integrations/wigle.py
+++ b/src/piwardrive/integrations/wigle.py
@@ -2,8 +2,17 @@
 
 from __future__ import annotations
 
-import aiohttp
 from typing import Any, Dict, List
+from types import SimpleNamespace
+
+try:  # pragma: no cover - optional dependency
+    import aiohttp
+except Exception:  # pragma: no cover - aiohttp not installed
+    aiohttp = SimpleNamespace(
+        BasicAuth=lambda *_a, **_k: None,
+        ClientTimeout=lambda *_a, **_k: None,
+        ClientSession=None,
+    )
 
 
 async def fetch_wigle_networks(
@@ -46,3 +55,6 @@ async def fetch_wigle_networks(
             }
         )
     return nets
+
+
+__all__ = ["fetch_wigle_networks", "aiohttp"]

--- a/src/piwardrive/r_integration.py
+++ b/src/piwardrive/r_integration.py
@@ -1,1 +1,22 @@
-from .integrations.r_integration import *
+"""Public entry points for R integrations."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, Optional
+
+
+def health_summary(path: str, plot_path: Optional[str] = None) -> Dict[str, float]:
+    """Return averages using ``health_summary.R`` via rpy2."""
+    try:
+        from rpy2 import robjects
+    except Exception as exc:  # pragma: no cover - rpy2 optional
+        raise RuntimeError("rpy2 is required for R integration") from exc
+
+    r_script = Path(__file__).parent / "scripts" / "health_summary.R"
+    robjects.r.source(str(r_script))
+    r_func = robjects.globalenv["health_summary"]
+    result = r_func(path, plot_path if plot_path is not None else robjects.NULL)
+    return dict(zip(result.names, map(float, list(result))))
+
+
+__all__ = ["health_summary"]

--- a/src/piwardrive/scripts/health_summary.R
+++ b/src/piwardrive/scripts/health_summary.R
@@ -1,0 +1,32 @@
+health_summary <- function(path, plot_path = NULL) {
+  if (grepl("\.json$", path)) {
+    library(jsonlite)
+    df <- jsonlite::read_json(path, simplifyVector = TRUE)
+    df <- as.data.frame(df)
+  } else {
+    df <- read.csv(path)
+  }
+  df$timestamp <- as.POSIXct(df$timestamp)
+  stats <- c(
+    temp_avg = mean(df$cpu_temp, na.rm = TRUE),
+    cpu_avg = mean(df$cpu_percent, na.rm = TRUE),
+    mem_avg = mean(df$memory_percent, na.rm = TRUE),
+    disk_avg = mean(df$disk_percent, na.rm = TRUE)
+  )
+  if (!is.null(plot_path)) {
+    library(ggplot2)
+    ggplot(df, aes(x = timestamp, y = cpu_temp)) +
+      geom_line() + theme_minimal() -> p
+    ggsave(plot_path, plot = p, width = 4, height = 2)
+  }
+  stats
+}
+
+if (!interactive()) {
+  args <- commandArgs(trailingOnly = TRUE)
+  if (length(args) < 1) {
+    stop('usage: Rscript health_summary.R <file> [plot.png]')
+  }
+  res <- health_summary(args[[1]], if (length(args) >= 2) args[[2]] else NULL)
+  print(res)
+}


### PR DESCRIPTION
## Summary
- support importing piwardrive.sigint_suite
- provide fallback HTTP session for vendor lookups
- allow wigle integration without aiohttp installed
- expose health_summary function and R script

## Testing
- `pytest -q tests/test_r_integration.py tests/test_vendor_lookup.py tests/test_wigle_integration.py`

------
https://chatgpt.com/codex/tasks/task_e_685cab9915fc83339e4f88cf72db924d