### PR TITLE
Implement vendor lookup

### DIFF
--- a/src/piwardrive/integrations/sigint_suite/enrichment/oui.py
+++ b/src/piwardrive/integrations/sigint_suite/enrichment/oui.py
@@ -10,25 +10,25 @@ from typing import Dict, Optional
 try:  # pragma: no cover - optional dependency
     from piwardrive.utils import HTTP_SESSION
 except Exception:  # pragma: no cover - minimal fallback
-    class _DummySession:
-        def get(self, *_a, **_k):  # pragma: no cover - simple stub
-            raise RuntimeError("HTTP session unavailable")
-
-    HTTP_SESSION = _DummySession()
     try:
         import requests  # type: ignore
     except Exception:  # pragma: no cover - missing dependency
         requests = None  # type: ignore
+    if requests is not None:
+        HTTP_SESSION = requests.Session()
+    else:
+        class _DummySession:
+            def get(self, *_a, **_k) -> None:  # pragma: no cover - simple stub
+                raise RuntimeError("HTTP session unavailable")
+
+        HTTP_SESSION = _DummySession()
 else:  # pragma: no cover - optional dependency available
     try:
         import requests  # type: ignore
     except Exception:  # pragma: no cover - missing dependency
         requests = None  # type: ignore
-
-if requests is not None:
-    HTTP_SESSION = requests.Session()
-else:  # pragma: no cover - unit tests stub this out
-    HTTP_SESSION = None  # type: ignore
+    if requests is not None:
+        HTTP_SESSION = requests.Session()
 
 from piwardrive.sigint_suite import paths
 


### PR DESCRIPTION
## Summary
- fix vendor lookup fallback to work without requests
- update vendor lookup tests

## Testing
- `pytest tests/test_vendor_lookup.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685dc7be8be08333bb9cba10365d25c2