### PR TITLE
Add common error reporting utilities

### DIFF
--- a/src/piwardrive/error_reporting.py
+++ b/src/piwardrive/error_reporting.py
@@ -1,0 +1,30 @@
+import logging
+
+try:
+    from kivy.app import App  # type: ignore
+except Exception:  # pragma: no cover - allow running without Kivy
+    class App:
+        @staticmethod
+        def get_running_app() -> None:
+            return None
+
+ERROR_PREFIX = "E"
+
+
+def format_error(code: int, message: str) -> str:
+    """Return standardized error string like ``[E001] message``."""
+    return f"[{ERROR_PREFIX}{int(code):03d}] {message}"
+
+
+def report_error(message: str) -> None:
+    """Log the error and display an alert via the running app if possible."""
+    logging.error(message)
+    try:
+        app = App.get_running_app()
+        if app and hasattr(app, "show_alert"):
+            app.show_alert("Error", message)
+    except Exception as exc:  # pragma: no cover - app may not be running
+        logging.exception("Failed to display error alert: %s", exc)
+
+
+__all__ = ["App", "ERROR_PREFIX", "format_error", "report_error"]

--- a/src/piwardrive/utils.py
+++ b/src/piwardrive/utils.py
@@ -1,1 +1,16 @@
-from .core.utils import *  # noqa: F401,F403
+"""Shared utilities with optional core features."""
+from __future__ import annotations
+
+from .error_reporting import App, format_error, report_error
+
+__all__ = ["App", "format_error", "report_error"]
+
+try:  # pragma: no cover - optional dependencies may be missing
+    from .core.utils import *  # type: ignore  # noqa: F401,F403
+    from .core.utils import __all__ as _core_all  # type: ignore
+    for _name in _core_all:
+        if _name not in __all__:
+            __all__.append(_name)
+except Exception:
+    # core utils couldn't be imported; keep basic functionality
+    pass


### PR DESCRIPTION
## Summary
- add a minimal `error_reporting` module with `report_error`
- rework `utils` to use the new module and allow importing without optional deps

## Testing
- `flake8 src/piwardrive/error_reporting.py src/piwardrive/utils.py`
- `pytest -q tests/test_error_reporting.py`


------
https://chatgpt.com/codex/tasks/task_e_685dc1d3c4bc833386b38e62840d0c96