### PR TITLE
Add IMSI catcher compatibility wrapper

### DIFF
--- a/src/piwardrive/sigint_suite/cellular/imsi_catcher/__init__.py
+++ b/src/piwardrive/sigint_suite/cellular/imsi_catcher/__init__.py
@@ -1,0 +1,1 @@
+from ....integrations.sigint_suite.cellular.imsi_catcher import *  # noqa: F401,F403

--- a/src/piwardrive/sigint_suite/cellular/imsi_catcher/scanner.py
+++ b/src/piwardrive/sigint_suite/cellular/imsi_catcher/scanner.py
@@ -1,0 +1,2 @@
+"""Compatibility wrapper importing the IMSI catcher scanner implementation."""
+from piwardrive.integrations.sigint_suite.cellular.imsi_catcher.scanner import *  # noqa: F401,F403


### PR DESCRIPTION
## Summary
- support cell identifier scanning via IMSI catcher utilities
- expose the IMSI catcher modules under `piwardrive.sigint_suite`

## Testing
- `pytest tests/test_imsi_catcher.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685dc719d5048333a12a04874a0eb607