### PR TITLE
Add event loop startup for HealthMonitor

### DIFF
--- a/src/piwardrive/diagnostics.py
+++ b/src/piwardrive/diagnostics.py
@@ -243,6 +243,10 @@ class HealthMonitor:
         collector: DataCollector | None = None,
         daily_summary: bool = False,
     ) -> None:
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            asyncio.set_event_loop(asyncio.new_event_loop())
         self._scheduler = scheduler
         self._interval = interval
         self._collector: DataCollector = collector or SelfTestCollector()


### PR DESCRIPTION
## Summary
- ensure event loop exists when creating `HealthMonitor`
- provide diagnostics and health monitor tests

## Testing
- `pytest -q tests/test_diagnostics.py tests/test_health_monitor.py`

------
https://chatgpt.com/codex/tasks/task_e_685dc1cd9ab88333a351e82b19e76633