### PR TITLE
Add React tests mirroring backend tests

### DIFF
--- a/webui/tests/serviceControl.test.js
+++ b/webui/tests/serviceControl.test.js
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { controlService } from '../src/serviceControl.js';
+
+let origFetch;
+let origPrompt;
+let origSession;
+
+describe('controlService', () => {
+  beforeEach(() => {
+    origFetch = global.fetch;
+    origPrompt = window.prompt;
+    origSession = global.sessionStorage;
+    global.fetch = vi.fn(() => Promise.resolve({ ok: true }));
+    window.prompt = vi.fn(() => 'pw');
+    const store = {};
+    global.sessionStorage = {
+      getItem: key => store[key] || null,
+      setItem: (key, val) => { store[key] = val; }
+    };
+  });
+
+  afterEach(() => {
+    global.fetch = origFetch;
+    window.prompt = origPrompt;
+    global.sessionStorage = origSession;
+  });
+
+  it('sends simple request', async () => {
+    const ok = await controlService('kismet', 'start');
+    expect(ok).toBe(true);
+    expect(global.fetch).toHaveBeenCalledWith('/service/kismet/start', { method: 'POST', headers: {} });
+  });
+
+  it('retries on 401 with password', async () => {
+    global.fetch
+      .mockResolvedValueOnce({ status: 401 })
+      .mockResolvedValueOnce({ ok: true });
+    const ok = await controlService('kismet', 'stop');
+    expect(ok).toBe(true);
+    expect(window.prompt).toHaveBeenCalled();
+    expect(global.fetch.mock.calls[1][1].headers['X-Admin-Password']).toBe('pw');
+  });
+});

--- a/webui/tests/webApiClient.test.js
+++ b/webui/tests/webApiClient.test.js
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { getGps, getAps, getBt, toggleKismet } from '../src/webApiClient.js';
+
+let origFetch;
+
+describe('webApiClient', () => {
+  beforeEach(() => {
+    origFetch = global.fetch;
+    global.fetch = vi.fn(() => Promise.resolve({ json: () => Promise.resolve({}) }));
+  });
+
+  afterEach(() => {
+    global.fetch = origFetch;
+  });
+
+  it('fetches gps', async () => {
+    global.fetch.mockResolvedValueOnce({ json: () => Promise.resolve({ lat: 1 }) });
+    const data = await getGps();
+    expect(global.fetch).toHaveBeenCalledWith('/api/gps');
+    expect(data.lat).toBe(1);
+  });
+
+  it('fetches aps', async () => {
+    global.fetch.mockResolvedValueOnce({ json: () => Promise.resolve({ features: [1] }) });
+    const data = await getAps();
+    expect(global.fetch).toHaveBeenCalledWith('/api/aps');
+    expect(data.features).toEqual([1]);
+  });
+
+  it('fetches bluetooth', async () => {
+    global.fetch.mockResolvedValueOnce({ json: () => Promise.resolve({ features: [2] }) });
+    const data = await getBt();
+    expect(global.fetch).toHaveBeenCalledWith('/api/bt');
+    expect(data.features).toEqual([2]);
+  });
+
+  it('toggles kismet', async () => {
+    global.fetch.mockResolvedValueOnce({});
+    await toggleKismet('start');
+    expect(global.fetch).toHaveBeenCalledWith('/api/kismet/toggle?state=start', { method: 'POST' });
+  });
+});

--- a/webui/tests/widgetPlugins.test.js
+++ b/webui/tests/widgetPlugins.test.js
@@ -1,0 +1,40 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+
+const tmpRoot = path.join(process.cwd(), 'tmp_plugin');
+const pluginDir = path.join(tmpRoot, '.config', 'piwardrive', 'plugins');
+let mod;
+
+function setupEnv() {
+  fs.rmSync(tmpRoot, { recursive: true, force: true });
+  fs.mkdirSync(pluginDir, { recursive: true });
+  process.env.HOME = tmpRoot;
+}
+
+describe('widgetPlugins', () => {
+  beforeEach(() => {
+    setupEnv();
+    fs.writeFileSync(path.join(pluginDir, 'plug1.js'), 'exports.Widget1 = function(){}');
+    mod = require('../src/widgetPlugins.js');
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+    delete require.cache[require.resolve('../src/widgetPlugins.js')];
+  });
+
+  it('discovers plugins', () => {
+    const names = mod.listPlugins();
+    expect(names).toContain('Widget1');
+    expect(typeof mod.getPlugin('Widget1')).toBe('function');
+  });
+
+  it('clears cache and reloads', () => {
+    mod.listPlugins();
+    fs.writeFileSync(path.join(pluginDir, 'plug2.js'), 'exports.Widget2 = function(){}');
+    mod.clearPluginCache();
+    const names = mod.listPlugins();
+    expect(names).toContain('Widget2');
+  });
+});

--- a/webui/tests/wifiScanner.test.js
+++ b/webui/tests/wifiScanner.test.js
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('../src/ouiRegistry.js', () => ({
+  cachedLookupVendor: vi.fn(bssid => ({ 'AA:BB:CC': 'VendorA', '11:22:33': 'VendorB' }[bssid.slice(0,8)] || null))
+}));
+vi.mock('../src/orientationSensors.js', () => ({ getHeading: vi.fn(() => 45.0) }));
+
+import { parseIwlist } from '../src/wifiScanner.js';
+
+const sample = `Cell 01 - Address: AA:BB:CC:DD:EE:FF
+          ESSID:"TestNet"
+          Frequency:2.437 GHz (Channel 6)
+          Encryption key:on
+          IE: WPA Version 1
+          Quality=70/70  Signal level=-40 dBm
+Cell 02 - Address: 11:22:33:44:55:66
+          ESSID:"OpenNet"
+          Frequency:2.422 GHz (Channel 3)
+          Encryption key:off
+          Quality=20/70  Signal level=-90 dBm`;
+
+describe('parseIwlist', () => {
+  it('parses vendor and heading', () => {
+    const out = parseIwlist(sample);
+    expect(out[0].vendor).toBe('VendorA');
+    expect(out[1].vendor).toBe('VendorB');
+    expect(out[0].channel).toBe('6');
+    expect(out[0].encryption).toBe('on WPA Version 1');
+    expect(out[0].heading).toBe(45.0);
+  });
+
+  it('handles missing vendor', () => {
+    const data = parseIwlist(`Cell 01 - Address: AA:BB:CC:DD:EE:FF\n          ESSID:\"TestNet\"\n          Frequency:2.437 GHz (Channel 6)\n          Encryption key:on`);
+    expect(data[0].vendor).toBe('VendorA');
+    expect(data[0].heading).toBe(45.0);
+  });
+});

--- a/webui/tests/wigleIntegration.test.js
+++ b/webui/tests/wigleIntegration.test.js
@@ -1,0 +1,25 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { fetchWigleNetworks } from '../src/wigleIntegration.js';
+
+let origFetch;
+
+describe('fetchWigleNetworks', () => {
+  beforeEach(() => {
+    origFetch = global.fetch;
+    global.fetch = vi.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve({
+      results: [{ netid: 'AA:BB:CC', ssid: 'Net', encryption: 'WPA2', trilat: 1.0, trilong: 2.0 }]
+    }) }));
+  });
+
+  afterEach(() => {
+    global.fetch = origFetch;
+  });
+
+  it('fetches networks', async () => {
+    const nets = await fetchWigleNetworks('u', 'k', 1.0, 2.0);
+    expect(global.fetch).toHaveBeenCalled();
+    const opts = global.fetch.mock.calls[0][1];
+    expect(opts.headers.Authorization).toBe('Basic ' + btoa('u:k'));
+    expect(nets).toEqual([{ bssid: 'AA:BB:CC', ssid: 'Net', encryption: 'WPA2', lat: 1.0, lon: 2.0 }]);
+  });
+});


### PR DESCRIPTION
## Summary
- add webApiClient tests for GPS/AP/BT fetch and Kismet toggle
- test service control authentication and retry logic
- add widget plugin discovery and cache tests
- test Wi-Fi scanner output parsing
- add WiGLE integration fetch test

## Testing
- `npm install --legacy-peer-deps`
- `npm test` *(fails: server not ready, missing modules)*
- `pytest -q` *(fails: 37 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_685dbb90c0b083338e81a46917aba18f