### PR TITLE
Fix pydocstyle warnings

### DIFF
--- a/src/piwardrive/integrations/sigint_suite/exports/exporter.py
+++ b/src/piwardrive/integrations/sigint_suite/exports/exporter.py
@@ -76,7 +76,6 @@ def export_records(
     fields: Sequence[str] | None = None,
 ) -> None:
     """Export ``records`` using ``fmt`` similar to :func:`piwardrive.export.export_records`."""
-
     fmt = fmt.lower()
     if fmt not in EXPORT_FORMATS:
         raise ValueError(f"Unsupported format: {fmt}")

--- a/src/piwardrive/integrations/sigint_suite/rf/utils.py
+++ b/src/piwardrive/integrations/sigint_suite/rf/utils.py
@@ -59,10 +59,8 @@ def parse_frequency(value: str | float) -> float:
     Strings may include units like ``kHz``, ``MHz`` or ``GHz`` (case-insensitive).
     Numbers are assumed to already be in Hz.
     """
-
     if isinstance(value, (int, float)):
         return float(value)
-
     match = re.match(r"\s*(\d+(?:\.\d+)?)([kKmMgG]?Hz)?\s*", value)
     if not match:
         raise ValueError(f"invalid frequency: {value!r}")

--- a/src/piwardrive/service.py
+++ b/src/piwardrive/service.py
@@ -364,8 +364,6 @@ async def update_config_endpoint(
     updates: dict = Body(...),
     _auth: None = Depends(_check_auth),
 ) -> dict:
-
-  
     """Update configuration values and persist them."""
     cfg = config.load_config()
     data = asdict(cfg)

--- a/src/piwardrive/utils.py
+++ b/src/piwardrive/utils.py
@@ -16,7 +16,7 @@ except Exception:
     # features can be patched in tests without import errors.
 
     def _stub(*_args: object, **_kwargs: object) -> None:  # pragma: no cover - placeholder
-        """Placeholder for optional functionality."""
+        """Raise ``NotImplementedError`` when optional functionality is unavailable."""
         raise NotImplementedError
 
     # The following stubs match the names used by the builtin widgets.  They are


### PR DESCRIPTION
## Summary
- update placeholder stub docstring to use imperative mood
- remove extra blank lines around function docstrings

## Testing
- `pydocstyle src/piwardrive`
- `pytest -q` *(fails: 34 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_685dcacf72dc8333a9fe4454e94e1dd1