### PR TITLE
Add serviceSync helper and Vitest coverage

### DIFF
--- a/webui/src/serviceSync.js
+++ b/webui/src/serviceSync.js
@@ -1,0 +1,16 @@
+import svc from '../../scripts/serviceSync.js';
+
+export async function serviceSync({ db, url, services = [] } = {}, helpers = {}) {
+  const args = [];
+  if (db) {
+    args.push('--db', db);
+    if (url) args.push('--url', url);
+  }
+  if (url && !db) {
+    args.push('--url', url);
+  }
+  if (services.length) {
+    args.push('--services', ...services);
+  }
+  return await svc.run(args, helpers);
+}

--- a/webui/tests/serviceSync.test.js
+++ b/webui/tests/serviceSync.test.js
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { serviceSync } from '../src/serviceSync.js';
+
+// use actual script but override helpers
+
+describe('serviceSync helper', () => {
+  it('runs script with options', async () => {
+    let uploaded = null;
+    const res = await serviceSync(
+      { db: 'file.db', url: 'http://x', services: ['a', 'b'] },
+      {
+        uploadDb: async (db, url) => { uploaded = { db, url }; },
+        checkStatus: () => true,
+      },
+    );
+    expect(uploaded).toEqual({ db: 'file.db', url: 'http://x' });
+    expect(res).toEqual({ synced: true, status: { a: true, b: true } });
+  });
+
+  it('throws when db or url missing', async () => {
+    await expect(serviceSync({ db: 'only.db' })).rejects.toBeInstanceOf(Error);
+  });
+});


### PR DESCRIPTION
## Summary
- implement `webui/src/serviceSync.js` to expose the CLI logic from `scripts/serviceSync.js`
- add Vitest coverage for the helper

## Testing
- `npx vitest run webui/tests/serviceSync.test.js`
- `pytest tests/test_service_sync.py -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685dc19f529c8333972c37a13172c45d