### PR TITLE
Add kiosk CLI module

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ piwardrive-prefetch-batch = "piwardrive.scripts.prefetch_batch:main"
 log-follow = "piwardrive.scripts.log_follow:main"
 config-cli = "piwardrive.scripts.config_cli:main"
 calibrate-orientation = "piwardrive.scripts.calibrate_orientation:main"
-piwardrive-kiosk = "piwardrive.scripts.kiosk:main"
+piwardrive-kiosk = "piwardrive.cli.kiosk:main"
 export-log-bundle = "piwardrive.scripts.export_log_bundle:main"
 
 

--- a/scripts/kiosk.py
+++ b/scripts/kiosk.py
@@ -1,36 +1,12 @@
 """Launch the web UI and open Chromium in kiosk mode."""
-import argparse
-import shutil
-import subprocess
-import time
-from typing import Sequence
+from __future__ import annotations
 
-DEFAULT_URL = "http://localhost:8000"
+import os
+import sys
 
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
 
-def main(argv: Sequence[str] | None = None) -> None:
-    """Start ``piwardrive-webui`` and open Chromium in kiosk mode."""
-    parser = argparse.ArgumentParser(
-        description="Start the API server and open Chromium in kiosk mode"
-    )
-    parser.add_argument(
-        "--url", default=DEFAULT_URL, help="dashboard URL to open"
-    )
-    parser.add_argument(
-        "--delay", type=float, default=2.0, help="seconds to wait for the server"
-    )
-    args = parser.parse_args(list(argv) if argv is not None else None)
-
-    proc = subprocess.Popen(["piwardrive-webui"])
-    try:
-        time.sleep(args.delay)
-        browser = shutil.which("chromium-browser") or shutil.which("chromium")
-        if browser is None:
-            raise FileNotFoundError("Chromium browser not found")
-        subprocess.run([browser, "--kiosk", args.url], check=True)
-    finally:
-        proc.terminate()
-
+from piwardrive.cli.kiosk import main
 
 if __name__ == "__main__":  # pragma: no cover - manual invocation
     main()

--- a/src/piwardrive/cli/kiosk.py
+++ b/src/piwardrive/cli/kiosk.py
@@ -1,0 +1,36 @@
+"""Command line utility to start PiWardrive in browser kiosk mode."""
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+import time
+from typing import Sequence
+
+DEFAULT_URL = "http://localhost:8000"
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    """Launch the dashboard using Chromium in kiosk mode."""
+    parser = argparse.ArgumentParser(
+        description="Start the API server and open Chromium in kiosk mode"
+    )
+    parser.add_argument("--url", default=DEFAULT_URL, help="dashboard URL to open")
+    parser.add_argument(
+        "--delay", type=float, default=2.0, help="seconds to wait for the server"
+    )
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    proc = subprocess.Popen(["piwardrive-webui"])
+    try:
+        time.sleep(args.delay)
+        browser = shutil.which("chromium-browser") or shutil.which("chromium")
+        if browser is None:
+            raise FileNotFoundError("Chromium browser not found")
+        subprocess.run([browser, "--kiosk", args.url], check=True)
+    finally:
+        proc.terminate()
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation
+    main()

--- a/src/piwardrive/kiosk.py
+++ b/src/piwardrive/kiosk.py
@@ -1,0 +1,2 @@
+"""Backward-compatible entry for the kiosk CLI."""
+from .cli.kiosk import *  # noqa: F401,F403


### PR DESCRIPTION
## Summary
- add new CLI module at `piwardrive/cli/kiosk.py`
- expose `piwardrive.kiosk` for backward compatibility
- update `scripts/kiosk.py` to delegate to the package version
- wire up entry point `piwardrive-kiosk` to the new module

## Testing
- `pytest -q tests/test_kiosk_cli.py`

------
https://chatgpt.com/codex/tasks/task_e_685dc723c1d083338d8291b149d99d8b