### PR TITLE
Add tower tracking history test and context manager

### DIFF
--- a/src/piwardrive/integrations/sigint_suite/cellular/tower_tracker/tracker.py
+++ b/src/piwardrive/integrations/sigint_suite/cellular/tower_tracker/tracker.py
@@ -12,6 +12,15 @@ class TowerTracker:
         self.db_path = db_path
         self.conn: aiosqlite.Connection | None = None
 
+    async def __aenter__(self) -> "TowerTracker":
+        """Allow usage as an async context manager."""
+        await self._get_conn()
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        """Close the underlying database connection."""
+        await self.close()
+
     async def _get_conn(self) -> aiosqlite.Connection:
         if self.conn is None:
             self.conn = await aiosqlite.connect(self.db_path)

--- a/tests/test_tower_tracking.py
+++ b/tests/test_tower_tracking.py
@@ -62,3 +62,17 @@ async def test_async_logging_and_retrieval(tmp_path):
     assert wifi and wifi[0]["timestamp"] == 50
     assert bt and bt[0]["timestamp"] == 60
     await tracker.close()
+
+
+@pytest.mark.asyncio
+async def test_tower_history(tmp_path):
+    db = tmp_path / "towers.db"
+    tr = TowerTracker(str(db))
+
+    await tr.log_tower("tower1", "-70", lat=1.0, lon=2.0, timestamp=100)
+    await tr.log_tower("tower1", "-60", lat=1.1, lon=2.1, timestamp=200)
+
+    hist = await tr.tower_history("tower1")
+    assert hist and [rec["rssi"] for rec in hist] == ["-60", "-70"]
+
+    await tr.close()


### PR DESCRIPTION
## Summary
- test tower history logging
- support async context management for TowerTracker

## Testing
- `pytest -q tests/test_tower_tracking.py`

------
https://chatgpt.com/codex/tasks/task_e_685dc78ee3f88333996e79b710e33796