### PR TITLE
Add status and sync service coverage

### DIFF
--- a/src/piwardrive/service.py
+++ b/src/piwardrive/service.py
@@ -25,6 +25,8 @@ except Exception:
         (),
         {
             "get": lambda *a, **k: (lambda f: f),
+            "post": lambda *a, **k: (lambda f: f),
+            "delete": lambda *a, **k: (lambda f: f),
             "websocket": lambda *a, **k: (lambda f: f),
         },
     )


### PR DESCRIPTION
## Summary
- improve FastAPI stub used when the dependency isn't installed
- keep status endpoint compatible with missing optional packages

## Testing
- `pytest -q tests/test_sync.py tests/test_status_service.py`

------
https://chatgpt.com/codex/tasks/task_e_685dc781416c8333a1c75a955616a8f6