### PR TITLE
Add SIGINT integration JS helper & tests

### DIFF
--- a/webui/src/sigintIntegration.js
+++ b/webui/src/sigintIntegration.js
@@ -1,0 +1,20 @@
+import fs from 'fs';
+import path from 'path';
+import { EXPORT_DIR } from './sigintPaths.js';
+
+export function loadSigintData(name) {
+  const exportDir = process.env.SIGINT_EXPORT_DIR || EXPORT_DIR;
+  const file = path.join(exportDir, `${name}.json`);
+  try {
+    const text = fs.readFileSync(file, 'utf-8');
+    const data = JSON.parse(text);
+    if (Array.isArray(data)) {
+      return data
+        .filter(r => typeof r === 'object' && r !== null)
+        .map(r => ({ ...r }));
+    }
+  } catch {
+    // ignore missing or invalid files
+  }
+  return [];
+}

--- a/webui/tests/sigintIntegration.test.js
+++ b/webui/tests/sigintIntegration.test.js
@@ -1,0 +1,28 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { loadSigintData } from '../src/sigintIntegration.js';
+
+let origDir;
+
+describe('sigint integration', () => {
+  beforeEach(() => { origDir = process.env.SIGINT_EXPORT_DIR; });
+  afterEach(() => {
+    if (origDir === undefined) delete process.env.SIGINT_EXPORT_DIR;
+    else process.env.SIGINT_EXPORT_DIR = origDir;
+  });
+
+  it('returns records from json file', () => {
+    const dir = fs.mkdtempSync(path.join(process.cwd(), 'tmp-'));
+    const data = [{ a: 1 }, { b: 2 }];
+    fs.writeFileSync(path.join(dir, 'wifi.json'), JSON.stringify(data));
+    process.env.SIGINT_EXPORT_DIR = dir;
+    expect(loadSigintData('wifi')).toEqual(data);
+  });
+
+  it('handles missing file', () => {
+    const dir = fs.mkdtempSync(path.join(process.cwd(), 'tmp-'));
+    process.env.SIGINT_EXPORT_DIR = dir;
+    expect(loadSigintData('wifi')).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- expose `loadSigintData` helper in the Web UI
- test JS helper to load SIGINT export files

## Testing
- `pytest tests/test_sigint_integration.py -q`
- `npx vitest run tests/sigintIntegration.test.js` *(fails: vitest not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685dc1a2cd7883339e172666f4492c79