### PR TITLE
Add service command failure handling

### DIFF
--- a/src/piwardrive/core/utils.py
+++ b/src/piwardrive/core/utils.py
@@ -662,9 +662,7 @@ async def _run_service_cmd_async(
         logging.exception(
             "Service command '%s %s' failed: %s", service, action, exc
         )
-        return await asyncio.get_running_loop().run_in_executor(
-            None, lambda: _run_systemctl(service, action)
-        )
+        return False, "", str(exc)
 
 
 def run_service_cmd(


### PR DESCRIPTION
## Summary
- handle DBus errors in `_run_service_cmd_async`
- add tests covering `control_service` and service command helpers

## Testing
- `pytest tests/test_control_service.py -q`
- `pytest tests/test_utils.py::test_run_service_cmd_success tests/test_utils.py::test_run_service_cmd_failure tests/test_utils.py::test_run_service_cmd_retries_until_success -q`


------
https://chatgpt.com/codex/tasks/task_e_685dc1c01f608333b1c081e53a5c7ddb