### PR TITLE
Add Node GPSD client

### DIFF
--- a/scripts/gpsdClient.js
+++ b/scripts/gpsdClient.js
@@ -1,0 +1,84 @@
+"use strict";
+
+let gpsd;
+try {
+  gpsd = require('gpsd');
+} catch {
+  gpsd = null;
+}
+
+class GPSDClient {
+  constructor(host, port, helpers = {}) {
+    this.host = host || process.env.PW_GPSD_HOST || '127.0.0.1';
+    const envPort = process.env.PW_GPSD_PORT;
+    this.port = port !== undefined ? port : envPort ? parseInt(envPort, 10) : 2947;
+    this._connected = false;
+    this._connect = helpers.connect || (gpsd && gpsd.connect);
+    this._getCurrent = helpers.getCurrent || (gpsd && (gpsd.getCurrent || gpsd.get_current));
+  }
+
+  _doConnect() {
+    if (!this._connect) return;
+    try {
+      this._connect(this.host, this.port);
+      this._connected = true;
+    } catch {
+      this._connected = false;
+    }
+  }
+
+  _ensureConnection() {
+    if (!this._connected) {
+      this._doConnect();
+    }
+  }
+
+  _getPacket() {
+    this._ensureConnection();
+    if (!this._connected || !this._getCurrent) return null;
+    try {
+      return this._getCurrent();
+    } catch {
+      this._connected = false;
+      return null;
+    }
+  }
+
+  getPosition() {
+    const pkt = this._getPacket();
+    if (!pkt) return null;
+    try {
+      if (typeof pkt.position === 'function') return pkt.position();
+      if (pkt.lat != null && pkt.lon != null) return [Number(pkt.lat), Number(pkt.lon)];
+    } catch {}
+    return null;
+  }
+
+  getAccuracy() {
+    const pkt = this._getPacket();
+    if (!pkt) return null;
+    try {
+      if (typeof pkt.position_precision === 'function') {
+        const res = pkt.position_precision();
+        return Array.isArray(res) ? Number(res[0]) : null;
+      }
+      if (pkt.epx != null && pkt.epy != null) return Math.max(Number(pkt.epx), Number(pkt.epy));
+    } catch {}
+    return null;
+  }
+
+  getFixQuality() {
+    const pkt = this._getPacket();
+    if (!pkt) return 'Unknown';
+    const map = {1:'No Fix',2:'2D',3:'3D',4:'DGPS'};
+    try {
+      const mode = pkt.mode;
+      if (typeof mode === 'number') return map[mode] || String(mode);
+    } catch {}
+    return 'Unknown';
+  }
+}
+
+const client = new GPSDClient();
+
+module.exports = { GPSDClient, client };

--- a/tests/gpsdClient.test.js
+++ b/tests/gpsdClient.test.js
@@ -1,0 +1,54 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const Module = require('module');
+const path = require('path');
+
+function reloadWithDummy({ connectOk = true, packet = null, raiseOnGet = false, getCurrent } = {}) {
+  const dummy = {
+    connect: () => {
+      if (!connectOk) throw new Error('fail');
+    },
+    getCurrent: getCurrent || (() => {
+      if (raiseOnGet) throw new Error('boom');
+      return packet;
+    }),
+  };
+
+  const original = Module._load;
+  Module._load = (request, parent, isMain) => {
+    if (request === 'gpsd') return dummy;
+    return original(request, parent, isMain);
+  };
+
+  delete require.cache[require.resolve('../scripts/gpsdClient.js')];
+  const mod = require('../scripts/gpsdClient.js');
+  Module._load = original;
+  return mod;
+}
+
+test('getPosition returns null on failure', () => {
+  const mod = reloadWithDummy({ connectOk: false });
+  assert.equal(mod.client.getPosition(), null);
+});
+
+test('reconnect after error', () => {
+  const pkt = { mode: 3, lat: 1.0, lon: 2.0, error: { x: 1.0, y: 1.0 } };
+  let first = true;
+  function getCurrent() {
+    if (first) { first = false; throw new Error('fail'); }
+    return pkt;
+  }
+  const mod = reloadWithDummy({ getCurrent });
+  assert.equal(mod.client.getPosition(), null);
+  assert.deepStrictEqual(mod.client.getPosition(), [1.0, 2.0]);
+});
+
+test('env overrides', () => {
+  process.env.PW_GPSD_HOST = '1.2.3.4';
+  process.env.PW_GPSD_PORT = '1234';
+  const mod = reloadWithDummy();
+  delete process.env.PW_GPSD_HOST;
+  delete process.env.PW_GPSD_PORT;
+  assert.equal(mod.client.host, '1.2.3.4');
+  assert.equal(mod.client.port, 1234);
+});


### PR DESCRIPTION
## Summary
- provide a GPSD client for Node in `scripts/gpsdClient.js`
- add tests for the GPSD client mirroring the Python tests

## Testing
- `node --test tests/gpsdClient.test.js`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685dc70c95a48333a1ed1c80bfe19516