### PR TITLE
Add Express server with basic auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,8 +271,9 @@ newer is required for the build tools. From the repository root run:
 cd webui
 npm install
 npm run build
-cd ..
-python -m piwardrive.webui_server
+npm start  # starts the Node server
+# or use the Python version
+# python -m piwardrive.webui_server
 ```
 To autostart the dashboard on boot copy `examples/piwardrive-webui.service` into `/etc/systemd/system/` and enable it with `sudo systemctl enable --now piwardrive-webui.service`.
 

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,83 @@
+const express = require('express');
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+
+function verifyPassword(password, hashed) {
+  try {
+    const data = Buffer.from(hashed, 'base64');
+    const salt = data.slice(0, 16);
+    const digest = data.slice(16);
+    const check = crypto.pbkdf2Sync(password, salt, 100000, digest.length, 'sha256');
+    return crypto.timingSafeEqual(check, digest);
+  } catch {
+    return false;
+  }
+}
+
+function basicAuth(req, res, next) {
+  const pwHash = process.env.PW_API_PASSWORD_HASH;
+  if (!pwHash) return next();
+  const header = req.headers.authorization || '';
+  if (!header.startsWith('Basic ')) {
+    res.set('WWW-Authenticate', 'Basic');
+    return res.status(401).end();
+  }
+  const decoded = Buffer.from(header.slice(6), 'base64').toString();
+  const password = decoded.split(':')[1] || '';
+  if (!verifyPassword(password, pwHash)) {
+    res.set('WWW-Authenticate', 'Basic');
+    return res.status(401).end();
+  }
+  next();
+}
+
+function parseWidgets() {
+  const file = path.join(__dirname, '..', 'src', 'piwardrive', 'widgets', '__init__.py');
+  try {
+    const text = fs.readFileSync(file, 'utf8');
+    const start = text.indexOf('__all__');
+    if (start === -1) return [];
+    const section = text.slice(start, text.indexOf(']', start));
+    return Array.from(section.matchAll(/"([^"]+)"/g)).map(m => m[1]);
+  } catch {
+    return [];
+  }
+}
+
+function createServer(opts = {}) {
+  const distDir = opts.distDir || path.join(__dirname, '..', 'webui', 'dist');
+  const healthFile = opts.healthFile || process.env.PW_HEALTH_FILE;
+  const app = express();
+
+  app.use('/api', basicAuth);
+  app.use(express.static(distDir));
+
+  function loadHealth() {
+    if (!healthFile) return [];
+    try {
+      return JSON.parse(fs.readFileSync(healthFile, 'utf8'));
+    } catch {
+      return [];
+    }
+  }
+
+  app.get('/api/status', (req, res) => {
+    res.json(loadHealth());
+  });
+
+  app.get('/api/widgets', (req, res) => {
+    res.json({ widgets: parseWidgets() });
+  });
+
+  return app;
+}
+
+if (require.main === module) {
+  const port = process.env.PORT || 8000;
+  createServer().listen(port, () => {
+    console.log(`Server listening on ${port}`);
+  });
+}
+
+module.exports = { createServer };

--- a/webui/README.md
+++ b/webui/README.md
@@ -59,7 +59,8 @@ Return to the repository root and run the bundled server. It serves the API unde
 
 ```bash
 cd ..
-python -m piwardrive.webui_server
+npm start  # launches the Node server
+# python -m piwardrive.webui_server  # alternative Python version
 ```
 
 Open a browser and navigate to `http://localhost:8000`. You should see the dashboard showing live system metrics. The server listens on all interfaces so other devices on the network may connect using the Pi's IP address.

--- a/webui/package.json
+++ b/webui/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "start": "vite preview",
+    "start": "node ../server/index.js",
     "test": "vitest run"
   },
   "dependencies": {

--- a/webui/tests/server.test.js
+++ b/webui/tests/server.test.js
@@ -1,0 +1,68 @@
+// @vitest-environment node
+import { describe, it, beforeAll, afterAll, expect } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import crypto from 'crypto';
+import { createServer } from '../../server/index.js';
+
+const PORT = 9123;
+let server;
+let tmpDir;
+let healthFile;
+let distDir;
+
+function hashPassword(password) {
+  const salt = crypto.randomBytes(16);
+  const digest = crypto.pbkdf2Sync(password, salt, 100000, 32, 'sha256');
+  return Buffer.concat([salt, digest]).toString('base64');
+}
+
+beforeAll(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'srv-'));
+  distDir = path.join(tmpDir, 'dist');
+  fs.mkdirSync(distDir);
+  fs.writeFileSync(path.join(distDir, 'index.html'), '<h1>hello</h1>');
+  healthFile = path.join(tmpDir, 'health.json');
+  fs.writeFileSync(healthFile, JSON.stringify([{ timestamp: 't1' }]));
+  process.env.PW_API_PASSWORD_HASH = hashPassword('pw');
+  server = createServer({ distDir, healthFile }).listen(PORT);
+});
+
+afterAll(() => {
+  server.close();
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+  delete process.env.PW_API_PASSWORD_HASH;
+});
+
+describe('node server', () => {
+  it('serves static files', async () => {
+    const res = await fetch(`http://127.0.0.1:${PORT}/`);
+    expect(res.status).toBe(200);
+    expect(await res.text()).toContain('hello');
+  });
+
+  it('requires auth for API', async () => {
+    const res = await fetch(`http://127.0.0.1:${PORT}/api/status`);
+    expect(res.status).toBe(401);
+  });
+
+  it('returns health records with auth', async () => {
+    const hdr = 'Basic ' + Buffer.from('u:pw').toString('base64');
+    const res = await fetch(`http://127.0.0.1:${PORT}/api/status`, {
+      headers: { Authorization: hdr },
+    });
+    const data = await res.json();
+    expect(data[0].timestamp).toBe('t1');
+  });
+
+  it('lists widgets', async () => {
+    const hdr = 'Basic ' + Buffer.from('u:pw').toString('base64');
+    const res = await fetch(`http://127.0.0.1:${PORT}/api/widgets`, {
+      headers: { Authorization: hdr },
+    });
+    const data = await res.json();
+    expect(Array.isArray(data.widgets)).toBe(true);
+    expect(data.widgets.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary
- implement `server/index.js` to serve static files and API routes
- test server functionality with new `server.test.js`
- add start script in webui package.json
- document new Node server usage in README files

## Testing
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685dbb059fe08333a2d765e6cf7ea3dd