### PR TITLE
Add CLI tests for vector tiles

### DIFF
--- a/src/piwardrive/map/vector_tile_customizer.py
+++ b/src/piwardrive/map/vector_tile_customizer.py
@@ -78,10 +78,7 @@ def build_mbtiles(folder: str, output: str) -> None:
                 with open(os.path.join(root, f), "rb") as fh:
                     data = fh.read()
                 db.execute(
-                    (
-                        "INSERT OR REPLACE INTO tiles (zoom_level, tile_column, "
-                        "tile_row, tile_data)"
-                    ),
+                    "INSERT OR REPLACE INTO tiles (zoom_level, tile_column, tile_row, tile_data) VALUES (?, ?, ?, ?)",
                     (z_i, x_i, tile_row, data),
                 )
         db.commit()

--- a/tests/test_vector_tile_customizer_cli.py
+++ b/tests/test_vector_tile_customizer_cli.py
@@ -1,0 +1,36 @@
+import sys
+
+
+def test_vector_tile_customizer_cli_build(monkeypatch):
+    called = {}
+    if 'piwardrive.scripts.vector_tile_customizer_cli' in sys.modules:
+        del sys.modules['piwardrive.scripts.vector_tile_customizer_cli']
+    import piwardrive.scripts.vector_tile_customizer_cli as cli
+
+    def fake_build(folder, output):
+        called['build'] = (folder, output)
+
+    monkeypatch.setattr(cli.vtc, 'build_mbtiles', fake_build)
+    cli.main(['build', 'tiles', 'out.mbtiles'])
+    assert called['build'] == ('tiles', 'out.mbtiles')
+
+
+def test_vector_tile_customizer_cli_style(monkeypatch):
+    called = {}
+    if 'piwardrive.scripts.vector_tile_customizer_cli' in sys.modules:
+        del sys.modules['piwardrive.scripts.vector_tile_customizer_cli']
+    import piwardrive.scripts.vector_tile_customizer_cli as cli
+
+    def fake_style(mbtiles, *, style_path=None, name=None, description=None):
+        called['style'] = (mbtiles, style_path, name, description)
+
+    monkeypatch.setattr(cli.vtc, 'apply_style', fake_style)
+    cli.main([
+        'style',
+        'db.mbtiles',
+        '--style', 'style.json',
+        '--name', 'N',
+        '--description', 'D',
+    ])
+    assert called['style'] == ('db.mbtiles', 'style.json', 'N', 'D')
+


### PR DESCRIPTION
## Summary
- test vector tile customizer CLI build & style commands
- fix `build_mbtiles` SQL statement to include VALUES clause

## Testing
- `pytest -q tests/test_vector_tiles_module.py tests/test_vector_tile_customizer.py tests/test_vector_tile_customizer_cli.py`

------
https://chatgpt.com/codex/tasks/task_e_685dc7991b6c8333adf059413997b9c2