### PR TITLE
Add tests for service and server startup

### DIFF
--- a/tests/test_aggregation_service_main.py
+++ b/tests/test_aggregation_service_main.py
@@ -1,0 +1,13 @@
+import asyncio
+import importlib
+from unittest.mock import AsyncMock
+
+
+def test_main_starts_uvicorn(monkeypatch):
+    module = importlib.import_module("piwardrive.aggregation_service")
+    monkeypatch.setattr(module, "_get_conn", AsyncMock())
+    server_mock = AsyncMock()
+    monkeypatch.setattr("uvicorn.Server", lambda cfg: server_mock)
+    monkeypatch.setattr("uvicorn.Config", lambda *a, **k: object())
+    asyncio.run(module.main())
+    server_mock.serve.assert_awaited()

--- a/tests/test_service_main.py
+++ b/tests/test_service_main.py
@@ -1,0 +1,17 @@
+import asyncio
+import importlib
+import sys
+from types import ModuleType
+from unittest.mock import AsyncMock
+
+
+def test_main_starts_uvicorn(monkeypatch):
+    dummy_sync = ModuleType("sync")
+    dummy_sync.upload_data = AsyncMock()
+    sys.modules["sync"] = dummy_sync
+    module = importlib.import_module("piwardrive.service")
+    server_mock = AsyncMock()
+    monkeypatch.setattr("uvicorn.Server", lambda cfg: server_mock)
+    monkeypatch.setattr("uvicorn.Config", lambda *a, **k: object())
+    asyncio.run(module.main())
+    server_mock.serve.assert_awaited()

--- a/tests/test_web_server_main.py
+++ b/tests/test_web_server_main.py
@@ -1,0 +1,16 @@
+import importlib
+import sys
+from types import ModuleType
+from unittest.mock import Mock
+
+
+def test_main_runs_uvicorn(monkeypatch):
+    dummy_sync = ModuleType("sync")
+    dummy_sync.upload_data = lambda: None
+    sys.modules["sync"] = dummy_sync
+    module = importlib.import_module("piwardrive.web_server")
+    run_mock = Mock()
+    monkeypatch.setattr("uvicorn.run", run_mock)
+    monkeypatch.setattr(module, "create_app", lambda: object())
+    module.main()
+    run_mock.assert_called()

--- a/tests/test_webui_server_main.py
+++ b/tests/test_webui_server_main.py
@@ -1,0 +1,16 @@
+import importlib
+import sys
+from types import ModuleType
+from unittest.mock import Mock
+
+
+def test_main_runs_uvicorn(monkeypatch):
+    dummy_sync = ModuleType("sync")
+    dummy_sync.upload_data = lambda: None
+    sys.modules["sync"] = dummy_sync
+    module = importlib.import_module("piwardrive.web.webui_server")
+    run_mock = Mock()
+    monkeypatch.setattr("uvicorn.run", run_mock)
+    monkeypatch.setattr(module, "create_app", lambda: object())
+    module.main()
+    run_mock.assert_called()


### PR DESCRIPTION
## Summary
- add tests for `main` functions that start Uvicorn servers

## Testing
- `pre-commit run --files tests/test_aggregation_service_main.py tests/test_service_main.py tests/test_web_server_main.py tests/test_webui_server_main.py`

------
https://chatgpt.com/codex/tasks/task_e_685de055cc1483338bf2137ca325f4f4