### PR TITLE
Add JS wrapper test for kiosk script

### DIFF
--- a/webui/src/startKioskScript.js
+++ b/webui/src/startKioskScript.js
@@ -1,0 +1,15 @@
+import { spawn as _spawn } from 'child_process';
+import { fileURLToPath } from 'url';
+import path from 'path';
+
+export function runStartKioskScript({ args = [], env = process.env, spawnFn = _spawn } = {}) {
+  const scriptPath = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', '..', 'scripts', 'start_kiosk.sh');
+  return new Promise((resolve, reject) => {
+    const proc = spawnFn('bash', [scriptPath, ...args], { env });
+    proc.on('error', reject);
+    proc.on('exit', code => {
+      if (code === 0) resolve(true);
+      else reject(new Error(`script exited with code ${code}`));
+    });
+  });
+}

--- a/webui/tests/startKioskScript.test.js
+++ b/webui/tests/startKioskScript.test.js
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { runStartKioskScript } from '../src/startKioskScript.js';
+
+describe('runStartKioskScript', () => {
+  it('launches server and browser', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'kiosk-'));
+    const bin = path.join(tmp, 'bin');
+    fs.mkdirSync(bin);
+    const log = path.join(tmp, 'log.txt');
+
+    fs.writeFileSync(
+      path.join(bin, 'piwardrive-webui'),
+      `#!/bin/sh\necho server_started >> "${log}"\ntrap 'exit 0' TERM\nwhile true; do sleep 0.1; done\n`
+    );
+    fs.writeFileSync(
+      path.join(bin, 'chromium-browser'),
+      `#!/bin/sh\necho browser_called >> "${log}"\n`
+    );
+    fs.writeFileSync(path.join(bin, 'sleep'), '#!/bin/sh\n:');
+    for (const f of ['piwardrive-webui', 'chromium-browser', 'sleep']) {
+      fs.chmodSync(path.join(bin, f), 0o755);
+    }
+
+    const env = { ...process.env, PATH: `${bin}:${process.env.PATH}` };
+    await runStartKioskScript({ args: ['--delay', '0'], env });
+
+    const text = fs.readFileSync(log, 'utf8');
+    expect(text).toContain('server_started');
+    expect(text).toContain('browser_called');
+  });
+});


### PR DESCRIPTION
## Summary
- add a startKioskScript wrapper to spawn the shell script
- verify behavior with a new Vitest suite

## Testing
- `npx vitest run tests/startKioskScript.test.js`
- `pytest -q` *(fails: ModuleNotFoundError: fastapi, aiosqlite, pydantic, requests_cache)*
- `pre-commit run --files webui/src/startKioskScript.js webui/tests/startKioskScript.test.js` *(fails: InvalidManifestError)*

------
https://chatgpt.com/codex/tasks/task_e_685dc1a6a9bc833394553a047253fce9