### PR TITLE
Add export utilities to web UI

### DIFF
--- a/webui/README.md
+++ b/webui/README.md
@@ -115,3 +115,20 @@ After the first successful build, the dashboard registers a service worker. It c
 ---
 
 Once these steps are complete you have a functioning browser based dashboard. Use the interface to monitor running services, view logs and adjust configuration without needing the on-device GUI.
+
+## 11. Export Utilities
+
+`exportUtils.js` mirrors the Python helpers for exporting collected records. It can filter result sets and save them to various geospatial formats.
+
+```javascript
+import { filterRecords, exportRecords, exportMapKml } from './src/exportUtils.js';
+
+const records = [{ ssid: 'AP', bssid: 'AA', lat: 1, lon: 2 }];
+const track = [[1, 2], [3, 4]];
+
+const filtered = filterRecords(records, { encryption: 'OPEN' });
+await exportRecords(filtered, 'out.csv', 'csv');
+await exportMapKml(track, filtered, [], 'track.kml');
+```
+
+Supported formats are **CSV**, **JSON**, **GPX**, **KML**, **GeoJSON** and **SHP**.

--- a/webui/package-lock.json
+++ b/webui/package-lock.json
@@ -9,6 +9,11 @@
       "version": "0.1.0",
       "dependencies": {
         "chart.js": "^4.5.0",
+        "csv-stringify": "^6.5.2",
+        "gpx-builder": "^5.6.0",
+        "gtran-kml": "^1.4.5",
+        "gtran-kmz": "^1.1.4",
+        "gtran-shapefile": "^1.1.3",
         "leaflet": "^1.9.4",
         "leaflet-draw": "^1.0.4",
         "leaflet.heat": "^0.2.0",
@@ -25,6 +30,7 @@
         "@testing-library/react": "^16.3.0",
         "@vitejs/plugin-react": "^4.0.0",
         "jsdom": "^26.1.0",
+        "jszip": "^3.10.1",
         "vite": "^5.0.0",
         "vite-plugin-pwa": "^0.20.0",
         "vitest": "^3.2.4"
@@ -1562,7 +1568,6 @@
       "version": "7.27.6",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.6.tgz",
       "integrity": "sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -2191,6 +2196,80 @@
       "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
       "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
       "license": "MIT"
+    },
+    "node_modules/@mapbox/shp-write": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@mapbox/shp-write/-/shp-write-0.4.3.tgz",
+      "integrity": "sha512-mkKIHgtnytyP+cXfk+joYeWwk+SODZ7COQusTcO1rZQVUn68MjzW2F74XMsNIusabnwj5aoKNI8B3mYq9KZ9AQ==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dbf": "0.2.0",
+        "file-saver": "2.0.5",
+        "jszip": "^3.10.1"
+      }
+    },
+    "node_modules/@maphubs/tokml": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@maphubs/tokml/-/tokml-0.5.2.tgz",
+      "integrity": "sha512-UZKR5aC3oSkWBlWV26DOgVHNX8/bTWt8Taug3rpzmGM9rmBj112ucTufkVAyBmoMFKVY6xPO0kvxYTUKLFO/iQ==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "minimist": "^1.2.0",
+        "rw": "^1.3.3",
+        "strxml": "github:mapbox/strxml",
+        "xml-escape": "^1.1.0"
+      },
+      "bin": {
+        "tokml": "tokml"
+      }
+    },
+    "node_modules/@oozcitak/dom": {
+      "version": "1.15.10",
+      "resolved": "https://registry.npmjs.org/@oozcitak/dom/-/dom-1.15.10.tgz",
+      "integrity": "sha512-0JT29/LaxVgRcGKvHmSrUTEvZ8BXvZhGl2LASRUgHqDTC1M5g1pLmVv56IYNyt3bG2CUjDkc67wnyZC14pbQrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@oozcitak/infra": "1.0.8",
+        "@oozcitak/url": "1.0.4",
+        "@oozcitak/util": "8.3.8"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/@oozcitak/infra": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@oozcitak/infra/-/infra-1.0.8.tgz",
+      "integrity": "sha512-JRAUc9VR6IGHOL7OGF+yrvs0LO8SlqGnPAMqyzOuFZPSZSXI7Xf2O9+awQPSMXgIWGtgUf/dA6Hs6X6ySEaWTg==",
+      "license": "MIT",
+      "dependencies": {
+        "@oozcitak/util": "8.3.8"
+      },
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/@oozcitak/url": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@oozcitak/url/-/url-1.0.4.tgz",
+      "integrity": "sha512-kDcD8y+y3FCSOvnBI6HJgl00viO/nGbQoCINmQ0h98OhnGITrWR3bOGfwYCthgcrV8AnTJz8MzslTQbC3SOAmw==",
+      "license": "MIT",
+      "dependencies": {
+        "@oozcitak/infra": "1.0.8",
+        "@oozcitak/util": "8.3.8"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/@oozcitak/util": {
+      "version": "8.3.8",
+      "resolved": "https://registry.npmjs.org/@oozcitak/util/-/util-8.3.8.tgz",
+      "integrity": "sha512-T8TbSnGsxo6TDBJx/Sgv/BlVJL3tshxZP7Aq5R1mSnM5OcHY2dQaxLMu2+E8u3gN0MLOzdjurqN4ZRVuzQycOQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0"
+      }
     },
     "node_modules/@react-leaflet/core": {
       "version": "2.1.0",
@@ -3095,6 +3174,15 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
     "node_modules/aria-query": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
@@ -3121,6 +3209,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/array-source": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/array-source/-/array-source-0.0.4.tgz",
+      "integrity": "sha512-frNdc+zBn80vipY+GdcJkLEbMWj3xmzArYApmUGxoiV8uAu/ygcs9icPdsGdA26h0MkHUMW6EN2piIvVx+M5Mw==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/arraybuffer.prototype.slice": {
       "version": "1.0.4",
@@ -3455,7 +3549,6 @@
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/common-tags": {
@@ -3496,6 +3589,12 @@
         "url": "https://opencollective.com/core-js"
       }
     },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT"
+    },
     "node_modules/crypto-random-string": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
@@ -3526,6 +3625,12 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/csv-stringify": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-6.5.2.tgz",
+      "integrity": "sha512-RFPahj0sXcmUyjrObAK+DOWtMvMIFV328n4qZJhgX3x2RqkQgOTU2mCUmiFR0CzM6AzChlRSUErjiJeEt8BaQA==",
+      "license": "MIT"
     },
     "node_modules/data-urls": {
       "version": "5.0.0",
@@ -3630,6 +3735,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/dbf": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/dbf/-/dbf-0.2.0.tgz",
+      "integrity": "sha512-JMeGCJzFcVGsfnkIuqrnuiSkJpTu6c4AKJg3LXDnfW7zU/2PSIue3KG4fz9c+/mmlDzT+rVCwyEHzzhxzrzPiA==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "jdataview": "~2.5.0"
       }
     },
     "node_modules/debug": {
@@ -3767,6 +3881,18 @@
       "integrity": "sha512-2bFhXP2zqSfQHugjqJIDFVwa+qIxyNApenmXTp9EjaKtdPrES5Qcn9/aSFy/NaP2E+fWG/zxKu/LBvY36p5VNQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/elementtree": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/elementtree/-/elementtree-0.1.7.tgz",
+      "integrity": "sha512-wkgGT6kugeQk/P6VZ/f4T+4HB41BVgNBq5CDIZVbQ02nvTVqAiVTbskxxu3eA/X96lMlfYOwnLQpN2v5E1zDEg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "sax": "1.1.4"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
     },
     "node_modules/entities": {
       "version": "6.0.1",
@@ -3973,6 +4099,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -4046,6 +4185,21 @@
         "picomatch": {
           "optional": true
         }
+      }
+    },
+    "node_modules/file-saver": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/file-saver/-/file-saver-2.0.5.tgz",
+      "integrity": "sha512-P9bmyZ3h/PRG+Nzga+rbdI4OEpNDzAVyy74uVO9ATgzLK6VtAsYybF/+TOCvrc0MO793d6+42lLyZTw7/ArVzA==",
+      "license": "MIT"
+    },
+    "node_modules/file-source": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/file-source/-/file-source-0.6.1.tgz",
+      "integrity": "sha512-1R1KneL7eTXmXfKxC10V/9NeGOdbsAXJ+lQ//fvvcHUgtaZcZDWNJNblxAoVOyV1cj45pOtUrR3vZTBwqcW8XA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "stream-source": "0.3"
       }
     },
     "node_modules/filelist": {
@@ -4312,12 +4466,62 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/gpx-builder": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/gpx-builder/-/gpx-builder-5.6.0.tgz",
+      "integrity": "sha512-KLsYZsWk5MbQAXOi4L3jFP58Lyu4feU0ewuB4eXxmE6AIGnb/nurDsf8wr2+EyQY1ju4PoG2p7mhrAtrMGyntQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/runtime": "^7.23.6",
+        "xmlbuilder2": "^3.1.1"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/gtran-kml": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/gtran-kml/-/gtran-kml-1.4.5.tgz",
+      "integrity": "sha512-E+EV6Tby715WTX+bRjMREOnLDbXNQY01Lvh411TTxekGvtEt8CdJK2nyx6U934O+dUGX8TfRD0BWsdz/4mqeHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@maphubs/tokml": "^0.5.2",
+        "elementtree": "^0.1.7",
+        "prettify-xml": "^1.2.0"
+      }
+    },
+    "node_modules/gtran-kmz": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/gtran-kmz/-/gtran-kmz-1.1.4.tgz",
+      "integrity": "sha512-+BuH5u7O8W64l0S8x2ZKZ0ozXIH7YErW211HkJJmCXIl6Jt8fdc8bTOB/bBkwmK9N53IFy2XJndv04+x1ZngXg==",
+      "license": "MIT",
+      "dependencies": {
+        "gtran-kml": "^1.0.0",
+        "jszip": "^2.5.0"
+      }
+    },
+    "node_modules/gtran-kmz/node_modules/jszip": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-2.7.0.tgz",
+      "integrity": "sha512-JIsRKRVC3gTRo2vM4Wy9WBC3TRcfnIZU8k65Phi3izkvPH975FowRYtKGT6PxevA0XnJ/yO8b0QwV0ydVyQwfw==",
+      "license": "(MIT OR GPL-3.0)",
+      "dependencies": {
+        "pako": "~1.0.2"
+      }
+    },
+    "node_modules/gtran-shapefile": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/gtran-shapefile/-/gtran-shapefile-1.1.6.tgz",
+      "integrity": "sha512-tYBncOTZAHCdvGF0Ed9OWyYF6UC4U+cZOaGwmCnacKYFGOJaJ8xIjCCa82JYTddG/gdDeJg8ahw8LxuIYY+JzA==",
+      "license": "MIT",
+      "dependencies": {
+        "@mapbox/shp-write": "^0.4.3",
+        "shapefile": "^0.6.6"
+      }
     },
     "node_modules/has-bigints": {
       "version": "1.1.0",
@@ -4474,6 +4678,12 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
+    },
     "node_modules/indent-string": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
@@ -4500,7 +4710,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/internal-slot": {
@@ -4966,11 +5175,29 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/jdataview": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/jdataview/-/jdataview-2.5.0.tgz",
+      "integrity": "sha512-ZJop3D5nyDcWPBPv4NPnhCvx3HgQNsCXMfw8gpNKY16BobgxmVF+kJ08aHuqk6bJQVeL2mkf6nDCcZPMompalw=="
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
     },
     "node_modules/jsdom": {
       "version": "26.1.0",
@@ -5112,6 +5339,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
     "node_modules/leaflet": {
       "version": "1.9.4",
       "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
@@ -5138,6 +5377,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
       }
     },
     "node_modules/lodash": {
@@ -5247,6 +5495,15 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/ms": {
@@ -5361,6 +5618,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parse5": {
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
@@ -5390,6 +5653,16 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/path-source": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/path-source/-/path-source-0.1.3.tgz",
+      "integrity": "sha512-dWRHm5mIw5kw0cs3QZLNmpUWty48f5+5v9nWD2dw3Y0Hf+s01Ag8iJEWV0Sm0kocE8kK27DrIowha03e1YR+Qw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "array-source": "0.0",
+        "file-source": "0.6"
+      }
     },
     "node_modules/pathe": {
       "version": "2.0.3",
@@ -5467,6 +5740,12 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/prettify-xml": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/prettify-xml/-/prettify-xml-1.2.0.tgz",
+      "integrity": "sha512-kuoTbmC+QQUfx45PrdkVzJqrNEp2lhK++WGyiqBx6JrCvZUQDgeYjdV3h53n7p+37s1Iwx6GjAQ7fcIgD8kkLQ==",
+      "license": "MIT"
+    },
     "node_modules/pretty-bytes": {
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-6.1.1.tgz",
@@ -5507,6 +5786,12 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -5642,6 +5927,33 @@
         "react": ">=16.8",
         "react-dom": ">=16.8"
       }
+    },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/readable-stream/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
+    "node_modules/readable-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
     },
     "node_modules/redent": {
       "version": "3.0.0",
@@ -5850,6 +6162,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/safe-array-concat": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
@@ -5932,6 +6250,12 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/sax": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.1.4.tgz",
+      "integrity": "sha512-5f3k2PbGGp+YtKJjOItpg3P99IMD84E4HOvcfleTb5joCHNXYLsR9yWFPOYGgaeMPDubQILTCMdsFb2OMeOjtg==",
+      "license": "ISC"
     },
     "node_modules/saxes": {
       "version": "6.0.0",
@@ -6024,6 +6348,30 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "license": "MIT"
+    },
+    "node_modules/shapefile": {
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/shapefile/-/shapefile-0.6.6.tgz",
+      "integrity": "sha512-rLGSWeK2ufzCVx05wYd+xrWnOOdSV7xNUW5/XFgx3Bc02hBkpMlrd2F1dDII7/jhWzv0MSyBFh5uJIy9hLdfuw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "array-source": "0.0",
+        "commander": "2",
+        "path-source": "0.1",
+        "slice-source": "0.4",
+        "stream-source": "0.3",
+        "text-encoding": "^0.6.4"
+      },
+      "bin": {
+        "dbf2json": "bin/dbf2json",
+        "shp2json": "bin/shp2json"
+      }
+    },
     "node_modules/side-channel": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
@@ -6107,6 +6455,12 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/slice-source": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/slice-source/-/slice-source-0.4.1.tgz",
+      "integrity": "sha512-YiuPbxpCj4hD9Qs06hGAz/OZhQ0eDuALN0lRWJez0eD/RevzKqGdUx1IOMUnXgpr+sXZLq3g8ERwbAH0bCb8vg==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/smob": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/smob/-/smob-1.5.0.tgz",
@@ -6166,6 +6520,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/stackback": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
@@ -6193,6 +6553,27 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/stream-source": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/stream-source/-/stream-source-0.3.5.tgz",
+      "integrity": "sha512-ZuEDP9sgjiAwUVoDModftG0JtYiLUV8K4ljYD1VyUMRWtbVf92474o4kuuul43iZ8t/hRuiDAx1dIJSvirrK/g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
     },
     "node_modules/string.prototype.matchall": {
       "version": "4.0.12",
@@ -6339,6 +6720,14 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/strxml": {
+      "version": "1.0.0",
+      "resolved": "git+ssh://git@github.com/mapbox/strxml.git#4325a5597621600183b869452da6104f8d2215b8",
+      "license": "ISC",
+      "dependencies": {
+        "xml-escape": "1.1.0"
+      }
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -6419,6 +6808,13 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/text-encoding": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
+      "integrity": "sha512-hJnc6Qg3dWoOMkqP53F0dzRIgtmsAge09kxUIqGrEUS4qr5rWLckGYaQAVr+opBrIMRErGgy6f5aPnyPpyGRfg==",
+      "deprecated": "no longer maintained",
+      "license": "Unlicense"
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -6742,6 +7138,12 @@
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/vite": {
       "version": "5.4.19",
@@ -7356,6 +7758,12 @@
         }
       }
     },
+    "node_modules/xml-escape": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/xml-escape/-/xml-escape-1.1.0.tgz",
+      "integrity": "sha512-B/T4sDK8Z6aUh/qNr7mjKAwwncIljFuUP+DO/D5hloYFj+90O88z8Wf7oSucZTHxBAsC1/CTP4rtx/x1Uf72Mg==",
+      "license": "MIT License"
+    },
     "node_modules/xml-name-validator": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
@@ -7364,6 +7772,21 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/xmlbuilder2": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder2/-/xmlbuilder2-3.1.1.tgz",
+      "integrity": "sha512-WCSfbfZnQDdLQLiMdGUQpMxxckeQ4oZNMNhLVkcekTu7xhD4tuUDyAPoY8CwXvBYE6LwBHd6QW2WZXlOWr1vCw==",
+      "license": "MIT",
+      "dependencies": {
+        "@oozcitak/dom": "1.15.10",
+        "@oozcitak/infra": "1.0.8",
+        "@oozcitak/util": "8.3.8",
+        "js-yaml": "3.14.1"
+      },
+      "engines": {
+        "node": ">=12.0"
       }
     },
     "node_modules/xmlchars": {

--- a/webui/package.json
+++ b/webui/package.json
@@ -18,7 +18,12 @@
     "react-dom": "^18.2.0",
     "react-leaflet": "^4.2.1",
     "react-leaflet-draw": "^0.19.0",
-    "react-router-dom": "^6.30.1"
+    "react-router-dom": "^6.30.1",
+    "csv-stringify": "^6.5.2",
+    "gtran-kml": "^1.4.5",
+    "gtran-kmz": "^1.1.4",
+    "gtran-shapefile": "^1.1.3",
+    "gpx-builder": "^5.6.0"
   },
   "devDependencies": {
     "@testing-library/dom": "^10.4.0",
@@ -28,6 +33,7 @@
     "jsdom": "^26.1.0",
     "vite": "^5.0.0",
     "vite-plugin-pwa": "^0.20.0",
-    "vitest": "^3.2.4"
+    "vitest": "^3.2.4",
+    "jszip": "^3.10.1"
   }
 }

--- a/webui/src/exportUtils.js
+++ b/webui/src/exportUtils.js
@@ -1,0 +1,162 @@
+// Utility functions for exporting data in various formats
+import fs from 'fs';
+import { stringify } from 'csv-stringify/sync';
+import kml from 'gtran-kml';
+import kmz from 'gtran-kmz';
+import shp from 'gtran-shapefile';
+import { buildGPX, BaseBuilder } from 'gpx-builder';
+
+export const EXPORT_FORMATS = ['csv', 'json', 'gpx', 'kml', 'geojson', 'shp'];
+
+export function filterRecords(records, { ssid, encryption, oui, minSignal, maxAge } = {}) {
+  const now = Date.now() / 1000;
+  const result = [];
+  for (const rec of records) {
+    if (ssid && !(rec.ssid || '').includes(ssid)) continue;
+    if (encryption && encryption !== rec.encryption) continue;
+    if (oui && !(rec.bssid || '').startsWith(oui)) continue;
+    if (minSignal !== undefined) {
+      const sig = rec.signal_dbm;
+      if (sig === undefined || Number(sig) < minSignal) continue;
+    }
+    if (maxAge !== undefined) {
+      const ts = rec.last_time;
+      if (ts === undefined || now - Number(ts) > maxAge) continue;
+    }
+    result.push({ ...rec });
+  }
+  return result;
+}
+
+function recordsToGeojson(records, fields) {
+  const features = [];
+  for (const rec of records) {
+    const lat = rec.lat;
+    const lon = rec.lon;
+    if (lat == null || lon == null) continue;
+    let props = { ...rec };
+    delete props.lat;
+    delete props.lon;
+    if (fields) {
+      props = {};
+      for (const name of fields) {
+        if (name !== 'lat' && name !== 'lon') props[name] = rec[name];
+      }
+    }
+    features.push({
+      type: 'Feature',
+      geometry: { type: 'Point', coordinates: [lon, lat] },
+      properties: props,
+    });
+  }
+  return { type: 'FeatureCollection', features };
+}
+
+export async function exportRecords(records, path, fmt, fields = null) {
+  if (fields) records = records.map(r => Object.fromEntries(fields.map(f => [f, r[f]])));
+  fmt = fmt.toLowerCase();
+  if (!EXPORT_FORMATS.includes(fmt)) throw new Error(`Unsupported format: ${fmt}`);
+
+  if (fmt === 'csv') {
+    const columns = fields || (records[0] ? Object.keys(records[0]) : []);
+    const out = stringify(records, { header: true, columns });
+    fs.writeFileSync(path, out);
+    return;
+  }
+
+  if (fmt === 'json') {
+    fs.writeFileSync(path, JSON.stringify(records, null, 2));
+    return;
+  }
+
+  if (fmt === 'gpx') {
+    const { Point } = BaseBuilder.MODELS;
+    const points = [];
+    for (const rec of records) {
+      const lat = rec.lat;
+      const lon = rec.lon;
+      if (lat == null || lon == null) continue;
+      const name = rec.ssid || rec.bssid;
+      const opts = name ? { name: String(name) } : {};
+      points.push(new Point(lat, lon, opts));
+    }
+    const builder = new BaseBuilder();
+    builder.setWayPoints(points);
+    fs.writeFileSync(path, buildGPX(builder.toObject()));
+    return;
+  }
+
+  const geojson = recordsToGeojson(records, fields);
+
+  if (fmt === 'geojson') {
+    fs.writeFileSync(path, JSON.stringify(geojson));
+    return;
+  }
+
+  if (fmt === 'kml') {
+    await kml.fromGeoJson(geojson, path);
+    return;
+  }
+
+  if (fmt === 'shp') {
+    await shp.fromGeoJson(geojson, path);
+    return;
+  }
+}
+
+export function estimateLocationFromRssi(points) {
+  let total = 0;
+  let sumLat = 0;
+  let sumLon = 0;
+  for (const p of points) {
+    const lat = parseFloat(p.lat);
+    const lon = parseFloat(p.lon);
+    const rssi = parseFloat(p.rssi);
+    if (isNaN(lat) || isNaN(lon) || isNaN(rssi)) continue;
+    const weight = 1 / Math.max(1, Math.abs(rssi));
+    sumLat += lat * weight;
+    sumLon += lon * weight;
+    total += weight;
+  }
+  if (total === 0) return null;
+  return [sumLat / total, sumLon / total];
+}
+
+export async function exportMapKml(track, aps, bts, path, { computePosition = false } = {}) {
+  const features = [];
+  if (track && track.length) {
+    features.push({
+      type: 'Feature',
+      geometry: { type: 'LineString', coordinates: track.map(([lat, lon]) => [lon, lat]) },
+      properties: { name: 'Track' },
+    });
+  }
+  for (const rec of aps) {
+    let { lat, lon } = rec;
+    if ((lat == null || lon == null) && computePosition) {
+      const loc = estimateLocationFromRssi(rec.observations || []);
+      if (loc) [lat, lon] = loc;
+    }
+    if (lat == null || lon == null) continue;
+    features.push({
+      type: 'Feature',
+      geometry: { type: 'Point', coordinates: [lon, lat] },
+      properties: { name: rec.ssid || rec.bssid },
+    });
+  }
+  for (const rec of bts) {
+    const { lat, lon } = rec;
+    if (lat == null || lon == null) continue;
+    features.push({
+      type: 'Feature',
+      geometry: { type: 'Point', coordinates: [lon, lat] },
+      properties: { name: rec.name || rec.address },
+    });
+  }
+  const geojson = { type: 'FeatureCollection', features };
+  if (path.toLowerCase().endsWith('.kmz')) {
+    await kmz.fromGeoJson(geojson, path);
+  } else {
+    await kml.fromGeoJson(geojson, path);
+  }
+}

--- a/webui/tests/exportUtils.test.js
+++ b/webui/tests/exportUtils.test.js
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi } from 'vitest';
+import fs from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import jszip from 'jszip';
+import shapefile from 'shapefile';
+import { filterRecords, exportRecords, exportMapKml } from '../src/exportUtils.js';
+
+describe('filterRecords', () => {
+  it('applies filters', () => {
+    const records = [
+      { ssid: 'A', encryption: 'WPA2', bssid: 'AA', lat: 1.0, lon: 2.0, signal_dbm: -40, last_time: 80 },
+      { ssid: 'B', encryption: 'OPEN', bssid: 'BB', lat: 3.0, lon: 4.0, signal_dbm: -80, last_time: 20 },
+    ];
+    vi.spyOn(Date, 'now').mockReturnValue(100000);
+    expect(filterRecords(records, { encryption: 'OPEN' })).toEqual([records[1]]);
+    expect(filterRecords(records, { oui: 'AA' })).toEqual([records[0]]);
+    expect(filterRecords(records, { minSignal: -50 })).toEqual([records[0]]);
+    expect(filterRecords(records, { maxAge: 30 })).toEqual([records[0]]);
+    Date.now.mockRestore();
+  });
+});
+
+describe('exportRecords', () => {
+  it('writes all formats', async () => {
+    const recs = [{ ssid: 'A', bssid: 'AA', lat: 1.0, lon: 2.0 }];
+    const dir = tmpdir();
+
+    const csvPath = join(dir, 'data.csv');
+    await exportRecords(recs, csvPath, 'csv');
+    expect(fs.readFileSync(csvPath, 'utf-8')).toContain('ssid');
+
+    const jsonPath = join(dir, 'data.json');
+    await exportRecords(recs, jsonPath, 'json');
+    expect(JSON.parse(fs.readFileSync(jsonPath))).toEqual(recs);
+
+    const gpxPath = join(dir, 'data.gpx');
+    await exportRecords(recs, gpxPath, 'gpx');
+    expect(fs.readFileSync(gpxPath, 'utf-8')).toContain('<wpt');
+
+    const kmlPath = join(dir, 'data.kml');
+    await exportRecords(recs, kmlPath, 'kml');
+    expect(fs.readFileSync(kmlPath, 'utf-8')).toContain('<Placemark>');
+
+    const geoPath = join(dir, 'data.geojson');
+    await exportRecords(recs, geoPath, 'geojson');
+    const gj = JSON.parse(fs.readFileSync(geoPath, 'utf-8'));
+    expect(gj.features[0].geometry.coordinates).toEqual([2.0, 1.0]);
+
+    const shpPath = join(dir, 'data.shp');
+    await exportRecords(recs, shpPath, 'shp');
+    const source = await shapefile.open(shpPath);
+    const { value } = await source.read();
+    expect(value.geometry.coordinates).toEqual([2.0, 1.0]);
+  });
+});
+
+describe('exportMapKml', () => {
+  it('creates kml and kmz', async () => {
+    const track = [[1.0, 2.0], [3.0, 4.0]];
+    const aps = [{ ssid: 'A', lat: 1.0, lon: 2.0 }];
+    const bts = [{ name: 'bt', lat: 5.0, lon: 6.0 }];
+
+    const dir = tmpdir();
+    const kmlFile = join(dir, 'map.kml');
+    await exportMapKml(track, aps, bts, kmlFile);
+    const text = fs.readFileSync(kmlFile, 'utf-8');
+    expect(text).toContain('<LineString>');
+    expect(text).toContain('2,1');
+    expect(text).toContain('6,5');
+
+    const kmzFile = join(dir, 'map.kmz');
+    await exportMapKml(track, aps, bts, kmzFile);
+    const buf = fs.readFileSync(kmzFile);
+    const zip = await jszip.loadAsync(buf);
+    expect(Object.keys(zip.files)).toContain('doc.kml');
+  });
+});


### PR DESCRIPTION
## Summary
- add Node implementation of export functions
- support exporting CSV/JSON/GPX/KML/GeoJSON/SHP
- document usage
- add vitest for export utils
- include required dependencies

## Testing
- `npm test` *(fails: gpsd library and aiosqlite missing)*

------
https://chatgpt.com/codex/tasks/task_e_685dbb00ebd08333afe9e480b0efd9d8