### PR TITLE
Add Node CLI test for tile maintenance

### DIFF
--- a/webui/tests/run_tile_maintenance_cli.py
+++ b/webui/tests/run_tile_maintenance_cli.py
@@ -1,0 +1,23 @@
+import sys
+import json
+
+from piwardrive.scripts import tile_maintenance_cli as cli
+
+called = {}
+
+def fake_purge(folder, days):
+    called["purge"] = [folder, int(days)]
+
+def fake_limit(folder, limit):
+    called["limit"] = [folder, int(limit)]
+
+def fake_vacuum(path):
+    called["vacuum"] = path
+
+cli.tile_maintenance.purge_old_tiles = fake_purge
+cli.tile_maintenance.enforce_cache_limit = fake_limit
+cli.tile_maintenance.vacuum_mbtiles = fake_vacuum
+
+cli.main(sys.argv[1:])
+
+print(json.dumps(called))

--- a/webui/tests/tileMaintenanceCli.js
+++ b/webui/tests/tileMaintenanceCli.js
@@ -1,0 +1,16 @@
+import { execFileSync } from 'child_process';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+export function runCli(args = []) {
+  const script = path.join(__dirname, 'run_tile_maintenance_cli.py');
+  const out = execFileSync('python', [script, ...args], {
+    cwd: path.join(__dirname, '..'),
+    env: { ...process.env, PYTHONPATH: path.join('..', 'src') },
+    encoding: 'utf-8'
+  });
+  return JSON.parse(out);
+}

--- a/webui/tests/tileMaintenanceCli.test.js
+++ b/webui/tests/tileMaintenanceCli.test.js
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { runCli } from './tileMaintenanceCli.js';
+
+describe('tile maintenance CLI', () => {
+  it('parses args and calls maintenance functions', () => {
+    const result = runCli([
+      '--purge',
+      '--limit',
+      '--vacuum',
+      '--offline',
+      'db.mbtiles',
+      '--folder',
+      'cache',
+      '--max-age-days',
+      '1',
+      '--limit-mb',
+      '2',
+    ]);
+    expect(result).toEqual({
+      purge: ['cache', 1],
+      limit: ['cache', 2],
+      vacuum: 'db.mbtiles',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add Python harness for tile_maintenance_cli
- add JS wrapper to execute the harness
- test CLI options via the new wrapper

## Testing
- `pytest -q`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685dc1ace28483339fa1d6d2b9117a64