### PR TITLE
Implement CLI utilities and kiosk scripts

### DIFF
--- a/scripts/service_status.py
+++ b/scripts/service_status.py
@@ -1,8 +1,16 @@
-"""Module service_status."""
+"""Command line helper for checking systemd service status."""
 import argparse
 import json
+from types import SimpleNamespace
 
-from piwardrive import diagnostics
+
+def _get_service_statuses(services=None):
+    """Import :mod:`piwardrive.diagnostics` lazily and get statuses."""
+    from piwardrive import diagnostics as _diag
+    return _diag.get_service_statuses(services)
+
+
+diagnostics = SimpleNamespace(get_service_statuses=_get_service_statuses)
 
 
 def main(argv: list[str] | None = None) -> None:

--- a/scripts/start_kiosk.sh
+++ b/scripts/start_kiosk.sh
@@ -2,4 +2,7 @@
 # Start the web UI and API server then open Chromium in kiosk mode.
 set -euo pipefail
 
-piwardrive-kiosk "$@"
+# Resolve the directory of this script so it works both from source checkouts and
+# when installed system wide.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec python3 "$SCRIPT_DIR/kiosk.py" "$@"

--- a/scripts/tile_maintenance_cli.py
+++ b/scripts/tile_maintenance_cli.py
@@ -1,6 +1,34 @@
-"""Module tile_maintenance_cli."""
+"""Lightweight command line interface for tile cache maintenance."""
 import argparse
-from piwardrive import tile_maintenance
+from types import SimpleNamespace
+
+
+def purge_old_tiles(folder: str, days: int) -> None:
+    """Lazy wrapper around :func:`tile_maintenance.purge_old_tiles`."""
+    from piwardrive.map import tile_maintenance as tm  # heavy import deferred
+    tm.purge_old_tiles(folder, days)
+
+
+def enforce_cache_limit(folder: str, limit: int) -> None:
+    """Lazy wrapper around :func:`tile_maintenance.enforce_cache_limit`."""
+    from piwardrive.map import tile_maintenance as tm
+    tm.enforce_cache_limit(folder, limit)
+
+
+def vacuum_mbtiles(path: str) -> None:
+    """Lazy wrapper around :func:`tile_maintenance.vacuum_mbtiles`."""
+    from piwardrive.map import tile_maintenance as tm
+    tm.vacuum_mbtiles(path)
+
+
+# Object used by tests to monkey patch the maintenance functions without forcing
+# the optional heavy imports above.  The wrappers import the real implementations
+# only when executed.
+tile_maintenance = SimpleNamespace(
+    purge_old_tiles=purge_old_tiles,
+    enforce_cache_limit=enforce_cache_limit,
+    vacuum_mbtiles=vacuum_mbtiles,
+)
 
 
 def main(argv: list[str] | None = None) -> None:

--- a/src/piwardrive/scripts/__init__.py
+++ b/src/piwardrive/scripts/__init__.py
@@ -2,8 +2,17 @@
 import os
 import sys
 
+# ``piwardrive.scripts`` acts as a thin wrapper around the top level ``scripts``
+# directory that contains the actual CLI implementations.  Historically the
+# project used a `src` layout which places the package under ``src/piwardrive``
+# while CLI utilities live in ``scripts`` at the repository root.  The previous
+# path calculation accidentally pointed to ``src/scripts`` which does not exist
+# resulting in ``ModuleNotFoundError`` when importing submodules such as
+# ``piwardrive.scripts.tile_maintenance_cli``.  Compute the correct path by
+# navigating four directories upwards from this file to reach the repository
+# root and then appending ``scripts``.
 SCRIPTS_DIR = os.path.normpath(
-    os.path.join(os.path.dirname(os.path.dirname(__file__)), "..", "scripts")
+    os.path.join(os.path.dirname(__file__), "..", "..", "..", "scripts")
 )
 if SCRIPTS_DIR not in sys.path:
     sys.path.insert(0, SCRIPTS_DIR)


### PR DESCRIPTION
## Summary
- provide lazy importing for CLI wrappers
- point internal scripts package to actual CLI directory
- update `start_kiosk.sh` to launch python CLI directly

## Testing
- `pytest -q tests/test_kiosk_cli.py::test_kiosk_cli_launches_browser tests/test_start_kiosk_script.py::test_start_kiosk_launches_browser tests/test_tile_maintenance_cli.py::test_tile_maintenance_cli tests/test_service_status_script.py::test_service_status_script_output`

------
https://chatgpt.com/codex/tasks/task_e_685caba3554483339ddca0da0325cd18