### PR TITLE
Add React tests for persistence and remote sync modules

### DIFF
--- a/webui/tests/persistence.test.js
+++ b/webui/tests/persistence.test.js
@@ -1,0 +1,43 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { saveHealthRecord, loadRecentHealth, saveAppState, loadAppState, saveDashboardSettings, loadDashboardSettings, purgeOldHealth } from '../src/persistence.js';
+
+// clear localStorage before each test
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('persistence utilities', () => {
+  it('saves and loads health record', async () => {
+    const rec = { timestamp: 't', cpu_temp: 1.0, cpu_percent: 2.0, memory_percent: 3.0, disk_percent: 4.0 };
+    await saveHealthRecord(rec);
+    const rows = await loadRecentHealth(1);
+    expect(rows.length).toBe(1);
+    expect(rows[0].cpu_temp).toBe(1.0);
+  });
+
+  it('saves and loads app state', async () => {
+    const state = { last_screen: 'Stats', last_start: 'now', first_run: false };
+    await saveAppState(state);
+    const loaded = await loadAppState();
+    expect(loaded).toEqual(state);
+  });
+
+  it('saves and loads dashboard settings', async () => {
+    const settings = { layout: [{ cls: 'TestWidget', pos: [1, 2] }], widgets: ['TestWidget'] };
+    await saveDashboardSettings(settings);
+    const loaded = await loadDashboardSettings();
+    expect(loaded).toEqual(settings);
+  });
+
+  it('purges old health records', async () => {
+    const old = { timestamp: new Date(Date.now() - 3 * 24 * 60 * 60 * 1000).toISOString(), cpu_temp: 1, cpu_percent: 1, memory_percent: 1, disk_percent: 1 };
+    const newer = { timestamp: new Date().toISOString(), cpu_temp: 2, cpu_percent: 2, memory_percent: 2, disk_percent: 2 };
+    await saveHealthRecord(old);
+    await saveHealthRecord(newer);
+    const remaining = await purgeOldHealth(1);
+    expect(remaining).toBe(1);
+    const rows = await loadRecentHealth(10);
+    expect(rows.length).toBe(1);
+    expect(rows[0].timestamp).toBe(newer.timestamp);
+  });
+});

--- a/webui/tests/rIntegration.test.js
+++ b/webui/tests/rIntegration.test.js
@@ -1,0 +1,25 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { healthSummary, setRpy2Available } from '../src/rIntegration.js';
+
+describe('rIntegration health summary', () => {
+  let origFetch;
+  beforeEach(() => { origFetch = global.fetch; });
+  afterEach(() => { global.fetch = origFetch; setRpy2Available(true); });
+
+  it('throws when rpy2 is missing', async () => {
+    setRpy2Available(false);
+    await expect(healthSummary('data.csv')).rejects.toThrow('rpy2 is required');
+  });
+
+  it('summarizes without plot', async () => {
+    global.fetch = vi.fn(() => Promise.resolve({ text: () => Promise.resolve('1\n2\n3') }));
+    const result = await healthSummary('file.csv');
+    expect(result).toEqual({ average: 2 });
+  });
+
+  it('summarizes with plot path', async () => {
+    global.fetch = vi.fn(() => Promise.resolve({ text: () => Promise.resolve('2\n4') }));
+    const result = await healthSummary('file.csv', 'out.png');
+    expect(result).toEqual({ average: 3, plot: 'out.png' });
+  });
+});

--- a/webui/tests/remoteSync.test.js
+++ b/webui/tests/remoteSync.test.js
@@ -1,0 +1,30 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { syncDatabaseToServer } from '../src/remoteSync.js';
+
+vi.useFakeTimers();
+
+describe('remoteSync', () => {
+  let origFetch;
+  beforeEach(() => { origFetch = global.fetch; });
+  afterEach(() => { global.fetch = origFetch; vi.clearAllTimers(); });
+
+  it('retries on failure', async () => {
+    const fetchMock = vi.fn()
+      .mockRejectedValueOnce(new Error('fail'))
+      .mockResolvedValue({ ok: true });
+    global.fetch = fetchMock;
+    const promise = syncDatabaseToServer('db', 'http://remote', { retries: 1, timeout: 0 });
+    await vi.runAllTimersAsync();
+    await expect(promise).resolves.toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('fails after retries exhausted', async () => {
+    const fetchMock = vi.fn(() => Promise.reject(new Error('boom')));
+    global.fetch = fetchMock;
+    const promise = syncDatabaseToServer('db', 'http://remote', { retries: 1, timeout: 0 });
+    await vi.runAllTimersAsync();
+    await expect(promise).rejects.toThrow('boom');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/webui/tests/remoteSyncPkg.test.js
+++ b/webui/tests/remoteSyncPkg.test.js
@@ -1,0 +1,27 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { syncNewRecords } from '../src/remoteSyncPkg.js';
+import * as remoteSync from '../src/remoteSync.js';
+import * as persistence from '../src/persistence.js';
+
+describe('remoteSyncPkg', () => {
+  beforeEach(() => { localStorage.clear(); });
+  afterEach(() => { vi.restoreAllMocks(); });
+
+  it('returns 0 when no new records', async () => {
+    vi.spyOn(persistence, 'loadRecentHealth').mockResolvedValue([]);
+    const count = await syncNewRecords('db', 'http://x');
+    expect(count).toBe(0);
+  });
+
+  it('syncs new records and updates state', async () => {
+    vi.spyOn(persistence, 'loadRecentHealth').mockResolvedValue([
+      { t: 1 }, { t: 2 }, { t: 3 }
+    ]);
+    const syncSpy = vi.spyOn(remoteSync, 'syncDatabaseToServer').mockResolvedValue(true);
+    localStorage.setItem('syncState', '1');
+    const count = await syncNewRecords('db', 'http://x', { stateKey: 'syncState' });
+    expect(count).toBe(2);
+    expect(syncSpy).toHaveBeenCalledWith('db', 'http://x', { retries: 3, rowRange: [2, 3] });
+    expect(localStorage.getItem('syncState')).toBe('3');
+  });
+});

--- a/webui/tests/rfUtils.test.js
+++ b/webui/tests/rfUtils.test.js
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { spectrumScan, demodulateFm } from '../src/rfUtils.js';
+
+describe('rfUtils', () => {
+  it('spectrumScan returns freq and power arrays', () => {
+    const [freqs, power] = spectrumScan(100, { sampleRate: 4, numSamples: 4 });
+    expect(freqs.length).toBe(4);
+    expect(power.length).toBe(4);
+    expect(freqs[0]).toBeCloseTo(98);
+  });
+
+  it('demodulateFm returns expected constant', () => {
+    const audio = demodulateFm(100, { sampleRate: 8, audioRate: 2, duration: 1 });
+    expect(audio.length).toBe(2);
+    audio.forEach(val => {
+      expect(Math.abs(val - Math.PI / 2)).toBeLessThan(1e-6);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add Vitest specs for persistence utilities
- create tests for rIntegration health summary
- test remote sync retry logic
- add incremental sync tests
- cover RF utility functions

## Testing
- `npm install` *(fails: could not resolve dependency)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685dbb7686888333a4969c1646fe4dd1