### PR TITLE
Add web UI tests for tile cache and towers

### DIFF
--- a/webui/tests/tileCache.test.js
+++ b/webui/tests/tileCache.test.js
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { purgeOldTiles, enforceCacheLimit, deg2num } from '../src/tileCache.js';
+
+const INDEX_KEY = 'tile-cache-index';
+
+let store;
+let cache;
+
+beforeEach(() => {
+  store = {};
+  global.localStorage = {
+    getItem: k => store[k] || null,
+    setItem: (k, v) => { store[k] = v; },
+    removeItem: k => { delete store[k]; },
+  };
+  cache = { delete: vi.fn() };
+  global.caches = { open: async () => cache };
+});
+
+describe('deg2num', () => {
+  it('converts lat/lon to tile numbers', () => {
+    const [x, y] = deg2num(0, 0, 1);
+    expect(x).toBe(1);
+    expect(y).toBe(1);
+  });
+});
+
+describe('purgeOldTiles', () => {
+  it('deletes outdated tiles', async () => {
+    const now = Date.now();
+    const idx = {
+      '16/1/2': { time: now - 10 * 86400 * 1000, size: 1 },
+      '16/3/4': { time: now, size: 1 },
+    };
+    store[INDEX_KEY] = JSON.stringify(idx);
+
+    await purgeOldTiles(5);
+
+    expect(cache.delete).toHaveBeenCalledWith('https://tile.openstreetmap.org/16/1/2.png');
+    const saved = JSON.parse(store[INDEX_KEY]);
+    expect(saved).toEqual({ '16/3/4': idx['16/3/4'] });
+  });
+});
+
+describe('enforceCacheLimit', () => {
+  it('removes oldest tiles when over limit', async () => {
+    const now = Date.now();
+    const idx = {
+      '16/1/1': { time: now - 1000, size: 200 * 1024 * 1024 },
+      '16/2/2': { time: now, size: 100 * 1024 * 1024 },
+    };
+    store[INDEX_KEY] = JSON.stringify(idx);
+
+    await enforceCacheLimit(250);
+
+    expect(cache.delete).toHaveBeenCalledWith('https://tile.openstreetmap.org/16/1/1.png');
+    const saved = JSON.parse(store[INDEX_KEY]);
+    expect(Object.keys(saved)).toEqual(['16/2/2']);
+  });
+});

--- a/webui/tests/towerScanner.test.js
+++ b/webui/tests/towerScanner.test.js
@@ -1,8 +1,11 @@
 import { describe, it, expect, vi } from 'vitest';
+vi.mock('child_process', () => {
+  const execFileSync = vi.fn();
+  const execFile = vi.fn();
+  return { execFileSync, execFile, default: { execFileSync, execFile } };
+});
 import { parseTowerOutput, scanTowers, asyncScanTowers } from '../src/towerScanner.js';
 import * as childProcess from 'child_process';
-
-vi.mock('child_process');
 
 describe('parseTowerOutput', () => {
   it('parses lines', () => {
@@ -17,20 +20,20 @@ describe('parseTowerOutput', () => {
 
 describe('scanTowers', () => {
   it('executes command', () => {
-    const spy = vi.spyOn(childProcess, 'execFileSync').mockReturnValue('123,-70');
+    childProcess.execFileSync.mockReturnValue('123,-70');
     const res = scanTowers('dummy');
-    expect(spy).toHaveBeenCalled();
+    expect(childProcess.execFileSync).toHaveBeenCalled();
     expect(res.length).toBe(1);
-    spy.mockRestore();
   });
 });
 
 describe('asyncScanTowers', () => {
   it('returns records', async () => {
-    vi.spyOn(childProcess, 'execFile').mockImplementation((cmd, opts, cb) => {
+    childProcess.execFile.mockImplementation((cmd, opts, cb) => {
       cb(null, '123,-70');
     });
     const res = await asyncScanTowers('dummy');
     expect(res).toEqual([{ tower_id: '123', rssi: '-70', lat: null, lon: null }]);
+    expect(childProcess.execFile).toHaveBeenCalled();
   });
 });

--- a/webui/tests/towerTracker.test.js
+++ b/webui/tests/towerTracker.test.js
@@ -20,4 +20,14 @@ describe('TowerTracker', () => {
     expect(wifi[0].ssid).toBe('Test');
     expect(bt[0].name).toBe('Phone');
   });
+
+  it('async logging and retrieval', async () => {
+    const tr = new TowerTracker();
+    await tr.logWifi('DE:AD:BE', 'Net', undefined, undefined, 50);
+    await tr.logBluetooth('AA:BB:CC', 'Headset', undefined, undefined, 60);
+    const wifi = await tr.wifiHistory('DE:AD:BE');
+    const bt = await tr.bluetoothHistory('AA:BB:CC');
+    expect(wifi[0].timestamp).toBe(50);
+    expect(bt[0].timestamp).toBe(60);
+  });
 });


### PR DESCRIPTION
## Summary
- add tile cache unit tests for deg2num, purge and limit
- improve tower scanner tests with proper mocking
- expand tower tracker tests for async history

## Testing
- `npx vitest run tests/tileCache.test.js tests/towerScanner.test.js tests/towerTracker.test.js tests/utils.test.js`

------
https://chatgpt.com/codex/tasks/task_e_685dbb881c388333a981699f13a4a3ad