### PR TITLE
Optimize parse_packets with compiled regex

### DIFF
--- a/benchmarks/packet_parse_benchmark.py
+++ b/benchmarks/packet_parse_benchmark.py
@@ -1,0 +1,21 @@
+"""Benchmark LoRa packet parsing."""
+
+import time
+from piwardrive import lora_scanner
+
+
+def generate_lines(n: int) -> list[str]:
+    base = "time=2024-01-01T00:00:00Z freq=868.1 rssi=-120 snr=7.5 devaddr=ABC"
+    return [base] * n
+
+
+def bench(count: int = 100000) -> None:
+    lines = generate_lines(count)
+    start = time.perf_counter()
+    lora_scanner.parse_packets(lines)
+    duration = time.perf_counter() - start
+    print(f"{count} lines in {duration:.3f}s ({count / duration:.1f} l/s)")
+
+
+if __name__ == "__main__":
+    bench()

--- a/src/piwardrive/lora_scanner.py
+++ b/src/piwardrive/lora_scanner.py
@@ -9,6 +9,8 @@ from dataclasses import dataclass
 from typing import List, Sequence
 import re
 
+PACKET_RE = re.compile(r"(\w+)=([\w.:-]+)")
+
 logger = logging.getLogger(__name__)
 
 
@@ -62,7 +64,7 @@ def parse_packets(lines: Sequence[str]) -> List[LoRaPacket]:
 
     packets: List[LoRaPacket] = []
     for line in lines:
-        fields = dict(re.findall(r"(\w+)=([\w.:-]+)", line))
+        fields = dict(PACKET_RE.findall(line))
         pkt = LoRaPacket(
             timestamp=fields.get("time"),
             freq=_to_float(fields.get("freq")),
@@ -73,6 +75,12 @@ def parse_packets(lines: Sequence[str]) -> List[LoRaPacket]:
         )
         packets.append(pkt)
     return packets
+
+
+async def async_parse_packets(lines: Sequence[str]) -> List[LoRaPacket]:
+    """Asynchronously parse packets from ``lines``."""
+    loop = asyncio.get_running_loop()
+    return await loop.run_in_executor(None, parse_packets, lines)
 
 
 def plot_signal_trend(packets: Sequence[LoRaPacket], path: str) -> None:

--- a/tests/test_lora_scanner.py
+++ b/tests/test_lora_scanner.py
@@ -58,6 +58,15 @@ def test_async_scan_lora(monkeypatch):
     assert lines == ["a", "b"]
 
 
+def test_async_parse_packets():
+    lines = [
+        "time=2024-01-01T00:00:00Z freq=868.1 rssi=-120 snr=7.5 devaddr=ABC",
+        "time=2024-01-01T00:00:01Z freq=868.1 rssi=-118 snr=6.8 devaddr=ABC",
+    ]
+    packets = asyncio.run(lora_scanner.async_parse_packets(lines))
+    assert len(packets) == 2
+
+
 def test_main(capsys, monkeypatch):
     monkeypatch.setattr(lora_scanner, "scan_lora", lambda iface="l0": ["x"])
     argv = sys.argv


### PR DESCRIPTION
## Summary
- optimize `parse_packets` by reusing a compiled regex
- expose `async_parse_packets`
- add benchmark for parsing throughput
- test the new async parser

## Testing
- `pytest tests/test_lora_scanner.py -q`
- `PYTHONPATH=src python benchmarks/packet_parse_benchmark.py`

------
https://chatgpt.com/codex/tasks/task_e_685ddfe3f7cc8333a6ef97f8b437a7dd