### PR TITLE
Add Node web API and update tests

### DIFF
--- a/In development/web_api.js
+++ b/In development/web_api.js
@@ -1,0 +1,71 @@
+const http = require('http');
+const fs = require('fs');
+const { spawnSync } = require('child_process');
+const url = require('url');
+
+function readGps(dbFile) {
+  try {
+    const res = spawnSync('sqlite3', ['-noheader', '-separator', '|', dbFile,
+      'SELECT lat, lon, time FROM gps_tracks ORDER BY time DESC LIMIT 1;']);
+    const output = res.stdout.toString().trim();
+    if (!output) return null;
+    const [lat, lon, time] = output.split('|');
+    return { lat: parseFloat(lat), lon: parseFloat(lon), time };
+  } catch {
+    return null;
+  }
+}
+
+function readGeo(file) {
+  try {
+    return JSON.parse(fs.readFileSync(file, 'utf8'));
+  } catch {
+    return { type: 'FeatureCollection', features: [] };
+  }
+}
+
+function toggleService(service, state) {
+  const cmd = state === 'start'
+    ? ['sudo', 'systemctl', 'start', service]
+    : ['sudo', 'systemctl', 'stop', service];
+  if (process.env.PW_RUN_LOG) {
+    fs.appendFileSync(process.env.PW_RUN_LOG, JSON.stringify(cmd) + '\n');
+  } else {
+    spawnSync(cmd[0], cmd.slice(1));
+  }
+  return { status: 'ok' };
+}
+
+function createServer(opts = {}) {
+  const gpsDb = opts.gpsDb || process.env.PW_GPS_DB || '/home/pi/.config/piwardrive/db.sqlite';
+  const apsFile = opts.apsFile || process.env.PW_APS_FILE || '/home/pi/.config/piwardrive/export/aps.geojson';
+  const btFile = opts.btFile || process.env.PW_BT_FILE || '/home/pi/.config/piwardrive/export/bt.geojson';
+
+  return http.createServer((req, res) => {
+    const parsed = url.parse(req.url, true);
+    res.setHeader('Content-Type', 'application/json');
+    if (req.method === 'GET' && parsed.pathname === '/api/gps') {
+      res.end(JSON.stringify(readGps(gpsDb) || { lat: null, lon: null, time: null }));
+    } else if (req.method === 'GET' && parsed.pathname === '/api/aps') {
+      res.end(JSON.stringify(readGeo(apsFile)));
+    } else if (req.method === 'GET' && parsed.pathname === '/api/bt') {
+      res.end(JSON.stringify(readGeo(btFile)));
+    } else if (req.method === 'POST' && parsed.pathname === '/api/kismet/toggle') {
+      res.end(JSON.stringify(toggleService('kismet', parsed.query.state)));
+    } else {
+      res.statusCode = 404;
+      res.setHeader('Content-Type', 'text/plain');
+      res.end('Not found');
+    }
+  });
+}
+
+if (require.main === module) {
+  const port = process.env.PORT !== undefined ? Number(process.env.PORT) : 3000;
+  const server = createServer();
+  server.listen(port, () => {
+    console.log(`Listening on ${server.address().port}`);
+  });
+}
+
+module.exports = { createServer };

--- a/tests/test_web_api.py
+++ b/tests/test_web_api.py
@@ -1,70 +1,90 @@
-import importlib.util
-from pathlib import Path
+import json
+import os
 import sqlite3
+import subprocess
+import urllib.request
+from pathlib import Path
 
-from fastapi.testclient import TestClient
-
-
-def load_web_api():
-    path = Path('In development') / 'web_api.py'
-    spec = importlib.util.spec_from_file_location('web_api', path)
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)  # type: ignore
-    return module
+SERVER_FILE = Path('In development') / 'web_api.js'
 
 
-def test_get_gps(tmp_path, monkeypatch):
-    mod = load_web_api()
+def start_server(tmp_path):
+    env = os.environ.copy()
+    env['PW_GPS_DB'] = str(tmp_path / 'db.sqlite')
+    env['PW_APS_FILE'] = str(tmp_path / 'aps.geojson')
+    env['PW_BT_FILE'] = str(tmp_path / 'bt.geojson')
+    env['PW_RUN_LOG'] = str(tmp_path / 'run.log')
+    env['PORT'] = '0'
+    proc = subprocess.Popen(
+        ['node', str(SERVER_FILE)], stdout=subprocess.PIPE, text=True, env=env
+    )
+    line = proc.stdout.readline()
+    if not line.startswith('Listening on '):
+        proc.kill()
+        raise RuntimeError('server failed to start')
+    port = int(line.strip().split()[-1])
+    return proc, port, Path(env['PW_RUN_LOG'])
+
+
+def request_json(port, path, method='GET'):
+    req = urllib.request.Request(f'http://127.0.0.1:{port}{path}', method=method)
+    with urllib.request.urlopen(req) as resp:
+        return json.loads(resp.read())
+
+
+def test_get_gps(tmp_path):
     db = tmp_path / 'db.sqlite'
     with sqlite3.connect(db) as conn:
         conn.execute('CREATE TABLE gps_tracks (lat REAL, lon REAL, time TEXT)')
         conn.execute("INSERT INTO gps_tracks VALUES (1.2, 3.4, 't')")
         conn.commit()
 
-    def fake_path(p):
-        return db if p.endswith('db.sqlite') else Path(p)
-    monkeypatch.setattr(mod, 'Path', fake_path)
+    proc, port, _ = start_server(tmp_path)
+    try:
+        data = request_json(port, '/api/gps')
+        assert data == {'lat': 1.2, 'lon': 3.4, 'time': 't'}
+    finally:
+        proc.terminate()
+        proc.wait()
 
-    client = TestClient(mod.app)
-    resp = client.get('/api/gps')
-    assert resp.json() == {'lat': 1.2, 'lon': 3.4, 'time': 't'}
 
-
-def test_get_aps(tmp_path, monkeypatch):
-    mod = load_web_api()
+def test_get_aps(tmp_path):
     aps = tmp_path / 'aps.geojson'
     aps.write_text('{"features": [1]}')
 
-    def fake_path(p):
-        return aps if p.endswith('aps.geojson') else Path(p)
-    monkeypatch.setattr(mod, 'Path', fake_path)
+    proc, port, _ = start_server(tmp_path)
+    try:
+        data = request_json(port, '/api/aps')
+        assert data['features'] == [1]
+    finally:
+        proc.terminate()
+        proc.wait()
 
-    client = TestClient(mod.app)
-    resp = client.get('/api/aps')
-    assert resp.json()['features'] == [1]
 
-
-def test_get_bt(tmp_path, monkeypatch):
-    mod = load_web_api()
+def test_get_bt(tmp_path):
     bt = tmp_path / 'bt.geojson'
     bt.write_text('{"features": [2]}')
 
-    def fake_path(p):
-        return bt if p.endswith('bt.geojson') else Path(p)
-    monkeypatch.setattr(mod, 'Path', fake_path)
+    proc, port, _ = start_server(tmp_path)
+    try:
+        data = request_json(port, '/api/bt')
+        assert data['features'] == [2]
+    finally:
+        proc.terminate()
+        proc.wait()
 
-    client = TestClient(mod.app)
-    resp = client.get('/api/bt')
-    assert resp.json()['features'] == [2]
 
+def test_toggle_kismet(tmp_path):
+    proc, port, log = start_server(tmp_path)
+    try:
+        request_json(port, '/api/kismet/toggle?state=start', method='POST')
+        request_json(port, '/api/kismet/toggle?state=stop', method='POST')
+    finally:
+        proc.terminate()
+        proc.wait()
 
-def test_toggle_kismet(monkeypatch):
-    mod = load_web_api()
-    calls = []
-    monkeypatch.setattr(mod.subprocess, 'run', lambda cmd, check=False: calls.append(cmd))
-
-    client = TestClient(mod.app)
-    resp = client.post('/api/kismet/toggle', params={'state': 'start'})
-    assert resp.status_code == 200
-    resp = client.post('/api/kismet/toggle', params={'state': 'stop'})
-    assert calls == [["sudo", "systemctl", "start", "kismet"], ["sudo", "systemctl", "stop", "kismet"]]
+    lines = [json.loads(l) for l in log.read_text().splitlines()]
+    assert lines == [
+        ["sudo", "systemctl", "start", "kismet"],
+        ["sudo", "systemctl", "stop", "kismet"],
+    ]


### PR DESCRIPTION
## Summary
- implement Node-based REST API
- update tests for Node API

## Testing
- `pytest tests/test_web_api.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685dc7d265c48333a472972a71a60fed