### PR TITLE
Add general SIGINT export formats

### DIFF
--- a/src/piwardrive/integrations/sigint_suite/exports/__init__.py
+++ b/src/piwardrive/integrations/sigint_suite/exports/__init__.py
@@ -1,5 +1,11 @@
 """Data export helpers for SIGINT modules."""
 
-from .exporter import export_csv, export_json, export_yaml
+from .exporter import (
+    export_csv,
+    export_json,
+    export_yaml,
+    export_records,
+    EXPORT_FORMATS,
+)
 
-__all__ = ["export_json", "export_csv", "export_yaml"]
+__all__ = ["export_json", "export_csv", "export_yaml", "export_records", "EXPORT_FORMATS"]

--- a/src/piwardrive/integrations/sigint_suite/exports/exporter.py
+++ b/src/piwardrive/integrations/sigint_suite/exports/exporter.py
@@ -1,7 +1,11 @@
 """Module exporter."""
 import csv
 import json
-from typing import Any, Iterable, Mapping
+from typing import Any, Iterable, Mapping, Sequence
+
+from piwardrive import export as _exp
+
+EXPORT_FORMATS = ("csv", "json", "yaml", "gpx", "kml", "geojson", "shp")
 
 
 def export_json(records: Iterable[Any], path: str) -> None:
@@ -61,3 +65,31 @@ def export_yaml(records: Iterable[Any], path: str) -> None:
             data.append(rec)
     with open(path, "w", encoding="utf-8") as fh:
         yaml.safe_dump(data, fh, sort_keys=False)
+
+
+def export_records(
+    records: Iterable[Mapping[str, Any]],
+    path: str,
+    fmt: str,
+    fields: Sequence[str] | None = None,
+) -> None:
+    """Export ``records`` using ``fmt`` similar to :func:`piwardrive.export.export_records`."""
+
+    fmt = fmt.lower()
+    if fmt not in EXPORT_FORMATS:
+        raise ValueError(f"Unsupported format: {fmt}")
+
+    if fields is not None:
+        records = [{k: r.get(k) for k in fields} for r in records]
+
+    if fmt == "json":
+        export_json(records, path)
+        return
+    if fmt == "csv":
+        export_csv(records, path)
+        return
+    if fmt == "yaml":
+        export_yaml(records, path)
+        return
+
+    _exp.export_records(list(records), path, fmt)


### PR DESCRIPTION
## Summary
- expose new export formats through sigint exports package
- add export_records helper to support CSV, JSON, YAML and geospatial formats

## Testing
- `pytest -q tests/test_sigint_exports.py`

------
https://chatgpt.com/codex/tasks/task_e_685dc767f8d883339840439e69629f6f