### PR TITLE
Clean up unused code flagged by Vulture

### DIFF
--- a/src/piwardrive/advanced_localization.py
+++ b/src/piwardrive/advanced_localization.py
@@ -24,7 +24,6 @@ class Config:
     dbscan_min_samples: int = 5
     centroid_rssi_weight_power: float = 1.5
     min_points_for_confidence: int = 5
-    map_zoom_start: int = 16
 
 
 def load_config(path: str | Path) -> Config:

--- a/src/piwardrive/aggregation_service.py
+++ b/src/piwardrive/aggregation_service.py
@@ -91,8 +91,9 @@ async def _process_upload(path: str) -> None:
 
 
 @app.post("/upload")
-async def upload(file: UploadFile) -> dict:
+async def upload(file: UploadFile) -> dict:  # noqa: V103 - FastAPI route
     """Save ``file`` and merge its contents into the aggregation database."""
+    # Called by FastAPI as a route handler.
     dest = os.path.join(UPLOAD_DIR, file.filename)
     fd, tmp_path = tempfile.mkstemp(dir=UPLOAD_DIR)
     os.close(fd)
@@ -106,8 +107,9 @@ async def upload(file: UploadFile) -> dict:
 
 
 @app.get("/stats")
-async def stats() -> dict:
+async def stats() -> dict:  # noqa: V103 - FastAPI route
     """Return averaged system metrics from all records."""
+    # Called by FastAPI as a route handler.
     conn = await _get_conn()
     cur = await conn.execute(
         "SELECT timestamp, cpu_temp, cpu_percent, memory_percent, "
@@ -119,8 +121,9 @@ async def stats() -> dict:
 
 
 @app.get("/overlay")
-async def overlay(bins: int = 100) -> dict:
+async def overlay(bins: int = 100) -> dict:  # noqa: V103 - FastAPI route
     """Return heatmap points derived from all uploaded access points."""
+    # Called by FastAPI as a route handler.
     conn = await _get_conn()
     cur = await conn.execute("SELECT lat, lon FROM ap_points")
     coords = [(float(r[0]), float(r[1])) for r in await cur.fetchall()]
@@ -136,6 +139,9 @@ async def main() -> None:
     config = uvicorn.Config(app, host="0.0.0.0", port=9100)
     server = uvicorn.Server(config)
     await server.serve()
+
+
+__all__ = ["app", "main", "upload", "stats", "overlay"]
 
 
 if __name__ == "__main__":

--- a/src/piwardrive/config_watcher.py
+++ b/src/piwardrive/config_watcher.py
@@ -15,11 +15,13 @@ class _ConfigHandler(FileSystemEventHandler):
         self._path = os.path.abspath(path)
         self._callback = callback
 
-    def on_modified(self, event):  # type: ignore[override]
+    def on_modified(self, event) -> None:  # noqa: V105 - Watchdog callback
+        """Watchdog callback for modifications to the watched file."""
         if os.path.abspath(event.src_path) == self._path:
             self._callback()
 
-    def on_created(self, event):  # type: ignore[override]
+    def on_created(self, event) -> None:  # noqa: V105 - Watchdog callback
+        """Watchdog callback for creation of the watched file."""
         if os.path.abspath(event.src_path) == self._path:
             self._callback()
 
@@ -31,3 +33,6 @@ def watch_config(path: str, callback: Callable[[], None]) -> Observer:
     observer.schedule(handler, os.path.dirname(path) or ".", recursive=False)
     observer.start()
     return observer
+
+
+__all__ = ["watch_config"]


### PR DESCRIPTION
## Summary
- document FastAPI route handlers and export them to silence Vulture
- mark watchdog callbacks as intentional and export watcher helper
- drop unused `map_zoom_start` config option

## Testing
- `vulture src/piwardrive/advanced_localization.py src/piwardrive/aggregation_service.py src/piwardrive/config_watcher.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685dcad977a083339a588396a4615555