### PR TITLE
Refactor export module

### DIFF
--- a/src/piwardrive/export.py
+++ b/src/piwardrive/export.py
@@ -1,13 +1,12 @@
-"""Module export."""
+"""Helpers for exporting data in various formats."""
+import csv
 import json
 import os
 import tempfile
 import zipfile
 import xml.etree.ElementTree as ET
-from typing import Any, Iterable, Mapping, Sequence
+from typing import Any, Iterable, Mapping, Sequence, Callable
 import time
-
-import csv
 
 try:  # Optional dependency for shapefile export
     import shapefile  # type: ignore
@@ -62,6 +61,148 @@ def filter_records(
     return result
 
 
+def export_csv(
+    rows: Sequence[Mapping[str, Any]], path: str, fields: Sequence[str] | None
+) -> None:
+    """Write ``rows`` to ``path`` in CSV format."""
+    it = iter(rows)
+    try:
+        first = next(it)
+    except StopIteration:
+        open(path, "w", newline="", encoding="utf-8").close()
+        return
+
+    fieldnames = fields or list(first.keys())
+    with open(path, "w", newline="", encoding="utf-8") as fh:
+        writer = csv.DictWriter(fh, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerow(first)
+        for row in it:
+            writer.writerow(row)
+
+
+def export_json(
+    rows: Sequence[Mapping[str, Any]], path: str, _fields: Sequence[str] | None
+) -> None:
+    """Write ``rows`` to ``path`` in JSON format."""
+    with open(path, "w", encoding="utf-8") as fh:
+        fh.write("[")
+        for i, rec in enumerate(rows):
+            if i:
+                fh.write(",")
+            json.dump(rec, fh)
+        fh.write("]")
+
+
+def export_gpx(
+    rows: Sequence[Mapping[str, Any]], path: str, _fields: Sequence[str] | None
+) -> None:
+    """Write ``rows`` to ``path`` in GPX format."""
+    root = ET.Element("gpx", version="1.1", creator="piwardrive")
+    for rec in rows:
+        lat = rec.get("lat")
+        lon = rec.get("lon")
+        if lat is None or lon is None:
+            continue
+        wpt = ET.SubElement(root, "wpt", lat=str(lat), lon=str(lon))
+        name = rec.get("ssid") or rec.get("bssid")
+        if name:
+            ET.SubElement(wpt, "name").text = str(name)
+    ET.ElementTree(root).write(path, encoding="utf-8", xml_declaration=True)
+
+
+def export_kml(
+    rows: Sequence[Mapping[str, Any]], path: str, _fields: Sequence[str] | None
+) -> None:
+    """Write ``rows`` to ``path`` in KML format."""
+    root = ET.Element("kml", xmlns="http://www.opengis.net/kml/2.2")
+    doc = ET.SubElement(root, "Document")
+    for rec in rows:
+        lat = rec.get("lat")
+        lon = rec.get("lon")
+        if lat is None or lon is None:
+            continue
+        placemark = ET.SubElement(doc, "Placemark")
+        name = rec.get("ssid") or rec.get("bssid")
+        if name:
+            ET.SubElement(placemark, "name").text = str(name)
+        point = ET.SubElement(placemark, "Point")
+        ET.SubElement(point, "coordinates").text = f"{lon},{lat}"
+    ET.ElementTree(root).write(path, encoding="utf-8", xml_declaration=True)
+
+
+def export_geojson(
+    rows: Sequence[Mapping[str, Any]], path: str, fields: Sequence[str] | None
+) -> None:
+    """Write ``rows`` to ``path`` in GeoJSON format."""
+    features = []
+    for rec in rows:
+        lat = rec.get("lat")
+        lon = rec.get("lon")
+        if lat is None or lon is None:
+            continue
+        props = dict(rec)
+        props.pop("lat", None)
+        props.pop("lon", None)
+        if fields is not None:
+            props = {k: props.get(k) for k in fields if k not in {"lat", "lon"}}
+        features.append(
+            {
+                "type": "Feature",
+                "geometry": {"type": "Point", "coordinates": [lon, lat]},
+                "properties": props,
+            }
+        )
+    with open(path, "w", encoding="utf-8") as fh:
+        json.dump({"type": "FeatureCollection", "features": features}, fh)
+
+
+def export_shp(
+    rows: Sequence[Mapping[str, Any]], path: str, fields: Sequence[str] | None
+) -> None:
+    """Write ``rows`` to ``path`` in Shapefile format."""
+    if shapefile is None:
+        raise RuntimeError("pyshp is required for shapefile export")
+    rows = list(rows)
+    base = path[:-4] if path.lower().endswith(".shp") else path
+    if getattr(shapefile, "__version__", "2").startswith("1."):
+        writer = shapefile.Writer(base)
+        writer.shapeType = shapefile.POINT
+    else:
+        writer = shapefile.Writer(base, shapefile.POINT)
+    fieldnames = fields or (list(rows[0].keys()) if rows else [])
+    for name in fieldnames:
+        if name in {"lat", "lon"}:
+            continue
+        writer.field(name[:10], "C")
+    for rec in rows:
+        lat = rec.get("lat")
+        lon = rec.get("lon")
+        if lat is None or lon is None:
+            continue
+        writer.point(lon, lat)
+        record = []
+        for name in fieldnames:
+            if name in {"lat", "lon"}:
+                continue
+            record.append(rec.get(name))
+        writer.record(*record)
+    if hasattr(writer, "close"):
+        writer.close()
+    else:  # pyshp < 2
+        writer.save(base)
+
+
+EXPORTERS: dict[str, Callable[[Sequence[Mapping[str, Any]], str, Sequence[str] | None], None]] = {
+    "csv": export_csv,
+    "json": export_json,
+    "gpx": export_gpx,
+    "kml": export_kml,
+    "geojson": export_geojson,
+    "shp": export_shp,
+}
+
+
 def export_records(
     records: Sequence[Mapping[str, Any]],
     path: str,
@@ -72,153 +213,9 @@ def export_records(
     if fields is not None:
         records = [{k: r.get(k) for k in fields} for r in records]
     fmt = fmt.lower()
-    if fmt not in EXPORT_FORMATS:
-        raise ValueError(f"Unsupported format: {fmt}")
-
-    def export_csv(
-        rows: Sequence[Mapping[str, Any]],
-        p: str,
-        f: Sequence[str] | None,
-    ) -> None:
-        it = iter(rows)
-        try:
-            first = next(it)
-        except StopIteration:
-            open(p, "w", newline="", encoding="utf-8").close()
-            return
-
-        fieldnames = f or list(first.keys())
-        with open(p, "w", newline="", encoding="utf-8") as fh:
-            writer = csv.DictWriter(fh, fieldnames=fieldnames)
-            writer.writeheader()
-            writer.writerow(first)
-            for row in it:
-                writer.writerow(row)
-
-    def export_json(
-        rs: Sequence[Mapping[str, Any]],
-        p: str,
-        _f: Sequence[str] | None,
-    ) -> None:
-        with open(p, "w", encoding="utf-8") as fh:
-            fh.write("[")
-            for i, rec in enumerate(rs):
-                if i:
-                    fh.write(",")
-                json.dump(rec, fh)
-            fh.write("]")
-
-    def export_gpx(
-        rs: Sequence[Mapping[str, Any]],
-        p: str,
-        _f: Sequence[str] | None,
-    ) -> None:
-        root = ET.Element("gpx", version="1.1", creator="piwardrive")
-        for rec in rs:
-            lat = rec.get("lat")
-            lon = rec.get("lon")
-            if lat is None or lon is None:
-                continue
-            wpt = ET.SubElement(root, "wpt", lat=str(lat), lon=str(lon))
-            name = rec.get("ssid") or rec.get("bssid")
-            if name:
-                ET.SubElement(wpt, "name").text = str(name)
-        ET.ElementTree(root).write(p, encoding="utf-8", xml_declaration=True)
-
-    def export_kml(
-        rs: Sequence[Mapping[str, Any]],
-        p: str,
-        _f: Sequence[str] | None,
-    ) -> None:
-        root = ET.Element("kml", xmlns="http://www.opengis.net/kml/2.2")
-        doc = ET.SubElement(root, "Document")
-        for rec in rs:
-            lat = rec.get("lat")
-            lon = rec.get("lon")
-            if lat is None or lon is None:
-                continue
-            placemark = ET.SubElement(doc, "Placemark")
-            name = rec.get("ssid") or rec.get("bssid")
-            if name:
-                ET.SubElement(placemark, "name").text = str(name)
-            point = ET.SubElement(placemark, "Point")
-            ET.SubElement(point, "coordinates").text = f"{lon},{lat}"
-        ET.ElementTree(root).write(p, encoding="utf-8", xml_declaration=True)
-
-    def export_geojson(
-        rs: Sequence[Mapping[str, Any]],
-        p: str,
-        f: Sequence[str] | None,
-    ) -> None:
-        features = []
-        for rec in rs:
-            lat = rec.get("lat")
-            lon = rec.get("lon")
-            if lat is None or lon is None:
-                continue
-            props = dict(rec)
-            props.pop("lat", None)
-            props.pop("lon", None)
-            if f is not None:
-                props = {k: props.get(k) for k in f if k not in {"lat", "lon"}}
-            features.append(
-                {
-                    "type": "Feature",
-                    "geometry": {"type": "Point", "coordinates": [lon, lat]},
-                    "properties": props,
-                }
-            )
-        with open(p, "w", encoding="utf-8") as fh:
-            json.dump({"type": "FeatureCollection", "features": features}, fh)
-
-    def export_shp(
-        rs: Sequence[Mapping[str, Any]],
-        p: str,
-        f: Sequence[str] | None,
-    ) -> None:
-        if shapefile is None:
-            raise RuntimeError("pyshp is required for shapefile export")
-        rs = list(rs)
-        base = p[:-4] if p.lower().endswith(".shp") else p
-        if getattr(shapefile, "__version__", "2").startswith("1."):
-            writer = shapefile.Writer(base)
-            writer.shapeType = shapefile.POINT
-        else:
-            writer = shapefile.Writer(base, shapefile.POINT)
-        fieldnames = f or (list(rs[0].keys()) if rs else [])
-        for name in fieldnames:
-            if name in {"lat", "lon"}:
-                continue
-            writer.field(name[:10], "C")
-        for rec in rs:
-            lat = rec.get("lat")
-            lon = rec.get("lon")
-            if lat is None or lon is None:
-                continue
-            writer.point(lon, lat)
-            record = []
-            for name in fieldnames:
-                if name in {"lat", "lon"}:
-                    continue
-                record.append(rec.get(name))
-            writer.record(*record)
-        if hasattr(writer, "close"):
-            writer.close()
-        else:  # pyshp < 2
-            writer.save(base)
-
-    exporters = {
-        "csv": export_csv,
-        "json": export_json,
-        "gpx": export_gpx,
-        "kml": export_kml,
-        "geojson": export_geojson,
-        "shp": export_shp,
-    }
-
     try:
-        exporter = exporters[fmt]
-    except KeyError as exc:  # pragma: no cover - safety net
+        exporter = EXPORTERS[fmt]
+    except KeyError as exc:
         raise ValueError(f"Unsupported format: {fmt}") from exc
     exporter(records, path, fields)
 


### PR DESCRIPTION
## Summary
- refactor export helpers into smaller functions
- keep a global EXPORTERS strategy map
- simplify export_records

## Testing
- `pytest tests/test_export.py::test_export_records_formats -q`
- `pytest tests/test_export.py::test_filter_records tests/test_export.py::test_export_records_formats -q`


------
https://chatgpt.com/codex/tasks/task_e_685dcb77a9cc83339b7b9dcd4746f9ca