### PR TITLE
Fix lint issues and import order

### DIFF
--- a/scripts/kiosk.py
+++ b/scripts/kiosk.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 import os
 import sys
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
-
-from piwardrive.cli.kiosk import main
+SRC_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src"))
+if SRC_PATH not in sys.path:
+    sys.path.insert(0, SRC_PATH)
 
 if __name__ == "__main__":  # pragma: no cover - manual invocation
+    from piwardrive.cli.kiosk import main  # noqa: E402
+
     main()

--- a/src/piwardrive/integrations/sigint_suite/cellular/imsi_catcher/scanner.py
+++ b/src/piwardrive/integrations/sigint_suite/cellular/imsi_catcher/scanner.py
@@ -1,15 +1,15 @@
 """Module scanner."""
+import asyncio
+import logging
 import os
 import shlex
 import subprocess
-import logging
-import asyncio
 from typing import Callable, List, Optional
 
-from piwardrive.sigint_suite.models import ImsiRecord
 from piwardrive.sigint_suite.cellular.parsers import parse_imsi_output
 from piwardrive.sigint_suite.gps import get_position
 from piwardrive.sigint_suite.hooks import apply_post_processors
+from piwardrive.sigint_suite.models import ImsiRecord
 
 logger = logging.getLogger(__name__)
 

--- a/src/piwardrive/integrations/sigint_suite/exports/__init__.py
+++ b/src/piwardrive/integrations/sigint_suite/exports/__init__.py
@@ -1,11 +1,12 @@
 """Data export helpers for SIGINT modules."""
 
-from .exporter import (
-    export_csv,
-    export_json,
-    export_yaml,
-    export_records,
-    EXPORT_FORMATS,
-)
+from .exporter import (EXPORT_FORMATS, export_csv, export_json, export_records,
+                       export_yaml)
 
-__all__ = ["export_json", "export_csv", "export_yaml", "export_records", "EXPORT_FORMATS"]
+__all__ = [
+    "export_json",
+    "export_csv",
+    "export_yaml",
+    "export_records",
+    "EXPORT_FORMATS",
+]

--- a/src/piwardrive/integrations/sigint_suite/exports/exporter.py
+++ b/src/piwardrive/integrations/sigint_suite/exports/exporter.py
@@ -1,6 +1,7 @@
 """Module exporter."""
 import csv
 import json
+from dataclasses import asdict, is_dataclass
 from typing import Any, Iterable, Mapping, Sequence
 
 from piwardrive import export as _exp
@@ -75,7 +76,9 @@ def export_records(
     fmt: str,
     fields: Sequence[str] | None = None,
 ) -> None:
-    """Export ``records`` using ``fmt`` similar to :func:`piwardrive.export.export_records`."""
+    """Export ``records`` using ``fmt`` similar to
+    :func:`piwardrive.export.export_records`.
+    """
 
     fmt = fmt.lower()
     if fmt not in EXPORT_FORMATS:

--- a/src/piwardrive/map/vector_tile_customizer.py
+++ b/src/piwardrive/map/vector_tile_customizer.py
@@ -78,7 +78,11 @@ def build_mbtiles(folder: str, output: str) -> None:
                 with open(os.path.join(root, f), "rb") as fh:
                     data = fh.read()
                 db.execute(
-                    "INSERT OR REPLACE INTO tiles (zoom_level, tile_column, tile_row, tile_data) VALUES (?, ?, ?, ?)",
+                    (
+                        "INSERT OR REPLACE INTO tiles "
+                        "(zoom_level, tile_column, tile_row, tile_data) "
+                        "VALUES (?, ?, ?, ?)"
+                    ),
                     (z_i, x_i, tile_row, data),
                 )
         db.commit()

--- a/src/piwardrive/service.py
+++ b/src/piwardrive/service.py
@@ -2,22 +2,15 @@
 
 from __future__ import annotations
 
-from dataclasses import asdict
-import os
 import inspect
+import os
 import typing
+from dataclasses import asdict
 
 try:  # pragma: no cover - optional FastAPI dependency
-    from fastapi import (
-        FastAPI,
-        Depends,
-        HTTPException,
-        WebSocket,
-        WebSocketDisconnect,
-        Body,
-        Request,
-    )
-    from fastapi.responses import StreamingResponse, Response
+    from fastapi import (Body, Depends, FastAPI, HTTPException, Request,
+                         WebSocket, WebSocketDisconnect)
+    from fastapi.responses import Response, StreamingResponse
     from fastapi.security import HTTPBasic, HTTPBasicCredentials
 except Exception:
     FastAPI = type(
@@ -43,27 +36,21 @@ except Exception:
     StreamingResponse = Response = object
     HTTPBasic = type("HTTPBasic", (), {"__init__": lambda self, **k: None})
     HTTPBasicCredentials = type("HTTPBasicCredentials", (), {})
-import importlib
-
 import asyncio
-import time
+import importlib
 import json
 import tempfile
+import time
+from collections.abc import Mapping, Sequence
 from pathlib import Path
-from collections.abc import Sequence, Mapping
-from typing import Any
-
+from typing import Any, Callable, Tuple
 
 from piwardrive.logconfig import DEFAULT_LOG_PATH
 
 try:  # allow tests to stub out ``persistence``
-    from persistence import (
-        load_recent_health,
-        load_ap_cache,
-        load_dashboard_settings,
-        save_dashboard_settings,
-        DashboardSettings,
-    )  # type: ignore
+    from persistence import (DashboardSettings, load_ap_cache,  # type: ignore
+                             load_dashboard_settings, load_recent_health,
+                             save_dashboard_settings)
 except Exception:  # pragma: no cover - fall back to real module
     from piwardrive.persistence import (
         load_recent_health,
@@ -72,20 +59,22 @@ except Exception:  # pragma: no cover - fall back to real module
         save_dashboard_settings,
         DashboardSettings,
     )
+
 from piwardrive.security import sanitize_path, verify_password
+
 try:  # allow tests to provide a simplified utils module
     import utils as _utils
 except Exception:  # pragma: no cover - fall back to real module
     from piwardrive import utils as _utils
 
+import config
 import psutil
 import vehicle_sensors
-import config
 from sync import upload_data
-from piwardrive.gpsd_client import client as gps_client
-from piwardrive import orientation_sensors
-from piwardrive import export
+
+from piwardrive import export, orientation_sensors
 from piwardrive.config import CONFIG_DIR
+from piwardrive.gpsd_client import client as gps_client
 
 fetch_metrics_async = getattr(
     _utils, "fetch_metrics_async", lambda *_a, **_k: ([], [], 0)
@@ -94,12 +83,14 @@ get_avg_rssi = getattr(_utils, "get_avg_rssi", lambda *_a, **_k: None)
 get_cpu_temp = getattr(_utils, "get_cpu_temp", lambda *_a, **_k: None)
 get_mem_usage = getattr(_utils, "get_mem_usage", lambda *_a, **_k: None)
 get_disk_usage = getattr(_utils, "get_disk_usage", lambda *_a, **_k: None)
-get_network_throughput = getattr(_utils, "get_network_throughput", lambda *_a, **_k: (0, 0))
+get_network_throughput = getattr(
+    _utils,
+    "get_network_throughput",
+    lambda *_a, **_k: (0, 0),
+)
 get_gps_fix_quality = getattr(_utils, "get_gps_fix_quality", lambda *_a, **_k: None)
 get_gps_accuracy = getattr(_utils, "get_gps_accuracy", lambda *_a, **_k: None)
 service_status_async = getattr(_utils, "service_status_async", lambda *_a, **_k: None)
-from typing import Callable, Tuple
-
 run_service_cmd: Callable[[str, str], Tuple[bool, str, str] | None] = getattr(
     _utils, "run_service_cmd", lambda *_a, **_k: None
 )
@@ -364,8 +355,6 @@ async def update_config_endpoint(
     updates: dict = Body(...),
     _auth: None = Depends(_check_auth),
 ) -> dict:
-
-  
     """Update configuration values and persist them."""
     cfg = config.load_config()
     data = asdict(cfg)

--- a/src/piwardrive/setup_wizard.py
+++ b/src/piwardrive/setup_wizard.py
@@ -4,12 +4,9 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-
+from typing import Any
 
 CONFIG_PATH = Path.home() / ".config" / "piwardrive" / "setup.json"
-
-
-from typing import Any
 
 
 def run_wizard() -> None:

--- a/src/piwardrive/sigint_suite/__init__.py
+++ b/src/piwardrive/sigint_suite/__init__.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 import importlib
 import os
 import sys
-from types import ModuleType
 from typing import Any, cast
 
 # Import the actual implementation from piwardrive.integrations.sigint_suite

--- a/src/piwardrive/sigint_suite/cellular/imsi_catcher/scanner.py
+++ b/src/piwardrive/sigint_suite/cellular/imsi_catcher/scanner.py
@@ -1,2 +1,2 @@
 """Compatibility wrapper importing the IMSI catcher scanner implementation."""
-from piwardrive.integrations.sigint_suite.cellular.imsi_catcher.scanner import *  # noqa: F401,F403
+from piwardrive.integrations.sigint_suite.cellular.imsi_catcher.scanner import *  # noqa: F401,F403,E501

--- a/src/piwardrive/utils.py
+++ b/src/piwardrive/utils.py
@@ -15,7 +15,8 @@ except Exception:
     # core utils couldn't be imported; define minimal stubs so optional
     # features can be patched in tests without import errors.
 
-    def _stub(*_args: object, **_kwargs: object) -> None:  # pragma: no cover - placeholder
+    # pragma: no cover - placeholder
+    def _stub(*_args: object, **_kwargs: object) -> None:
         """Placeholder for optional functionality."""
         raise NotImplementedError
 
@@ -34,7 +35,10 @@ except Exception:
     def get_disk_usage(*_args: object, **_kwargs: object) -> float | None:
         return None
 
-    async def fetch_kismet_devices_async(*_args: object, **_kwargs: object) -> tuple[list, list]:
+    async def fetch_kismet_devices_async(
+        *_args: object,
+        **_kwargs: object,
+    ) -> tuple[list, list]:
         return [], []
 
     def run_async_task(*_args: object, **_kwargs: object) -> None:

--- a/src/service.py
+++ b/src/service.py
@@ -9,23 +9,20 @@ effect within ``piwardrive.service``.  When the package isn't installed, the
 
 from __future__ import annotations
 
+import importlib
 import os
 import sys
-import importlib
 
 SRC_PATH = os.path.join(os.path.dirname(__file__), "src")
 if SRC_PATH not in sys.path:
     sys.path.insert(0, SRC_PATH)
 
-from piwardrive import service as _p  # noqa: E402
-from piwardrive import orientation_sensors  # noqa: F401,E402
+from typing import Any, Callable  # noqa: E402
 
+from piwardrive import orientation_sensors  # noqa: F401,E402
+from piwardrive import service as _p  # noqa: E402
 # Re-export everything from the real module
 from piwardrive.service import *  # noqa: F401,F403,E402
-
-from importlib import import_module
-from types import ModuleType
-from typing import Any, Callable
 
 
 def _proxy(name: str) -> Callable[..., Any]:


### PR DESCRIPTION
## Summary
- update kiosk entry script
- clean up SIGINT suite exports
- refine exporter logic
- simplify Wi-Fi scanner
- break long SQL line in vector tile customizer
- adjust service imports and config wizard
- trim unused imports
- tweak utils stubs
- silence lint on service wrapper

## Testing
- `flake8`
- `isort --check .`
- `pre-commit run --files scripts/kiosk.py src/piwardrive/integrations/sigint_suite/exports/__init__.py src/piwardrive/integrations/sigint_suite/exports/exporter.py src/piwardrive/integrations/sigint_suite/wifi/scanner.py src/piwardrive/map/vector_tile_customizer.py src/piwardrive/service.py src/piwardrive/setup_wizard.py src/piwardrive/sigint_suite/__init__.py src/piwardrive/sigint_suite/cellular/imsi_catcher/scanner.py src/piwardrive/utils.py src/service.py` *(fails: InvalidManifestError)*

------
https://chatgpt.com/codex/tasks/task_e_685dcac4d3108333babfd482ade9cd7b