### PR TITLE
Add global error handler for web ui

### DIFF
--- a/webui/src/App.jsx
+++ b/webui/src/App.jsx
@@ -2,6 +2,7 @@
 // loaded dynamically by name. Plugin authors should place React components under
 // `webui/src/components` with file names matching the Python class names.
 import { useEffect, useState } from "react";
+import { reportError } from "./exceptionHandler.js";
 import BatteryStatus from "./components/BatteryStatus.jsx";
 import ServiceStatus from "./components/ServiceStatus.jsx";
 import HandshakeCount from "./components/HandshakeCount.jsx";
@@ -55,7 +56,7 @@ export default function App() {
         if (data.status) setStatus(data.status);
         if (data.metrics) setMetrics(data.metrics);
       } catch (e) {
-        console.error("status parse error", e);
+        reportError(e);
       }
     };
 
@@ -136,7 +137,7 @@ export default function App() {
             const mod = await importer();
             loaded.push({ name, Component: mod.default });
           } catch (err) {
-            console.error('Failed loading plugin component', name, err);
+            reportError(err);
           }
         }
       }

--- a/webui/src/components/HeatmapLayer.jsx
+++ b/webui/src/components/HeatmapLayer.jsx
@@ -1,5 +1,6 @@
 import { useEffect } from 'react';
 import { useMap } from 'react-leaflet';
+import { reportError } from '../exceptionHandler.js';
 import 'leaflet.heat';
 
 export default function HeatmapLayer({ show }) {
@@ -14,7 +15,7 @@ export default function HeatmapLayer({ show }) {
         const pts = (data.points || []).map(([lat, lon, cnt]) => [lat, lon, cnt]);
         layer = window.L.heatLayer(pts, { radius: 25 }).addTo(map);
       } catch (e) {
-        console.error('heatmap load error', e);
+        reportError(e);
       }
     };
     load();

--- a/webui/src/components/MapScreen.jsx
+++ b/webui/src/components/MapScreen.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
+import { reportError } from '../exceptionHandler.js';
 import { MapContainer, TileLayer, Marker, Popup, Polygon } from 'react-leaflet';
 import HeatmapLayer from './HeatmapLayer.jsx';
 import 'leaflet/dist/leaflet.css';
@@ -62,7 +63,7 @@ export default function MapScreen() {
     fetch('/config')
       .then(r => r.json())
       .then(setConfig)
-      .catch(e => console.error('config fetch failed', e));
+      .catch(e => reportError(e));
   }, []);
 
   useEffect(() => {
@@ -126,7 +127,7 @@ export default function MapScreen() {
           }
         }
       } catch (e) {
-        console.error('gps fetch failed', e);
+        reportError(e);
       }
       if (active) timer.current = setTimeout(poll, interval);
     };
@@ -150,7 +151,7 @@ export default function MapScreen() {
         }));
         setAps(markers);
       } catch (e) {
-        console.error('ap fetch error', e);
+        reportError(e);
       }
     };
     load();
@@ -180,7 +181,7 @@ export default function MapScreen() {
           });
         }
       } catch (e) {
-        console.error('ap stream parse error', e);
+        reportError(e);
       }
     };
 

--- a/webui/src/components/TrackMap.jsx
+++ b/webui/src/components/TrackMap.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
+import { reportError } from '../exceptionHandler.js';
 import { MapContainer, TileLayer, Marker, Popup, Polyline } from 'react-leaflet';
 import HeatmapLayer from './HeatmapLayer.jsx';
 import 'leaflet/dist/leaflet.css';
@@ -37,7 +38,7 @@ export default function TrackMap() {
           forceUpdate(n => n + 1);
         }
       } catch (e) {
-        console.error('gps fetch failed', e);
+        reportError(e);
       }
     }, 5000);
     return () => clearInterval(id);
@@ -56,7 +57,7 @@ export default function TrackMap() {
         }));
         setAps(markers);
       } catch (e) {
-        console.error('ap fetch error', e);
+        reportError(e);
       }
     };
     load();
@@ -75,7 +76,7 @@ export default function TrackMap() {
         }));
         setBts(markers);
       } catch (e) {
-        console.error('bt fetch error', e);
+        reportError(e);
       }
     };
     load();
@@ -98,7 +99,7 @@ export default function TrackMap() {
           });
         }
       } catch (e) {
-        console.error('ap stream parse error', e);
+        reportError(e);
       }
     };
 

--- a/webui/src/exceptionHandler.js
+++ b/webui/src/exceptionHandler.js
@@ -1,0 +1,26 @@
+import { setupLogging } from './logconfig.js';
+
+let installed = false;
+let logger = null;
+
+export function reportError(err, alertUser = false) {
+  if (!logger) {
+    logger = setupLogging({ logFile: 'webui-errors.log' });
+  }
+  const message = err && err.message ? err.message : String(err);
+  logger.error(message);
+  if (alertUser) {
+    alert(message);
+  }
+}
+
+export function install({ alertUser = false } = {}) {
+  if (installed) return;
+  installed = true;
+  window.onerror = function (msg, src, line, col, error) {
+    reportError(error || msg, alertUser);
+  };
+  window.addEventListener('unhandledrejection', e => {
+    reportError(e.reason, alertUser);
+  });
+}

--- a/webui/src/main.jsx
+++ b/webui/src/main.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import { install } from './exceptionHandler.js';
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import App from './App.jsx';
 import ConsoleView from './components/ConsoleView.jsx';
@@ -13,6 +14,8 @@ import SettingsForm from './components/SettingsForm.jsx';
 import SplitView from './components/SplitView.jsx';
 import NavBar from './components/NavBar.jsx';
 import HealthImport from './components/HealthImport.jsx';
+
+install();
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>

--- a/webui/src/orientationSensors.js
+++ b/webui/src/orientationSensors.js
@@ -1,3 +1,5 @@
+import { reportError } from './exceptionHandler.js';
+
 export const DEFAULT_ORIENTATION_MAP = {
   normal: 0.0,
   'bottom-up': 180.0,
@@ -54,7 +56,7 @@ export function getOrientationDbus() {
       iface.ReleaseAccelerometer();
     }
   } catch (e) {
-    console.error('DBus orientation read failed:', e);
+    reportError(e);
     return null;
   }
 }
@@ -68,7 +70,7 @@ export function readMpu6050(address = 0x68) {
       gyroscope: sensor.get_gyro_data(),
     };
   } catch (e) {
-    console.error('MPU6050 read failed:', e);
+    reportError(e);
     return null;
   }
 }

--- a/webui/src/ouiRegistry.js
+++ b/webui/src/ouiRegistry.js
@@ -1,3 +1,5 @@
+import { reportError } from './exceptionHandler.js';
+
 let OUI_MAP = null;
 export const DEFAULT_OUI_URL = '/oui.csv';
 
@@ -16,7 +18,7 @@ export async function loadOuiMap(url = DEFAULT_OUI_URL) {
     OUI_MAP = map;
     return map;
   } catch (e) {
-    console.error('OUI map load failed:', e);
+    reportError(e);
     OUI_MAP = {};
     return OUI_MAP;
   }

--- a/webui/src/serviceControl.js
+++ b/webui/src/serviceControl.js
@@ -1,3 +1,5 @@
+import { reportError } from './exceptionHandler.js';
+
 export async function controlService(service, action) {
   let password = sessionStorage.getItem('adminPassword') || null;
   const headers = {};
@@ -7,7 +9,7 @@ export async function controlService(service, action) {
   try {
     resp = await fetch(`/service/${service}/${action}`, { method: 'POST', headers });
   } catch (e) {
-    alert(`Failed to ${action} ${service}`);
+    reportError(e, true);
     return false;
   }
   if (resp.status === 401) {
@@ -17,7 +19,7 @@ export async function controlService(service, action) {
     resp = await fetch(`/service/${service}/${action}`, { method: 'POST', headers: { 'X-Admin-Password': password } });
   }
   if (!resp.ok) {
-    alert(`Failed to ${action} ${service}`);
+    reportError(new Error(`Failed to ${action} ${service}`), true);
     return false;
   }
   return true;

--- a/webui/src/vehicleSensors.js
+++ b/webui/src/vehicleSensors.js
@@ -1,3 +1,5 @@
+import { reportError } from './exceptionHandler.js';
+
 export let obd = null;
 
 export function readSpeedObd(port = null) {
@@ -7,7 +9,7 @@ export function readSpeedObd(port = null) {
     const rsp = conn.query(obd.commands.SPEED);
     return rsp && rsp.value != null ? Number(rsp.value.to('km/h')) : null;
   } catch (e) {
-    console.error('OBD speed read failed:', e);
+    reportError(e);
     return null;
   }
 }
@@ -19,7 +21,7 @@ export function readRpmObd(port = null) {
     const rsp = conn.query(obd.commands.RPM);
     return rsp && rsp.value != null ? Number(rsp.value.to('rpm')) : null;
   } catch (e) {
-    console.error('OBD RPM read failed:', e);
+    reportError(e);
     return null;
   }
 }
@@ -31,7 +33,7 @@ export function readEngineLoadObd(port = null) {
     const rsp = conn.query(obd.commands.ENGINE_LOAD);
     return rsp && rsp.value != null ? Number(rsp.value.to('percent')) : null;
   } catch (e) {
-    console.error('OBD engine load read failed:', e);
+    reportError(e);
     return null;
   }
 }

--- a/webui/src/wifiScanner.js
+++ b/webui/src/wifiScanner.js
@@ -1,6 +1,7 @@
 import { execFileSync, execFile } from 'child_process';
 import { getHeading } from './orientationSensors.js';
 import { cachedLookupVendor } from './ouiRegistry.js';
+import { reportError } from './exceptionHandler.js';
 
 export function parseIwlist(output) {
   const records = [];
@@ -67,7 +68,7 @@ export function scanWifi(iface = 'wlan0', iwlistCmd = 'iwlist', privCmd = 'sudo'
     });
     return parseIwlist(out);
   } catch (e) {
-    console.error('Wi-Fi scan failed:', e);
+    reportError(e);
     return [];
   }
 }

--- a/webui/tests/exceptionHandler.test.js
+++ b/webui/tests/exceptionHandler.test.js
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('../src/logconfig.js', () => ({
+  setupLogging: vi.fn(() => ({ error: vi.fn() }))
+}));
+
+import { setupLogging } from '../src/logconfig.js';
+
+let origOnError;
+
+beforeEach(() => {
+  origOnError = window.onerror;
+  vi.resetModules();
+});
+
+afterEach(() => {
+  window.onerror = origOnError;
+});
+
+describe('exception handler', () => {
+  it('logs reported errors', async () => {
+    const log = { error: vi.fn() };
+    setupLogging.mockReturnValue(log);
+    const mod = await import('../src/exceptionHandler.js');
+    mod.reportError(new Error('boom'));
+    expect(log.error).toHaveBeenCalledWith('boom');
+  });
+
+  it('installs only once', async () => {
+    const add = vi.spyOn(window, 'addEventListener');
+    const mod = await import('../src/exceptionHandler.js');
+    mod.install();
+    const first = window.onerror;
+    mod.install();
+    expect(window.onerror).toBe(first);
+    expect(add).toHaveBeenCalledTimes(1);
+    add.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- add exception handler module for the web UI
- log and optionally alert via `reportError`
- install handler from `main.jsx`
- use `reportError` in several modules
- provide unit tests for the new handler

## Testing
- `pytest -q`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685dbaffaa3c8333b048314b7fdb2366