### PR TITLE
Add JS widget cache

### DIFF
--- a/webui/src/pluginLoader.js
+++ b/webui/src/pluginLoader.js
@@ -1,16 +1,5 @@
+import { loadPlugins } from './widgetCache.js';
+
 export async function loadPluginComponents(names, modules) {
-  const loaded = [];
-  for (const name of names) {
-    const path = `./components/${name}.jsx`;
-    const importer = modules[path];
-    if (importer) {
-      try {
-        const mod = await importer();
-        loaded.push({ name, Component: mod.default });
-      } catch {
-        // ignore failed import
-      }
-    }
-  }
-  return loaded;
+  return loadPlugins(names, modules);
 }

--- a/webui/src/widgetCache.js
+++ b/webui/src/widgetCache.js
@@ -1,0 +1,26 @@
+export const _cache = {};
+
+export async function loadPlugins(names = [], modules = {}) {
+  const loaded = [];
+  for (const name of names) {
+    if (name in _cache) {
+      loaded.push({ name, Component: _cache[name] });
+      continue;
+    }
+    const importer = modules[`./components/${name}.jsx`];
+    if (importer) {
+      try {
+        const mod = await importer();
+        _cache[name] = mod.default;
+        loaded.push({ name, Component: mod.default });
+      } catch {
+        // ignore failed import
+      }
+    }
+  }
+  return loaded;
+}
+
+export function clearCache() {
+  for (const key in _cache) delete _cache[key];
+}

--- a/webui/tests/widgetCache.test.js
+++ b/webui/tests/widgetCache.test.js
@@ -1,0 +1,19 @@
+import { describe, it, expect, vi } from 'vitest';
+import { loadPlugins, clearCache, _cache } from '../src/widgetCache.js';
+
+const modules = {
+  './components/TestWidget.jsx': vi.fn(async () => ({ default: () => 'plug' }))
+};
+
+describe('widget cache', () => {
+  it('caches loaded plugins', async () => {
+    await loadPlugins(['TestWidget'], modules);
+    expect(modules['./components/TestWidget.jsx']).toHaveBeenCalledTimes(1);
+    await loadPlugins(['TestWidget'], modules);
+    expect(modules['./components/TestWidget.jsx']).toHaveBeenCalledTimes(1);
+    expect(_cache.TestWidget).toBeDefined();
+    clearCache();
+    await loadPlugins(['TestWidget'], modules);
+    expect(modules['./components/TestWidget.jsx']).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Summary
- add widgetCache.js to cache plugin components
- delegate pluginLoader.js to the new cache
- test widget cache behaviour

## Testing
- `npm install --legacy-peer-deps`
- `npm test --silent` *(fails: gpsd library missing and other import errors)*

------
https://chatgpt.com/codex/tasks/task_e_685dbb03a4a08333bda3578f328f720f