### PR TITLE
Add exception handling for geofence saving

### DIFF
--- a/src/piwardrive/service.py
+++ b/src/piwardrive/service.py
@@ -151,8 +151,11 @@ def _load_geofences() -> list:
 
 def _save_geofences(polys: list) -> None:
     os.makedirs(CONFIG_DIR, exist_ok=True)
-    with open(GEOFENCE_FILE, "w", encoding="utf-8") as fh:
-        json.dump(polys, fh, indent=2)
+    try:
+        with open(GEOFENCE_FILE, "w", encoding="utf-8") as fh:
+            json.dump(polys, fh, indent=2)
+    except OSError as exc:
+        logging.exception("Failed to save geofences: %s", exc)
 
 
 def _check_auth(credentials: HTTPBasicCredentials = Depends(security)) -> None:


### PR DESCRIPTION
## Summary
- log an exception when saving geofence data fails

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685de00fec4c8333a022670d8fa3071a