### PR TITLE
Add RF helper functions

### DIFF
--- a/src/piwardrive/integrations/sigint_suite/rf/__init__.py
+++ b/src/piwardrive/integrations/sigint_suite/rf/__init__.py
@@ -2,5 +2,24 @@
 
 from .demod import demodulate_fm
 from .spectrum import spectrum_scan
+from .utils import (
+    ghz_to_hz,
+    hz_to_ghz,
+    hz_to_khz,
+    hz_to_mhz,
+    khz_to_hz,
+    mhz_to_hz,
+    parse_frequency,
+)
 
-__all__ = ["spectrum_scan", "demodulate_fm"]
+__all__ = [
+    "spectrum_scan",
+    "demodulate_fm",
+    "hz_to_khz",
+    "hz_to_mhz",
+    "hz_to_ghz",
+    "khz_to_hz",
+    "mhz_to_hz",
+    "ghz_to_hz",
+    "parse_frequency",
+]

--- a/src/piwardrive/integrations/sigint_suite/rf/utils.py
+++ b/src/piwardrive/integrations/sigint_suite/rf/utils.py
@@ -1,0 +1,73 @@
+"""RF helper functions for basic frequency conversions."""
+
+from __future__ import annotations
+
+import re
+
+__all__ = [
+    "hz_to_khz",
+    "hz_to_mhz",
+    "hz_to_ghz",
+    "khz_to_hz",
+    "mhz_to_hz",
+    "ghz_to_hz",
+    "parse_frequency",
+]
+
+
+def hz_to_khz(freq: float) -> float:
+    """Return ``freq`` expressed in kHz."""
+    return freq / 1_000.0
+
+
+def hz_to_mhz(freq: float) -> float:
+    """Return ``freq`` expressed in MHz."""
+    return freq / 1_000_000.0
+
+
+def hz_to_ghz(freq: float) -> float:
+    """Return ``freq`` expressed in GHz."""
+    return freq / 1_000_000_000.0
+
+
+def khz_to_hz(freq: float) -> float:
+    """Return ``freq`` expressed in Hz from kHz."""
+    return freq * 1_000.0
+
+
+def mhz_to_hz(freq: float) -> float:
+    """Return ``freq`` expressed in Hz from MHz."""
+    return freq * 1_000_000.0
+
+
+def ghz_to_hz(freq: float) -> float:
+    """Return ``freq`` expressed in Hz from GHz."""
+    return freq * 1_000_000_000.0
+
+
+_UNIT_MAP = {
+    "hz": 1.0,
+    "khz": 1_000.0,
+    "mhz": 1_000_000.0,
+    "ghz": 1_000_000_000.0,
+}
+
+
+def parse_frequency(value: str | float) -> float:
+    """Return frequency in Hz parsed from ``value``.
+
+    Strings may include units like ``kHz``, ``MHz`` or ``GHz`` (case-insensitive).
+    Numbers are assumed to already be in Hz.
+    """
+
+    if isinstance(value, (int, float)):
+        return float(value)
+
+    match = re.match(r"\s*(\d+(?:\.\d+)?)([kKmMgG]?Hz)?\s*", value)
+    if not match:
+        raise ValueError(f"invalid frequency: {value!r}")
+
+    number = float(match.group(1))
+    unit = (match.group(2) or "Hz").lower()
+    scale = _UNIT_MAP.get(unit, 1.0)
+    return number * scale

--- a/tests/test_rf_utils.py
+++ b/tests/test_rf_utils.py
@@ -8,6 +8,12 @@ import pytest
 from piwardrive.sigint_suite.rf.spectrum import spectrum_scan
 from piwardrive.sigint_suite.rf.demod import demodulate_fm
 from piwardrive.sigint_suite.rf import demod as demod_module
+from piwardrive.sigint_suite.rf.utils import (
+    hz_to_khz,
+    hz_to_mhz,
+    mhz_to_hz,
+    parse_frequency,
+)
 
 
 class DummySdr:
@@ -67,3 +73,16 @@ def test_fm_demodulate_basic():
     samples = np.exp(1j * np.linspace(0, np.pi, 5))
     demod = demod_module.fm_demodulate(samples)
     assert np.allclose(demod, np.full(4, np.pi / 4))
+
+
+def test_frequency_conversions():
+    assert mhz_to_hz(100.0) == 100.0 * 1_000_000.0
+    assert hz_to_mhz(50_000_000.0) == 50.0
+    assert hz_to_khz(30_000.0) == 30.0
+
+
+def test_parse_frequency():
+    assert parse_frequency("2.4GHz") == 2.4e9
+    assert parse_frequency("100MHz") == 100e6
+    assert parse_frequency("200kHz") == 200e3
+    assert parse_frequency("300") == 300.0


### PR DESCRIPTION
## Summary
- implement frequency conversion helpers in rf utils
- expose helpers in rf package
- test new helpers with RF utils tests

## Testing
- `pytest tests/test_rf_utils.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685dc7557cb08333a5c56e8b47bae0d7