### PR TITLE
Add config_mtime test

### DIFF
--- a/tests/test_config_runtime.py
+++ b/tests/test_config_runtime.py
@@ -1,7 +1,4 @@
-import sys
-import os
 from pathlib import Path
-
 
 from piwardrive import config
 
@@ -15,12 +12,21 @@ def setup_tmp(tmp_path: Path) -> Path:
 
 
 def test_config_mtime_updates(tmp_path: Path) -> None:
-    path = setup_tmp(tmp_path)
+    setup_tmp(tmp_path)
     cfg = config.Config(theme="Dark")
     config.save_config(cfg)
     first = config.config_mtime()
     cfg.theme = "Green"
     config.save_config(cfg)
     second = config.config_mtime()
-    assert first is not None and second is not None
-    assert second >= first
+    assert first is not None and second is not None  # nosec B101
+    assert second >= first  # nosec B101
+
+
+def test_config_mtime_returns_timestamp(tmp_path: Path) -> None:
+    path = setup_tmp(tmp_path)
+    path.write_text("{}")
+    expected = path.stat().st_mtime
+    actual = config.config_mtime()
+    assert actual is not None  # nosec B101
+    assert abs(actual - expected) < 1e-3  # nosec B101


### PR DESCRIPTION
## Summary
- add test verifying that `config_mtime` returns modification time

## Testing
- `pre-commit run --files tests/test_config_runtime.py`

------
https://chatgpt.com/codex/tasks/task_e_685de6ce02c883339732776a3e1f6228