### PR TITLE
Add log bundle export CLI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ log-follow = "piwardrive.scripts.log_follow:main"
 config-cli = "piwardrive.scripts.config_cli:main"
 calibrate-orientation = "piwardrive.scripts.calibrate_orientation:main"
 piwardrive-kiosk = "piwardrive.scripts.kiosk:main"
+export-log-bundle = "piwardrive.scripts.export_log_bundle:main"
 
 
 

--- a/scripts/export_log_bundle.py
+++ b/scripts/export_log_bundle.py
@@ -1,0 +1,31 @@
+"""Module export_log_bundle."""
+import argparse
+import asyncio
+
+try:  # allow tests to substitute a lightweight main module
+    from main import PiWardriveApp  # type: ignore
+except Exception:  # pragma: no cover - fallback
+    from piwardrive.main import PiWardriveApp
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Bundle recent log files into an archive."""
+    parser = argparse.ArgumentParser(description="Export a bundled archive of logs")
+    parser.add_argument("output", nargs="?", help="Output file path")
+    parser.add_argument(
+        "--lines",
+        "-n",
+        type=int,
+        default=200,
+        help="Number of lines from each log to include",
+    )
+    args = parser.parse_args(argv)
+
+    app = PiWardriveApp()
+    path = asyncio.run(app.export_log_bundle(args.output, args.lines))
+    if path:
+        print(path)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation
+    main()

--- a/tests/test_export_log_bundle_script.py
+++ b/tests/test_export_log_bundle_script.py
@@ -1,0 +1,23 @@
+import sys
+from types import SimpleNamespace
+
+
+def test_export_log_bundle_script(monkeypatch, tmp_path):
+    called = {}
+
+    async def fake_bundle(self, path=None, lines=200):
+        called['path'] = path
+        called['lines'] = lines
+        return 'ok'
+
+    class DummyApp:
+        export_log_bundle = fake_bundle
+
+    monkeypatch.setitem(sys.modules, 'main', SimpleNamespace(PiWardriveApp=DummyApp))
+    if 'piwardrive.scripts.export_log_bundle' in sys.modules:
+        del sys.modules['piwardrive.scripts.export_log_bundle']
+    import piwardrive.scripts.export_log_bundle as ex
+    ex.main([str(tmp_path / 'bundle.zip'), '--lines', '5'])
+    assert called['path'] == str(tmp_path / 'bundle.zip')
+    assert called['lines'] == 5
+


### PR DESCRIPTION
## Summary
- add `export_log_bundle.py` CLI utility to archive recent logs
- implement `export_log_bundle` method in `PiWardriveApp`
- expose new script in `pyproject.toml`
- test CLI wrapper

## Testing
- `pre-commit run --files scripts/export_log_bundle.py tests/test_export_log_bundle_script.py pyproject.toml src/piwardrive/main.py` *(fails: command not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685dc1e247b88333be197d330ea9a112