### PR TITLE
Refactor Wi-Fi scanner functions

### DIFF
--- a/src/piwardrive/integrations/sigint_suite/wifi/scanner.py
+++ b/src/piwardrive/integrations/sigint_suite/wifi/scanner.py
@@ -22,7 +22,7 @@ def _vendor_hook(records: List[Dict[str, Union[str, float]]]) -> List[Dict[str, 
     """Add vendor names based on BSSID prefixes."""
     for rec in records:
         bssid = rec.get("bssid")
-        vendor = cached_lookup_vendor(bssid)
+        vendor = lookup_vendor(bssid)
         if vendor:
             rec["vendor"] = vendor
     return records
@@ -31,38 +31,41 @@ def _vendor_hook(records: List[Dict[str, Union[str, float]]]) -> List[Dict[str, 
 register_post_processor("wifi", _vendor_hook)
 
 
-def _parse_iwlist_output(output: str, heading: float | None) -> Iterable[Dict[str, str]]:
-    """Yield dictionaries parsed from ``iwlist`` command output."""
-    current: Dict[str, str] = {}
-def scan_wifi(
-    interface: str = "wlan0",
-    iwlist_cmd: Optional[str] = None,
-    priv_cmd: Optional[str] = None,
-    timeout: Optional[int] = None,
-) -> List[WifiNetwork]:
-    """Scan for Wi-Fi networks using ``iwlist`` and return results."""
-    iwlist_cmd = str(iwlist_cmd or os.getenv("IWLIST_CMD", "iwlist"))
-    priv_cmd = priv_cmd if priv_cmd is not None else os.getenv("IW_PRIV_CMD", "sudo")
+def _parse_iwlist_output(
+    output: str, heading: float | None
+) -> Iterable[Dict[str, Union[str, float]]]:
+    """Parse ``iwlist`` command output into record dictionaries."""
 
-    cmd: List[str] = []
-    if priv_cmd:
-        cmd.extend(shlex.split(priv_cmd))
-    cmd.extend([iwlist_cmd, interface, "scanning"])
-    timeout = (
-        timeout if timeout is not None else int(os.getenv("WIFI_SCAN_TIMEOUT", "10"))
-    )
+    def finalize(rec: Dict[str, Union[str, float]], enc: List[str]) -> Dict[str, Union[str, float]]:
+        if heading is not None:
+            rec["heading"] = heading
+        if enc:
+            extra = " ".join(enc).strip()
+            if "encryption" in rec:
+                rec["encryption"] = f"{rec['encryption']} {extra}".strip()
+            else:
+                rec["encryption"] = extra
+        return rec
 
-    try:
-        output = subprocess.check_output(
-            cmd, text=True, stderr=subprocess.DEVNULL, timeout=timeout
-        )
-    except Exception as exc:
-        logger.exception("Wi-Fi scan failed: %s", exc)
-        return []
+    def parse_info(line: str, rec: Dict[str, Union[str, float]], enc: List[str]) -> None:
+        if "ESSID" in line:
+            rec["ssid"] = line.split(":", 1)[-1].strip('"')
+        elif line.startswith("Encryption key:"):
+            rec["encryption"] = line.split("Encryption key:")[-1].strip()
+        elif line.startswith("IE:"):
+            enc.append(line.split("IE:", 1)[-1].strip())
+        elif "Address" in line:
+            rec["bssid"] = line.split("Address:")[-1].strip()
+        elif "Frequency" in line:
+            rec["frequency"] = line.split("Frequency:")[-1].split()[0]
+            if "(Channel" in line:
+                rec["channel"] = line.split("(Channel")[-1].split(")")[0].strip()
+        elif line.startswith("Channel:"):
+            rec["channel"] = line.split("Channel:")[-1].strip()
+        elif "Quality" in line:
+            rec["quality"] = line.split("Quality=")[-1].split()[0]
 
-    heading = orientation_sensors.get_heading()
     records: List[Dict[str, Union[str, float]]] = []
-
     current: Dict[str, Union[str, float]] = {}
     enc_lines: List[str] = []
 
@@ -70,52 +73,19 @@ def scan_wifi(
         line = line.strip()
         if line.startswith("Cell"):
             if current:
-                if heading is not None:
-                    current["heading"] = heading
-                if enc_lines:
-                    if "encryption" in current:
-                        current["encryption"] = (
-                            f"{current['encryption']} {' '.join(enc_lines)}"
-                        ).strip()
-                    else:
-                        current["encryption"] = " ".join(enc_lines).strip()
-                yield current
-            bssid = None
-            if "Address:" in line:
-                bssid = line.split("Address:")[-1].strip()
+                records.append(finalize(current, enc_lines))
+            bssid = line.split("Address:")[-1].strip() if "Address:" in line else None
             current = {"cell": line}
             if bssid:
                 current["bssid"] = bssid
             enc_lines = []
-        elif "ESSID" in line:
-            current["ssid"] = line.split(":", 1)[-1].strip('"')
-        elif line.startswith("Encryption key:"):
-            current["encryption"] = line.split("Encryption key:")[-1].strip()
-        elif line.startswith("IE:"):
-            enc_lines.append(line.split("IE:", 1)[-1].strip())
-        elif "Address" in line:
-            current["bssid"] = line.split("Address:")[-1].strip()
-        elif "Frequency" in line:
-            current["frequency"] = line.split("Frequency:")[-1].split()[0]
-            if "(Channel" in line:
-                ch = line.split("(Channel")[-1].split(")")[0].strip()
-                current["channel"] = ch
-        elif line.startswith("Channel:"):
-            current["channel"] = line.split("Channel:")[-1].strip()
-        elif "Quality" in line:
-            current["quality"] = line.split("Quality=")[-1].split()[0]
+        else:
+            parse_info(line, current, enc_lines)
 
     if current:
-        if heading is not None:
-            current["heading"] = heading
-        if enc_lines:
-            if "encryption" in current:
-                current["encryption"] = (
-                    f"{current['encryption']} {' '.join(enc_lines)}"
-                ).strip()
-            else:
-                current["encryption"] = " ".join(enc_lines).strip()
-        yield current
+        records.append(finalize(current, enc_lines))
+
+    return records
 
 
 def scan_wifi(
@@ -123,7 +93,7 @@ def scan_wifi(
     iwlist_cmd: Optional[str] = None,
     priv_cmd: Optional[str] = None,
     timeout: Optional[int] = None,
-) -> List[Dict[str, str]]:
+) -> List[WifiNetwork]:
     """Scan for Wi-Fi networks using ``iwlist`` and return results."""
     iwlist_cmd = iwlist_cmd or os.getenv("IWLIST_CMD", "iwlist")
     priv_cmd = priv_cmd if priv_cmd is not None else os.getenv("IW_PRIV_CMD", "sudo")
@@ -148,6 +118,8 @@ def scan_wifi(
     records = [rec for rec in _parse_iwlist_output(output, heading)]
     records = apply_post_processors("wifi", records)
     return [WifiNetwork(**rec) for rec in records]
+
+
 
 
 async def async_scan_wifi(
@@ -183,37 +155,6 @@ async def async_scan_wifi(
     heading = orientation_sensors.get_heading()
 
     records = [rec for rec in _parse_iwlist_output(output, heading)]
-    records: List[Dict[str, Union[str, float]]] = []
-    current: Dict[str, Union[str, float]] = {}
-    for line in output.splitlines():
-        line = line.strip()
-        if line.startswith("Cell"):
-            if current:
-                if heading is not None:
-                    current["heading"] = heading
-                records.append(current)
-            bssid = None
-            if "Address:" in line:
-                bssid = line.split("Address:")[-1].strip()
-            current = {"cell": line}
-            if bssid:
-                current["bssid"] = bssid
-        elif "ESSID" in line:
-            current["ssid"] = line.split(":", 1)[-1].strip('"')
-        elif "Address" in line:
-            bssid = line.split("Address:")[-1].strip()
-            current["bssid"] = bssid
-            vendor = cached_lookup_vendor(bssid)
-            if vendor:
-                current["vendor"] = vendor
-        elif "Frequency" in line:
-            current["frequency"] = line.split("Frequency:")[-1].split(" ")[0]
-        elif "Quality" in line:
-            current["quality"] = line.split("Quality=")[-1].split(" ")[0]
-    if current:
-        if heading is not None:
-            current["heading"] = heading
-        records.append(current)
     records = apply_post_processors("wifi", records)
     return [WifiNetwork(**rec) for rec in records]
 


### PR DESCRIPTION
## Summary
- simplify Wi-Fi scan parser and async scanner
- use overridable `lookup_vendor` helper in hooks

## Testing
- `pytest tests/test_wifi_scanner.py::test_scan_wifi_enriches_vendor -q`


------
https://chatgpt.com/codex/tasks/task_e_685dcae1715c8333b0e1fbefb8170db0