### PR TITLE
Add JS scripts for service sync and log export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ logs/
 
 build/
 ckml*.so
+node_modules/
 webui/node_modules/
 webui/dist/
 webui/package-lock.json

--- a/scripts/exportLogs.js
+++ b/scripts/exportLogs.js
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+// Export recent log lines and optionally upload them.
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+function defaultLogPath() {
+  return path.join(os.homedir(), '.config', 'piwardrive', 'app.log');
+}
+
+function tailLines(file, count) {
+  const data = fs.readFileSync(file, 'utf8').split('\n');
+  return data.slice(-count).join('\n');
+}
+
+function saveLogs(lines, outPath) {
+  fs.writeFileSync(outPath, lines, 'utf8');
+  return outPath;
+}
+
+async function uploadFile(file, url) {
+  const buf = fs.readFileSync(file);
+  const form = new FormData();
+  form.append('file', new Blob([buf]), path.basename(file));
+  const resp = await fetch(url, { method: 'POST', body: form });
+  if (!resp.ok) throw new Error(`upload failed: ${resp.status}`);
+  return true;
+}
+
+function parseArgs(argv) {
+  const args = { lines: 200 };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--output') args.output = argv[++i];
+    else if (a === '--lines' || a === '-n') args.lines = parseInt(argv[++i], 10);
+    else if (a === '--upload') args.upload = argv[++i];
+  }
+  return args;
+}
+
+async function run(argv = process.argv.slice(2), helpers = {}) {
+  const opts = {
+    defaultLogPath,
+    tailLines,
+    saveLogs,
+    uploadFile,
+    ...helpers,
+  };
+
+  const args = parseArgs(argv);
+
+  const outPath = args.output || path.join(os.tmpdir(), `logs-${Date.now()}.txt`);
+  const logPath = opts.defaultLogPath();
+  const data = opts.tailLines(logPath, args.lines);
+  opts.saveLogs(data, outPath);
+
+  if (args.upload) {
+    await opts.uploadFile(outPath, args.upload);
+    return { uploaded: true };
+  }
+  return { path: outPath };
+}
+
+if (require.main === module) {
+  run().then(r => {
+    console.log(JSON.stringify(r));
+  }).catch(err => {
+    console.error(err.message);
+    process.exit(1);
+  });
+}
+
+module.exports = { run, tailLines, saveLogs, uploadFile, defaultLogPath };

--- a/scripts/serviceSync.js
+++ b/scripts/serviceSync.js
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+// Minimal utility for syncing a database file and reporting service status.
+// Usage: node serviceSync.js --db path --url url --services svc1 svc2
+
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+async function uploadDb(dbPath, url) {
+  const data = fs.readFileSync(dbPath);
+  const form = new FormData();
+  form.append('file', new Blob([data]), path.basename(dbPath));
+  const resp = await fetch(url, { method: 'POST', body: form });
+  if (!resp.ok) throw new Error(`upload failed: ${resp.status}`);
+  return true;
+}
+
+function checkStatus(service) {
+  try {
+    execSync(`systemctl is-active --quiet ${service}`);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function parseArgs(argv) {
+  const args = { services: [] };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--db') args.db = argv[++i];
+    else if (a === '--url') args.url = argv[++i];
+    else if (a === '--services') {
+      while (argv[i + 1] && !argv[i + 1].startsWith('--')) {
+        args.services.push(argv[++i]);
+      }
+    }
+  }
+  return args;
+}
+
+async function run(argv = process.argv.slice(2), helpers = {}) {
+  const opts = { uploadDb, checkStatus, ...helpers };
+
+  const args = parseArgs(argv);
+
+  if ((args.db && !args.url) || (!args.db && args.url)) {
+    throw new Error('db and url must be provided together');
+  }
+
+  const result = {};
+
+  if (args.services.length) {
+    result.status = {};
+    for (const svc of args.services) {
+      result.status[svc] = opts.checkStatus(svc);
+    }
+  }
+
+  if (args.db && args.url) {
+    await opts.uploadDb(args.db, args.url);
+    result.synced = true;
+  }
+
+  return result;
+}
+
+if (require.main === module) {
+  run().then(r => {
+    console.log(JSON.stringify(r));
+  }).catch(err => {
+    console.error(err.message);
+    process.exit(1);
+  });
+}
+
+module.exports = { run, uploadDb, checkStatus };

--- a/tests/exportLogsScript.test.js
+++ b/tests/exportLogsScript.test.js
@@ -1,0 +1,35 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const ex = require('../scripts/exportLogs.js');
+
+test('writes logs and uploads', async () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'logs-'));
+  const log = path.join(tmp, 'app.log');
+  fs.writeFileSync(log, '1\n2\n3');
+  let uploaded = null;
+  const res = await ex.run(
+    ['--lines', '2', '--upload', 'http://remote', '--output', path.join(tmp,'out.txt')],
+    {
+      defaultLogPath: () => log,
+      uploadFile: async (file, url) => { uploaded = { file, url }; },
+    },
+  );
+  assert.ok(fs.existsSync(path.join(tmp,'out.txt')));
+  const out = fs.readFileSync(path.join(tmp,'out.txt'),'utf8');
+  assert.equal(out, '2\n3');
+  assert.deepStrictEqual(uploaded.url, 'http://remote');
+  assert.deepStrictEqual(res, { uploaded: true });
+});
+
+test('returns path when not uploading', async () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'logs-'));
+  const log = path.join(tmp, 'app.log');
+  fs.writeFileSync(log, 'a\nb\nc');
+  const res = await ex.run(['-n','1','--output',path.join(tmp,'out.txt')], { defaultLogPath: () => log });
+  assert.equal(res.path.endsWith('out.txt'), true);
+  const out = fs.readFileSync(res.path,'utf8');
+  assert.equal(out, 'c');
+});

--- a/tests/serviceSync.test.js
+++ b/tests/serviceSync.test.js
@@ -1,0 +1,27 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const svc = require('../scripts/serviceSync.js');
+
+// helper to run run() and capture result
+
+test('parses options and uploads', async () => {
+  let uploaded = null;
+  const res = await svc.run(
+    ['--db', 'file.db', '--url', 'http://x', '--services', 'a', 'b'],
+    {
+      uploadDb: async (db, url) => { uploaded = { db, url }; },
+      checkStatus: () => true,
+    },
+  );
+  assert.deepStrictEqual(uploaded, { db: 'file.db', url: 'http://x' });
+  assert.deepStrictEqual(res, { synced: true, status: { a: true, b: true } });
+});
+
+test('errors when only db provided', async () => {
+  try {
+    await svc.run(['--db', 'only.db']);
+    assert.fail('should throw');
+  } catch (err) {
+    assert.ok(err instanceof Error);
+  }
+});


### PR DESCRIPTION
## Summary
- add `serviceSync.js` for syncing DB files and checking service status
- add `exportLogs.js` for bundling and uploading log data
- ignore `node_modules/`
- test option parsing and failure cases for the new utilities

## Testing
- `node --test tests/serviceSync.test.js tests/exportLogsScript.test.js`
- `pytest -q tests/test_export_logs_script.py tests/test_service_status_script.py`


------
https://chatgpt.com/codex/tasks/task_e_685dbb02f3008333b2a5cc7c20a98e0e