### PR TITLE
Add TypeScript DI container

### DIFF
--- a/webui/src/di.ts
+++ b/webui/src/di.ts
@@ -1,0 +1,31 @@
+export type Factory<T> = () => T;
+
+export class Container {
+  private instances = new Map<string, unknown>();
+  private factories = new Map<string, Factory<unknown>>();
+
+  registerInstance<T>(key: string, instance: T): void {
+    this.instances.set(key, instance);
+  }
+
+  registerFactory<T>(key: string, factory: Factory<T>): void {
+    this.factories.set(key, factory as Factory<unknown>);
+  }
+
+  has(key: string): boolean {
+    return this.instances.has(key) || this.factories.has(key);
+  }
+
+  resolve<T>(key: string): T {
+    if (this.instances.has(key)) {
+      return this.instances.get(key) as T;
+    }
+    if (this.factories.has(key)) {
+      const factory = this.factories.get(key) as Factory<T>;
+      const inst = factory();
+      this.instances.set(key, inst);
+      return inst;
+    }
+    throw new Error(`No provider for ${key}`);
+  }
+}

--- a/webui/tests/di.test.ts
+++ b/webui/tests/di.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { Container } from '../src/di.js';
+import { Container } from '../src/di.ts';
 
 describe('Container', () => {
   it('registers instance and resolves', () => {


### PR DESCRIPTION
## Summary
- port DI container to TypeScript
- convert DI tests to use TypeScript

## Testing
- `npx vitest run tests/di.test.ts`
- `pytest tests/test_di.py -q`
- `pre-commit run --files src/piwardrive/di.py tests/test_di.py webui/src/di.ts webui/tests/di.test.ts` *(fails: InvalidManifestError due to missing GitHub access)*

------
https://chatgpt.com/codex/tasks/task_e_685dc1c94a34833394e2c2bd10c2190c