### PR TITLE
Add exception handler install-once behavior

### DIFF
--- a/src/piwardrive/exception_handler.py
+++ b/src/piwardrive/exception_handler.py
@@ -1,6 +1,9 @@
-"""Module exception_handler."""
+"""Helpers for capturing uncaught exceptions."""
 import logging
 from kivy.base import ExceptionHandler, ExceptionManager
+
+
+_installed = False
 
 
 class LogExceptionHandler(ExceptionHandler):
@@ -17,4 +20,12 @@ class LogExceptionHandler(ExceptionHandler):
 
 def install():
     """Register the log exception handler with Kivy."""
+    global _installed
+    if _installed:
+        return
+    for h in ExceptionManager.handlers:
+        if isinstance(h, LogExceptionHandler):
+            _installed = True
+            return
     ExceptionManager.add_handler(LogExceptionHandler())
+    _installed = True


### PR DESCRIPTION
## Summary
- make exception handler idempotent so multiple installs don't add duplicates
- improve associated tests

## Testing
- `flake8 src/piwardrive/exception_handler.py tests/test_exception_handler.py`
- `pytest tests/test_exception_handler.py -q`


------
https://chatgpt.com/codex/tasks/task_e_685dc1d860e48333b922f69ff4549330