### PR TITLE
Implement continuous scan service

### DIFF
--- a/src/piwardrive/integrations/sigint_suite/continuous_scan.py
+++ b/src/piwardrive/integrations/sigint_suite/continuous_scan.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from typing import Callable, Dict, List
+import time
+
+from .wifi import scan_wifi
+from .bluetooth import scan_bluetooth
+
+Result = Dict[str, List]
+
+
+def scan_once() -> Result:
+    """Return Wi-Fi and Bluetooth scan results."""
+    wifi = scan_wifi()
+    bt = scan_bluetooth()
+    return {"wifi": wifi, "bluetooth": bt}
+
+
+def run_continuous_scan(
+    interval: float = 60.0,
+    iterations: int = 0,
+    on_result: Callable[[Result], None] | None = None,
+) -> None:
+    """Run :func:`scan_once` repeatedly."""
+    count = 0
+    while True:
+        result = scan_once()
+        if on_result:
+            on_result(result)
+        count += 1
+        if iterations and count >= iterations:
+            break
+        time.sleep(interval)

--- a/tests/test_continuous_scan.py
+++ b/tests/test_continuous_scan.py
@@ -1,15 +1,29 @@
-import os
-import sys
 import json
 
+import piwardrive.sigint_suite.continuous_scan as cs
+import piwardrive.sigint_suite.scripts.continuous_scan as cli
 
-import piwardrive.sigint_suite.scripts.continuous_scan as cs
+
+def test_scan_once_returns_data(monkeypatch):
+    monkeypatch.setattr(cs, "scan_wifi", lambda: [{"ssid": "x"}])
+    monkeypatch.setattr(cs, "scan_bluetooth", lambda: [{"address": "a"}])
+    result = cs.scan_once()
+    assert result["wifi"][0]["ssid"] == "x"
+    assert result["bluetooth"][0]["address"] == "a"
+
+
+def test_run_continuous_scan_iterations(monkeypatch):
+    calls = {"n": 0}
+    monkeypatch.setattr(cs, "scan_wifi", lambda: [])
+    monkeypatch.setattr(cs, "scan_bluetooth", lambda: [])
+    monkeypatch.setattr(cs.time, "sleep", lambda _s: None)
+    cs.run_continuous_scan(interval=0, iterations=3, on_result=lambda _r: calls.update(n=calls["n"] + 1))
+    assert calls["n"] == 3
 
 
 def test_run_once_writes_json(tmp_path, monkeypatch):
-    monkeypatch.setattr(cs, "scan_wifi", lambda: [{"ssid": "x"}])
-    monkeypatch.setattr(cs, "scan_bluetooth", lambda: [{"address": "a"}])
-    cs.run_once(str(tmp_path))
+    monkeypatch.setattr(cs, "scan_once", lambda: {"wifi": [{"ssid": "x"}], "bluetooth": [{"address": "a"}]})
+    cli.run_once(str(tmp_path))
     wifi = json.load(open(tmp_path / "wifi.json"))
     bt = json.load(open(tmp_path / "bluetooth.json"))
     assert wifi[0]["ssid"] == "x"
@@ -19,10 +33,13 @@ def test_run_once_writes_json(tmp_path, monkeypatch):
 def test_main_runs_iterations(tmp_path, monkeypatch):
     calls = {"n": 0}
 
-    def fake_run_once(_dir: str) -> None:
+    def fake_save(_dir: str, _res: cs.Result) -> None:
         calls["n"] += 1
 
-    monkeypatch.setattr(cs, "run_once", fake_run_once)
+    monkeypatch.setattr(cli, "_save_results", fake_save)
+    monkeypatch.setattr(cs, "scan_once", lambda: {"wifi": [], "bluetooth": []})
     monkeypatch.setattr(cs.time, "sleep", lambda _s: None)
-    cs.main(["--interval", "0", "--iterations", "3", "--export-dir", str(tmp_path)])
+
+    cli.main(["--interval", "0", "--iterations", "3", "--export-dir", str(tmp_path)])
     assert calls["n"] == 3
+


### PR DESCRIPTION
## Summary
- implement continuous scan routines in `sigint_suite`
- update CLI helper to use new routines
- port continuous scan tests

## Testing
- `pytest tests/test_continuous_scan.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'watchdog')*

------
https://chatgpt.com/codex/tasks/task_e_685dc1bf70248333bd4033bd09d5c288