### PR TITLE
docs: add SIGINT plugin directory documentation

### DIFF
--- a/docs/environment.rst
+++ b/docs/environment.rst
@@ -108,4 +108,15 @@ SIGINT Suite
 ``SIGINT_DEBUG``
     Set to ``1`` to enable debug logging for SIGINT scanners.
 
+SIGINT Plugins
+~~~~~~~~~~~~~~
+
+Custom SIGINT scanners can be added as plugins. Place Python modules in
+``~/.config/piwardrive/sigint_plugins`` and they will be imported automatically
+whenever :mod:`piwardrive.sigint_suite` is loaded. Each plugin should provide a
+``scan()`` function returning records such as ``WifiNetwork`` or
+``BluetoothDevice``. After installing new plugins, call
+``piwardrive.sigint_suite.plugins.clear_plugin_cache()`` so the next import
+reloads the directory.
+
 


### PR DESCRIPTION
## Summary
- document SIGINT plugin directory used by `piwardrive.sigint_suite`

## Testing
- `pytest tests/test_sigint_export_json.py tests/test_sigint_exports.py tests/test_sigint_integration.py tests/test_sigint_paths.py tests/test_sigint_plugins.py -q`


------
https://chatgpt.com/codex/tasks/task_e_685dc7720b648333ae67f04e0d44a607