### PR TITLE
Implement SIGINT suite wrapper and plugin reload

### DIFF
--- a/src/piwardrive/integrations/sigint_suite/bluetooth/scanner.py
+++ b/src/piwardrive/integrations/sigint_suite/bluetooth/scanner.py
@@ -7,7 +7,7 @@ import contextlib
 from typing import Dict, List
 
 
-from sigint_suite.models import BluetoothDevice
+from piwardrive.sigint_suite.models import BluetoothDevice
 
 logger = logging.getLogger(__name__)
 

--- a/src/piwardrive/integrations/sigint_suite/cellular/band_scanner/scanner.py
+++ b/src/piwardrive/integrations/sigint_suite/cellular/band_scanner/scanner.py
@@ -7,8 +7,8 @@ import asyncio
 from typing import List, Optional
 
 
-from sigint_suite.cellular.parsers import parse_band_output
-from sigint_suite.models import BandRecord
+from piwardrive.sigint_suite.cellular.parsers import parse_band_output
+from piwardrive.sigint_suite.models import BandRecord
 
 logger = logging.getLogger(__name__)
 

--- a/src/piwardrive/integrations/sigint_suite/cellular/imsi_catcher/scanner.py
+++ b/src/piwardrive/integrations/sigint_suite/cellular/imsi_catcher/scanner.py
@@ -6,10 +6,10 @@ import logging
 import asyncio
 from typing import Callable, List, Optional
 
-from sigint_suite.models import ImsiRecord
-from sigint_suite.cellular.parsers import parse_imsi_output
-from sigint_suite.gps import get_position
-from sigint_suite.hooks import apply_post_processors
+from piwardrive.sigint_suite.models import ImsiRecord
+from piwardrive.sigint_suite.cellular.parsers import parse_imsi_output
+from piwardrive.sigint_suite.gps import get_position
+from piwardrive.sigint_suite.hooks import apply_post_processors
 
 logger = logging.getLogger(__name__)
 

--- a/src/piwardrive/integrations/sigint_suite/cellular/parsers/__init__.py
+++ b/src/piwardrive/integrations/sigint_suite/cellular/parsers/__init__.py
@@ -2,7 +2,7 @@
 
 from typing import List
 
-from sigint_suite.models import BandRecord, ImsiRecord, TowerRecord
+from piwardrive.sigint_suite.models import BandRecord, ImsiRecord, TowerRecord
 
 
 def parse_band_output(output: str) -> List[BandRecord]:

--- a/src/piwardrive/integrations/sigint_suite/cellular/tower_scanner/scanner.py
+++ b/src/piwardrive/integrations/sigint_suite/cellular/tower_scanner/scanner.py
@@ -5,10 +5,10 @@ import shlex
 import subprocess
 from typing import List, Optional
 
-from sigint_suite.cellular.parsers import parse_tower_output
-from sigint_suite.models import TowerRecord
-from sigint_suite.gps import get_position
-from sigint_suite.hooks import apply_post_processors
+from piwardrive.sigint_suite.cellular.parsers import parse_tower_output
+from piwardrive.sigint_suite.models import TowerRecord
+from piwardrive.sigint_suite.gps import get_position
+from piwardrive.sigint_suite.hooks import apply_post_processors
 
 logger = logging.getLogger(__name__)
 

--- a/src/piwardrive/integrations/sigint_suite/enrichment/oui.py
+++ b/src/piwardrive/integrations/sigint_suite/enrichment/oui.py
@@ -9,7 +9,7 @@ from typing import Dict, Optional
 
 from piwardrive.utils import HTTP_SESSION
 
-from sigint_suite import paths
+from piwardrive.sigint_suite import paths
 
 # Persist the OUI registry under the main configuration directory
 OUI_PATH = paths.OUI_PATH

--- a/src/piwardrive/integrations/sigint_suite/wifi/scanner.py
+++ b/src/piwardrive/integrations/sigint_suite/wifi/scanner.py
@@ -6,9 +6,9 @@ import subprocess
 import asyncio
 
 from typing import Dict, List, Optional
-from sigint_suite.enrichment import cached_lookup_vendor
-from sigint_suite.models import WifiNetwork
-from sigint_suite.hooks import apply_post_processors, register_post_processor
+from piwardrive.sigint_suite.enrichment import cached_lookup_vendor
+from piwardrive.sigint_suite.models import WifiNetwork
+from piwardrive.sigint_suite.hooks import apply_post_processors, register_post_processor
 from piwardrive import orientation_sensors
 
 logger = logging.getLogger(__name__)

--- a/src/piwardrive/sigint_suite/__init__.py
+++ b/src/piwardrive/sigint_suite/__init__.py
@@ -1,0 +1,47 @@
+"""SIGINT suite compatibility wrapper."""
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+from types import ModuleType
+from typing import Any
+
+# Import the actual implementation from piwardrive.integrations.sigint_suite
+_impl: ModuleType = importlib.import_module("piwardrive.integrations.sigint_suite")
+
+# Reload paths to pick up environment changes (e.g. HOME) that may occur between
+# imports during tests.
+_paths_mod = importlib.reload(importlib.import_module("piwardrive.integrations.sigint_suite.paths"))
+_impl.paths = _paths_mod
+sys.modules[__name__ + ".paths"] = _paths_mod
+
+if hasattr(_impl, "plugins"):
+    # Ensure the plugin loader uses the updated configuration directory
+    _impl.plugins.CONFIG_DIR = _paths_mod.CONFIG_DIR
+
+# Reload plugins each time the wrapper is imported so that tests manipulating the
+# configuration directory get a fresh view.
+if hasattr(_impl, "plugins"):
+    _impl.plugins.clear_plugin_cache()
+    _impl.plugins._load_plugins()
+
+# Expose this compatibility wrapper under the original top-level package name so
+# that modules inside ``sigint_suite`` using absolute imports (e.g.
+# ``from sigint_suite.hooks import ...``) resolve to this package. This ensures
+# a single module instance is used regardless of whether callers import
+# ``sigint_suite`` or ``piwardrive.sigint_suite``.
+sys.modules.setdefault("sigint_suite", sys.modules[__name__])
+
+# Expose package submodules by extending __path__ to include the implementation
+# package directory. This allows ``piwardrive.sigint_suite.<mod>`` imports to
+# resolve to modules under ``piwardrive.integrations.sigint_suite``.
+_pkg_dir = os.path.join(os.path.dirname(__file__), os.pardir, "integrations", "sigint_suite")
+if os.path.isdir(_pkg_dir) and _pkg_dir not in __path__:
+    __path__.append(_pkg_dir)
+
+__all__ = list(getattr(_impl, "__all__", []))
+
+
+def __getattr__(name: str) -> Any:
+    return getattr(_impl, name)


### PR DESCRIPTION
## Summary
- provide `piwardrive.sigint_suite` compatibility wrapper
- reload configuration and plugins on import so tests can manipulate environment
- update SIGINT modules to use the new package path

## Testing
- `pytest tests/test_imsi_catcher.py tests/test_rf_utils.py tests/test_sigint_export_json.py tests/test_sigint_exports.py tests/test_sigint_integration.py tests/test_sigint_plugins.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685cab9e937c833387bbe572abee2a12