### PR TITLE
Use structured logging in export_logs script

### DIFF
--- a/scripts/export_logs.py
+++ b/scripts/export_logs.py
@@ -1,6 +1,8 @@
 """Module export_logs."""
+
 import argparse
 import asyncio
+import logging
 
 try:  # allow tests to substitute a lightweight main module
     from main import PiWardriveApp  # type: ignore
@@ -24,6 +26,7 @@ def main(argv: list[str] | None = None) -> None:
     app = PiWardriveApp()
     path = asyncio.run(app.export_logs(args.output, args.lines))
     if path:
+        logging.info("Logs exported to %s", path)
         print(path)
 
 

--- a/tests/test_export_logs_script.py
+++ b/tests/test_export_logs_script.py
@@ -3,24 +3,25 @@ import sys
 from types import SimpleNamespace
 
 
-
 def test_export_logs_script(monkeypatch, tmp_path):
     called = {}
 
     async def fake_export(self, path=None, lines=200):
-        called['path'] = path
-        called['lines'] = lines
-        return 'ok'
+        called["path"] = path
+        called["lines"] = lines
+        return "ok"
 
     class DummyApp:
         def __init__(self):
             pass
+
         export_logs = fake_export
 
-    monkeypatch.setitem(sys.modules, 'main', SimpleNamespace(PiWardriveApp=DummyApp))
-    if 'piwardrive.scripts.export_logs' in sys.modules:
-        del sys.modules['piwardrive.scripts.export_logs']
+    monkeypatch.setitem(sys.modules, "main", SimpleNamespace(PiWardriveApp=DummyApp))
+    if "piwardrive.scripts.export_logs" in sys.modules:
+        del sys.modules["piwardrive.scripts.export_logs"]
     import piwardrive.scripts.export_logs as ex
-    ex.main([str(tmp_path / 'log.txt'), '--lines', '10'])
-    assert called['path'] == str(tmp_path / 'log.txt')
-    assert called['lines'] == 10
+
+    ex.main([str(tmp_path / "log.txt"), "--lines", "10"])
+    assert called["path"] == str(tmp_path / "log.txt")
+    assert called["lines"] == 10


### PR DESCRIPTION
## Summary
- use logging in CLI utility `export_logs.py`
- update related test

## Testing
- `pre-commit run --files scripts/export_logs.py tests/test_export_logs_script.py` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_685de01b8db8833391626aff69896dd2