### PR TITLE
Add Node config watcher

### DIFF
--- a/scripts/configWatcher.js
+++ b/scripts/configWatcher.js
@@ -1,0 +1,16 @@
+const fs = require('fs');
+const path = require('path');
+
+function watchConfig(filePath, callback) {
+  const abs = path.resolve(filePath);
+  const dir = path.dirname(abs);
+  const base = path.basename(abs);
+  const watcher = fs.watch(dir, { persistent: true }, (eventType, filename) => {
+    if (!filename || filename === base) {
+      callback();
+    }
+  });
+  return watcher;
+}
+
+module.exports = { watchConfig };

--- a/tests/configWatcher.test.js
+++ b/tests/configWatcher.test.js
@@ -1,0 +1,28 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { watchConfig } = require('../scripts/configWatcher.js');
+
+function sleep(ms) {
+  return new Promise(r => setTimeout(r, ms));
+}
+
+test('watchConfig triggers on change', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cfg-'));
+  const file = path.join(dir, 'config.json');
+  fs.writeFileSync(file, '{}');
+  let triggered = false;
+  const watcher = watchConfig(file, () => { triggered = true; });
+  try {
+    await sleep(100);
+    fs.writeFileSync(file, '{"a":1}');
+    for (let i = 0; i < 20 && !triggered; i++) {
+      await sleep(100);
+    }
+  } finally {
+    watcher.close();
+  }
+  assert.ok(triggered);
+});


### PR DESCRIPTION
## Summary
- add `watchConfig` helper to monitor a file and invoke callback on changes
- test Node implementation of config watcher

## Testing
- `pytest -q tests/test_config_watcher.py`
- `node --test tests/configWatcher.test.js`

------
https://chatgpt.com/codex/tasks/task_e_685dc1b82b8483339fdbb1a0ea7cb590