### PR TITLE
Add tile maintenance helpers and tests

### DIFF
--- a/webui/src/tileMaintenance.js
+++ b/webui/src/tileMaintenance.js
@@ -1,0 +1,8 @@
+import { prefetch, purgeOld, enforceLimit } from '../../scripts/tileMaintenance.js';
+import { execFileSync } from 'child_process';
+
+export { prefetch, purgeOld, enforceLimit };
+
+export function vacuumMbtiles(path) {
+  execFileSync('sqlite3', [path, 'VACUUM']);
+}

--- a/webui/tests/tileMaintenance.test.js
+++ b/webui/tests/tileMaintenance.test.js
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+vi.mock('child_process', () => {
+  const execFileSync = vi.fn();
+  return { default: { execFileSync }, execFileSync };
+});
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import * as childProcess from 'child_process';
+import { prefetch, purgeOld, enforceLimit, vacuumMbtiles } from '../src/tileMaintenance.js';
+
+let origFetch;
+
+describe('tileMaintenance helpers', () => {
+  beforeEach(() => { origFetch = global.fetch; });
+  afterEach(() => { global.fetch = origFetch; });
+
+  it('prefetches and cleans tiles', async () => {
+    global.fetch = vi.fn(() => Promise.resolve({
+      ok: true,
+      arrayBuffer: () => Promise.resolve(new ArrayBuffer(1))
+    }));
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'tiles-'));
+    await prefetch([0, 0, 0.1, 0.1], { zoom: 1, folder: dir });
+    expect(fetch).toHaveBeenCalled();
+
+    const idxPath = path.join(dir, 'tile-cache-index.json');
+    let idx = JSON.parse(fs.readFileSync(idxPath, 'utf8'));
+    const keys = Object.keys(idx);
+    const key = keys[0];
+    const file = path.join(dir, `${key}.png`);
+
+    for (const k of keys) {
+      idx[k].time = Date.now() - 10 * 86400 * 1000;
+      idx[k].size = 1;
+    }
+    fs.writeFileSync(idxPath, JSON.stringify(idx));
+    await purgeOld(dir, 1);
+    expect(fs.existsSync(file)).toBe(false);
+    idx = JSON.parse(fs.readFileSync(idxPath, 'utf8'));
+    expect(idx).toEqual({});
+
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(file, 'x');
+    fs.writeFileSync(idxPath, JSON.stringify({ [key]: { time: Date.now(), size: 10 } }));
+    await enforceLimit(dir, 0);
+    expect(fs.existsSync(file)).toBe(false);
+    idx = JSON.parse(fs.readFileSync(idxPath, 'utf8'));
+    expect(idx).toEqual({});
+  });
+
+  it('vacuumMbtiles runs sqlite3', () => {
+    vacuumMbtiles('test.db');
+    expect(childProcess.execFileSync).toHaveBeenCalledWith('sqlite3', ['test.db', 'VACUUM']);
+  });
+});


### PR DESCRIPTION
## Summary
- expose tile maintenance functions for Node via new module
- test tile prefetch/cleanup helpers

## Testing
- `pytest tests/test_tile_maintenance.py::test_tile_maintenance_runs -q`
- `npx vitest run tests/tileMaintenance.test.js --silent`

------
https://chatgpt.com/codex/tasks/task_e_685dc1a9b6c88333baa2f03c4b25d669