### PR TITLE
Add dataclass handling to SIGINT JSON exporter

### DIFF
--- a/src/piwardrive/integrations/sigint_suite/exports/exporter.py
+++ b/src/piwardrive/integrations/sigint_suite/exports/exporter.py
@@ -1,6 +1,7 @@
 """Module exporter."""
 import csv
 import json
+from dataclasses import asdict, is_dataclass
 from typing import Any, Iterable, Mapping
 
 
@@ -10,6 +11,8 @@ def export_json(records: Iterable[Any], path: str) -> None:
     def normalise(record: Any) -> Any:
         if hasattr(record, "model_dump"):
             return record.model_dump()
+        if is_dataclass(record):
+            return asdict(record)
         if isinstance(record, Mapping):
             return dict(record)
         return record


### PR DESCRIPTION
## Summary
- support dataclasses when exporting SIGINT data to JSON

## Testing
- `pytest tests/test_sigint_export_json.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685dc76401bc8333a788ee621bc543da