### PR TITLE
Update packaging metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ exclude = ["tests*", "docs*", "benchmarks*", "examples*"]
 [project]
 name = "piwardrive"
 version = "0.1.0"
-description = "Headless war-driving toolkit with a Kivy interface"
+description = "Headless war-driving toolkit with a browser-based interface"
 readme = "README.md"
 requires-python = ">=3.10"
 license = {file = "LICENSE"}


### PR DESCRIPTION
## Summary
- clarify that PiWardrive's headless interface is browser-based

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685de7668d2883338cff40ae6b7aa66f