### PR TITLE
Refactor Wi-Fi scanner parsing

### DIFF
--- a/tests/test_wifi_scanner.py
+++ b/tests/test_wifi_scanner.py
@@ -1,8 +1,10 @@
 import os
+import asyncio
 import sys
+import pytest
 
 
-from piwardrive.sigint_suite.wifi.scanner import scan_wifi
+from piwardrive.sigint_suite.wifi.scanner import async_scan_wifi, scan_wifi
 
 
 def _mock_lookup_vendor(bssid: str):
@@ -68,3 +70,40 @@ Cell 01 - Address: AA:BB:CC:DD:EE:FF
     assert nets[0].channel == "6"
     assert nets[0].encryption == "on"
     assert nets[0].heading is None
+
+
+def test_async_scan_wifi(monkeypatch):
+    output = """
+Cell 01 - Address: AA:BB:CC:DD:EE:FF
+          ESSID:"TestNet"
+          Frequency:2.437 GHz (Channel 6)
+          Encryption key:on
+          IE: WPA Version 1
+          Quality=70/70  Signal level=-40 dBm
+Cell 02 - Address: 11:22:33:44:55:66
+          ESSID:"OpenNet"
+          Frequency:2.422 GHz (Channel 3)
+          Encryption key:off
+          Quality=20/70  Signal level=-90 dBm
+"""
+
+    async def dummy_proc(*_a, **_k):
+        class P:
+            async def communicate(self):
+                return (output.encode(), b"")
+
+        return P()
+
+    monkeypatch.setattr("asyncio.create_subprocess_exec", dummy_proc)
+    monkeypatch.setattr(
+        "piwardrive.sigint_suite.wifi.scanner.lookup_vendor", _mock_lookup_vendor
+    )
+    monkeypatch.setattr(
+        "piwardrive.sigint_suite.wifi.scanner.orientation_sensors.get_heading",
+        lambda: 90.0,
+    )
+
+    nets = asyncio.run(async_scan_wifi("wlan0"))
+    assert nets[0].vendor == "VendorA"
+    assert nets[1].vendor == "VendorB"
+    assert nets[0].heading == 90.0


### PR DESCRIPTION
## Summary
- add `lookup_vendor` alias for tests
- factor Wi-Fi scanning text parsing into `_parse_iwlist_output`
- reuse the helper from `scan_wifi` and `async_scan_wifi`
- extend tests to cover the async scanner

## Testing
- `pytest tests/test_wifi_scanner.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685dba577f64833380cf826bb0834e43