### PR TITLE
Add Node module tests

### DIFF
--- a/webui/src/vectorTiles.js
+++ b/webui/src/vectorTiles.js
@@ -1,0 +1,35 @@
+import fs from 'fs';
+import sqlite3 from 'sqlite3';
+
+sqlite3.verbose();
+
+export class MBTiles {
+  constructor(path) {
+    if (!fs.existsSync(path)) throw new Error(path);
+    this.path = path;
+  }
+
+  tiles(z, x, y) {
+    return new Promise(resolve => {
+      const db = new sqlite3.Database(this.path);
+      db.get(
+        'SELECT tile_data FROM tiles WHERE zoom_level=? AND tile_column=? AND tile_row=?',
+        [z, x, y],
+        (err, row) => {
+          db.close();
+          resolve(err ? null : row ? row.tile_data : null);
+        }
+      );
+    });
+  }
+}
+
+export function availableTiles(path) {
+  return new Promise(resolve => {
+    const db = new sqlite3.Database(path);
+    db.all('SELECT zoom_level, tile_column, tile_row FROM tiles', (err, rows) => {
+      db.close();
+      resolve(rows ? rows.map(r => [r.zoom_level, r.tile_column, r.tile_row]) : []);
+    });
+  });
+}

--- a/webui/tests/ouiRegistry.test.js
+++ b/webui/tests/ouiRegistry.test.js
@@ -1,0 +1,26 @@
+import { describe, it, expect, vi } from 'vitest';
+import { loadOuiMap, lookupVendor, cachedLookupVendor } from '../src/ouiRegistry.js';
+
+describe('ouiRegistry', () => {
+  it('loads file and caches vendor lookup', async () => {
+    global.fetch = vi.fn().mockResolvedValue({ text: () => Promise.resolve('Assignment,Organization Name\nAA-BB-CC,VendorX\n') });
+    await loadOuiMap('/oui.csv');
+    const vendor = lookupVendor('AA:BB:CC:00:11:22');
+    expect(vendor).toBe('VendorX');
+    global.fetch.mockRejectedValue(new Error('boom'));
+    const vendor2 = await cachedLookupVendor('AA:BB:CC:33:44:55');
+    expect(vendor2).toBe('VendorX');
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    global.fetch.mockRestore();
+  });
+
+  it('logs error on load failure', async () => {
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    global.fetch = vi.fn().mockRejectedValue(new Error('fail'));
+    const map = await loadOuiMap('/oui.csv');
+    expect(map).toEqual({});
+    expect(errSpy).toHaveBeenCalled();
+    global.fetch.mockRestore();
+    errSpy.mockRestore();
+  });
+});

--- a/webui/tests/vacuumDb.test.js
+++ b/webui/tests/vacuumDb.test.js
@@ -1,0 +1,12 @@
+import { describe, it, expect, vi } from 'vitest';
+import { main } from '../src/vacuumDb.js';
+import * as childProcess from 'child_process';
+
+describe('vacuumDb script', () => {
+  it('calls sqlite3 vacuum', () => {
+    const spy = vi.spyOn(childProcess, 'execFileSync').mockReturnValue(null);
+    main('test.db');
+    expect(spy).toHaveBeenCalledWith('sqlite3', ['test.db', 'VACUUM']);
+    spy.mockRestore();
+  });
+});

--- a/webui/tests/vectorTiles.test.js
+++ b/webui/tests/vectorTiles.test.js
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { MBTiles, availableTiles } from '../src/vectorTiles.js';
+import fs from 'fs';
+import path from 'path';
+import sqlite3 from 'sqlite3';
+
+sqlite3.verbose();
+
+function createDb(p) {
+  return new Promise(resolve => {
+    const db = new sqlite3.Database(p);
+    db.serialize(() => {
+      db.run('CREATE TABLE tiles (zoom_level INTEGER, tile_column INTEGER, tile_row INTEGER, tile_data BLOB)');
+      db.run('INSERT INTO tiles VALUES (1,2,3,?)', Buffer.from('data'));
+      db.run('INSERT INTO tiles VALUES (2,0,0,?)', Buffer.from('foo'), () => { db.close(); resolve(); });
+    });
+  });
+}
+
+describe('vectorTiles module', () => {
+  it('throws on missing file', () => {
+    expect(() => new MBTiles('missing.mbtiles')).toThrow();
+  });
+
+  it('reads tiles and lists available', async () => {
+    const file = path.join(process.cwd(), 'tiles.mbtiles');
+    fs.writeFileSync(file, '');
+    await createDb(file);
+    const mb = new MBTiles(file);
+    const data = await mb.tiles(1, 2, 3);
+    expect(Buffer.isBuffer(data) && data.equals(Buffer.from('data'))).toBe(true);
+    expect(await mb.tiles(9, 9, 9)).toBeNull();
+    const tiles = await availableTiles(file);
+    expect(new Set(tiles.map(t => t.join(',')))).toEqual(new Set(['1,2,3','2,0,0']));
+    fs.unlinkSync(file);
+  });
+});

--- a/webui/tests/vehicleSensors.test.js
+++ b/webui/tests/vehicleSensors.test.js
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import * as vs from '../src/vehicleSensors.js';
+
+describe('vehicleSensors', () => {
+  it('returns null when obd missing', () => {
+    vs.obd = null;
+    expect(vs.readRpmObd()).toBeNull();
+  });
+
+  it('reads values with dummy obd', () => {
+    class DummyVal {
+      constructor(v) { this.v = v; }
+      to() { return this.v; }
+    }
+    class DummyConn {
+      query() { return { value: new DummyVal(50) }; }
+    }
+    vs.obd = {
+      OBD: () => new DummyConn(),
+      commands: { ENGINE_LOAD: 'ENGINE_LOAD', RPM: 'RPM' }
+    };
+    expect(vs.readEngineLoadObd()).toBe(50);
+    expect(vs.readRpmObd()).toBe(50);
+  });
+});


### PR DESCRIPTION
## Summary
- add vacuum DB script test in React
- test vehicle sensors logic
- verify OUI registry fetching
- implement MBTiles reader and tests

## Testing
- `npx vitest run tests/vacuumDb.test.js tests/vectorTiles.test.js tests/vehicleSensors.test.js tests/ouiRegistry.test.js --silent` *(fails: Cannot spy on export `execFileSync`)*
- `pytest tests/test_vacuum_script.py -q`
- `pytest tests/test_vector_tile_customizer.py -q` *(fails: sqlite3.OperationalError)*

------
https://chatgpt.com/codex/tasks/task_e_685dbb8ba5b08333af4d76f8a9ec44f5