### PR TITLE
Add React diagnostics utilities

### DIFF
--- a/webui/README.md
+++ b/webui/README.md
@@ -133,3 +133,15 @@ await exportMapKml(track, filtered, [], 'track.kml');
 ```
 
 Supported formats are **CSV**, **JSON**, **GPX**, **KML**, **GeoJSON** and **SHP**.
+
+## 12. Diagnostics Helpers
+
+`diagnostics.js` offers utilities for gathering system metrics and rotating log files similar to the Python module.
+
+```javascript
+import { selfTest, rotateLog } from './src/diagnostics.js';
+
+const report = selfTest();
+rotateLog('/var/log/piwardrive.log');
+```
+

--- a/webui/src/diagnostics.js
+++ b/webui/src/diagnostics.js
@@ -1,0 +1,119 @@
+import os from 'os';
+import fs from 'fs';
+import { execSync } from 'child_process';
+import { gzipSync } from 'zlib';
+
+let lastNetworkOk = 0;
+
+function getCpuTemp() {
+  try {
+    const text = fs.readFileSync('/sys/class/thermal/thermal_zone0/temp', 'utf8');
+    return parseFloat(text) / 1000;
+  } catch (_) {
+    try {
+      const out = execSync('vcgencmd measure_temp', { encoding: 'utf8' });
+      const m = out.match(/temp=([\d.]+)/);
+      if (m) return parseFloat(m[1]);
+    } catch (_) {
+      return null;
+    }
+  }
+  return null;
+}
+
+function getDiskPercent() {
+  try {
+    const out = execSync("df -P / | awk 'NR==2 {print $5}'", { encoding: 'utf8' });
+    return parseFloat(out) || 0;
+  } catch (_) {
+    return 0;
+  }
+}
+
+export function generateSystemReport() {
+  return {
+    timestamp: new Date().toISOString(),
+    cpu_temp: getCpuTemp(),
+    cpu_percent: (os.loadavg()[0] * 100) / os.cpus().length,
+    memory_percent: (1 - os.freemem() / os.totalmem()) * 100,
+    disk_percent: getDiskPercent(),
+  };
+}
+
+export function runNetworkTest(host = '8.8.8.8', cacheSeconds = 30) {
+  const now = Date.now() / 1000;
+  if (lastNetworkOk && now - lastNetworkOk < cacheSeconds) return true;
+  try {
+    execSync(`ping -c 1 ${host}`, { stdio: 'ignore' });
+    lastNetworkOk = now;
+    return true;
+  } catch (_) {
+    return false;
+  }
+}
+
+export function getInterfaceStatus() {
+  const ifaces = os.networkInterfaces();
+  const res = {};
+  for (const name of Object.keys(ifaces)) {
+    res[name] = (ifaces[name] || []).length > 0;
+  }
+  return res;
+}
+
+export function listUsbDevices() {
+  try {
+    const out = execSync('lsusb', { encoding: 'utf8' });
+    return out.trim().split(/\r?\n/);
+  } catch (_) {
+    return [];
+  }
+}
+
+export function getServiceStatuses(services = ['kismet', 'bettercap', 'gpsd']) {
+  const result = {};
+  for (const svc of services) {
+    try {
+      const out = execSync(`systemctl is-active ${svc}`, { encoding: 'utf8' });
+      result[svc] = out.trim() === 'active';
+    } catch (_) {
+      result[svc] = false;
+    }
+  }
+  return result;
+}
+
+export function rotateLog(path, maxFiles = 3) {
+  if (!fs.existsSync(path)) return;
+  for (const ext of ['.gz', '']) {
+    const old = `${path}.${maxFiles}${ext}`;
+    if (fs.existsSync(old)) fs.unlinkSync(old);
+  }
+  for (let i = maxFiles - 1; i >= 1; i--) {
+    const srcGz = `${path}.${i}.gz`;
+    const dstGz = `${path}.${i + 1}.gz`;
+    if (fs.existsSync(srcGz)) {
+      fs.renameSync(srcGz, dstGz);
+      continue;
+    }
+    const src = `${path}.${i}`;
+    if (fs.existsSync(src)) {
+      fs.renameSync(src, dstGz);
+    }
+  }
+  const tmp = `${path}.1`;
+  fs.renameSync(path, tmp);
+  const data = fs.readFileSync(tmp);
+  fs.writeFileSync(`${tmp}.gz`, gzipSync(data));
+  fs.unlinkSync(tmp);
+}
+
+export function selfTest() {
+  return {
+    system: generateSystemReport(),
+    network_ok: runNetworkTest(),
+    interfaces: getInterfaceStatus(),
+    usb: listUsbDevices(),
+    services: getServiceStatuses(),
+  };
+}

--- a/webui/src/errorReporting.js
+++ b/webui/src/errorReporting.js
@@ -1,0 +1,1 @@
+export { reportError } from './exceptionHandler.js';

--- a/webui/tests/diagnostics.test.js
+++ b/webui/tests/diagnostics.test.js
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi } from 'vitest';
+import fs from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import * as childProcess from 'child_process';
+import { rotateLog, runNetworkTest, listUsbDevices } from '../src/diagnostics.js';
+
+describe('rotateLog', () => {
+  it('compresses and rotates', () => {
+    const dir = fs.mkdtempSync(join(tmpdir(), 'logs-'));
+    const log = join(dir, 'app.log');
+    fs.writeFileSync(log, 'first');
+    rotateLog(log, 2);
+    expect(fs.existsSync(`${log}.1.gz`)).toBe(true);
+    fs.writeFileSync(log, 'second');
+    rotateLog(log, 2);
+    expect(fs.existsSync(`${log}.2.gz`)).toBe(true);
+    fs.writeFileSync(log, 'third');
+    rotateLog(log, 2);
+    expect(fs.existsSync(`${log}.3.gz`)).toBe(false);
+  });
+});
+
+describe('runNetworkTest', () => {
+  it('uses cache on success', () => {
+    const spy = vi.spyOn(childProcess, 'execSync').mockReturnValue('');
+    expect(runNetworkTest('localhost', 30)).toBe(true);
+    const calls = spy.mock.calls.length;
+    expect(runNetworkTest('localhost', 30)).toBe(true);
+    expect(spy.mock.calls.length).toBe(calls);
+    spy.mockRestore();
+  });
+
+  it('handles failure', () => {
+    const spy = vi.spyOn(childProcess, 'execSync').mockImplementation(() => {
+      throw new Error('fail');
+    });
+    expect(runNetworkTest('localhost', 0)).toBe(false);
+    spy.mockRestore();
+  });
+});
+
+describe('listUsbDevices', () => {
+  it('returns empty on failure', () => {
+    const spy = vi.spyOn(childProcess, 'execSync').mockImplementation(() => {
+      throw new Error('boom');
+    });
+    expect(listUsbDevices()).toEqual([]);
+    spy.mockRestore();
+  });
+});

--- a/webui/tests/errorReporting.test.js
+++ b/webui/tests/errorReporting.test.js
@@ -1,0 +1,11 @@
+import { describe, it, expect, vi } from 'vitest';
+vi.mock('../src/exceptionHandler.js', () => ({ reportError: vi.fn() }));
+import { reportError } from '../src/errorReporting.js';
+import { reportError as inner } from '../src/exceptionHandler.js';
+
+describe('error reporting', () => {
+  it('delegates to exception handler', () => {
+    reportError('boom');
+    expect(inner).toHaveBeenCalledWith('boom');
+  });
+});


### PR DESCRIPTION
## Summary
- add a diagnostics helper module for Node/React
- re-export reportError for convenience
- document the new diagnostics helpers
- add vitest coverage for diagnostics and error reporting

## Testing
- `npm install --legacy-peer-deps`
- `npm test` *(fails: Failed to resolve imports and missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685dbb5f33b083339c7da1454d674ab9