### PR TITLE
Enable automated linting and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,6 @@ name: CI
 
 on:
   push:
-    branches: [main]
   pull_request:
 
 jobs:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,12 @@
 repos:
+  - repo: https://github.com/psf/black
+    rev: 25.1.0
+    hooks:
+      - id: black
+  - repo: https://github.com/pre-commit/mirrors-isort
+    rev: v5.10.1
+    hooks:
+      - id: isort
   - repo: https://github.com/pycqa/flake8
     rev: 7.2.0
     hooks:
@@ -7,13 +15,15 @@ repos:
     rev: v1.16.0
     hooks:
       - id: mypy
-  - repo: https://github.com/pytest-dev/pytest
-    rev: 8.4.0
+  - repo: https://github.com/PyCQA/bandit
+    rev: 1.8.5
+    hooks:
+      - id: bandit
+  - repo: local
     hooks:
       - id: pytest
+        name: pytest
+        entry: pytest
+        language: system
+        types: [python]
         args: ["-q"]
-        additional_dependencies:
-          - "-r"
-          - requirements.txt
-          - "-r"
-          - requirements-dev.txt

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,3 +3,7 @@ mypy==1.16.0
 pytest==8.4.0
 radon==6.0.1
 pydocstyle==6.3.0
+pre-commit==3.7.1
+black==25.1.0
+isort==6.0.1
+bandit==1.8.5


### PR DESCRIPTION
## Summary
- add Black, isort, Bandit and pre-commit to dev deps
- update pre-commit hooks for Black, isort, Flake8, Mypy, Bandit and Pytest
- run CI workflow on every push

## Testing
- `pre-commit run --files requirements-dev.txt .pre-commit-config.yaml .github/workflows/ci.yml`
- `pytest -q` *(fails: 34 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_685dcaec84b48333bedc448d78c24027