### PR TITLE
Implement SIGINT integration wrappers

### DIFF
--- a/src/piwardrive/__init__.py
+++ b/src/piwardrive/__init__.py
@@ -5,30 +5,17 @@ from importlib import import_module
 import sys
 
 # Expose ``sigint_suite`` as a top-level module for backwards compatibility
-_sigint_name = "piwardrive.integrations.sigint_suite"
-if _sigint_name in sys.modules:
-    sigint_suite = sys.modules[_sigint_name]
-else:
-    try:  # pragma: no cover - optional dependency
-        sigint_suite = import_module(_sigint_name)
-    except Exception:  # pragma: no cover - missing optional modules
+try:  # pragma: no cover - optional dependency
+    from . import sigint_suite as sigint_suite
+except Exception:  # pragma: no cover - missing optional modules
+    try:
+        sigint_suite = import_module("piwardrive.integrations.sigint_suite")
+    except Exception:
         sigint_suite = None
 
 if sigint_suite is not None:
-    # Register the module under legacy import paths
     sys.modules.setdefault("sigint_suite", sigint_suite)
     sys.modules.setdefault(__name__ + ".sigint_suite", sigint_suite)
-from types import ModuleType
-
-try:  # pragma: no cover - optional dependency
-    sigint_suite: ModuleType | None = import_module("piwardrive.integrations.sigint_suite")
-    # Expose as ``sigint_suite`` and ``piwardrive.sigint_suite`` for backwards
-    # compatibility with older paths used throughout the tests.
-    if sigint_suite is not None:
-        sys.modules.setdefault("sigint_suite", sigint_suite)
-        sys.modules.setdefault(__name__ + ".sigint_suite", sigint_suite)
-except Exception:  # pragma: no cover - missing optional modules
-    sigint_suite = None
 
 # Provide top-level access to frequently imported modules
 for _mod in (


### PR DESCRIPTION
## Summary
- expose sigint_suite wrapper when importing the package
- keep backwards compatibility with legacy `sigint_suite` path

## Testing
- `pytest -q tests/test_sigint_integration.py tests/test_sigint_export_json.py tests/test_sigint_exports.py tests/test_sigint_paths.py tests/test_sigint_plugins.py`

------
https://chatgpt.com/codex/tasks/task_e_685dc76d0e7883339b84a8a1b09b244f