### PR TITLE
Add kiosk launch helper script

### DIFF
--- a/scripts/start_kiosk.sh
+++ b/scripts/start_kiosk.sh
@@ -1,8 +1,9 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Start the web UI and API server then open Chromium in kiosk mode.
 set -euo pipefail
 
 # Resolve the directory of this script so it works both from source checkouts and
 # when installed system wide.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Use the bundled Python helper to launch the server and browser.
 exec python3 "$SCRIPT_DIR/kiosk.py" "$@"


### PR DESCRIPTION
## Summary
- tweak the kiosk launcher script for portability

## Testing
- `pytest tests/test_start_kiosk_script.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685dc777a2d883338366a6635515e442