### PR TITLE
Add domain-specific error classes

### DIFF
--- a/src/piwardrive/errors.py
+++ b/src/piwardrive/errors.py
@@ -1,0 +1,14 @@
+class PiWardriveError(Exception):
+    """Base class for PiWardrive domain errors."""
+
+
+class ConfigError(PiWardriveError):
+    """Raised when configuration validation fails."""
+
+
+class ExportError(PiWardriveError):
+    """Raised when exporting data fails."""
+
+
+class GeofenceError(PiWardriveError):
+    """Raised for geofence load/save issues."""


### PR DESCRIPTION
## Summary
- create `errors.py` with PiWardriveError base class and related exceptions

## Testing
- `pre-commit run --files src/piwardrive/errors.py` *(fails: pytest - no tests ran)*
- `pytest -q` *(fails: 34 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_685de015839883338c90acc72114f8b9