### PR TITLE
Add missing python dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -36,6 +36,13 @@ rpy2==3.6.1
 scikit-learn==1.5.0
 mpu6050
 
+# Additional GUI and scientific libraries
+kivy
+kivymd
+numpy
+folium
+dronekit
+
 # Web UI build dependencies
 # Requires Node.js >=18 and npm
 # Debian/Ubuntu packages: nodejs npm libdbus-1-dev libglib2.0-dev


### PR DESCRIPTION
## Summary
- include kivy, kivymd, numpy, folium and dronekit in requirements

## Testing
- `pyright --level warning | grep -E "numpy" | head -n 1`
- `pip install -q -r requirements.txt` *(fails: dependency build errors)*

------
https://chatgpt.com/codex/tasks/task_e_685dcadc94908333b972f8d616fe372a