### PR TITLE
Remove Kivy reliance and add REST APIs

### DIFF
--- a/webui/src/components/LoRaScan.jsx
+++ b/webui/src/components/LoRaScan.jsx
@@ -10,16 +10,9 @@ export default function LoRaScan() {
 
   useEffect(() => {
     const load = () => {
-      fetch('/command', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ cmd: 'lora-scan --iface lora0' }),
-      })
+      fetch('/lora-scan')
         .then(r => r.json())
-        .then(d => {
-          const lines = d.output ? d.output.trim().split('\n') : [];
-          setCount(lines.length);
-        })
+        .then(d => setCount(d.count))
         .catch(() => setCount(null));
     };
     load();

--- a/webui/tests/extraWidgets.test.jsx
+++ b/webui/tests/extraWidgets.test.jsx
@@ -24,7 +24,7 @@ describe('extra widgets', () => {
   it('fetches LoRa scan results', async () => {
     let origFetch = global.fetch;
     global.fetch = vi.fn(() => Promise.resolve({
-      json: () => Promise.resolve({ output: 'a\nb\nc' })
+      json: () => Promise.resolve({ count: 3 })
     }));
     render(<LoRaScan />);
     expect(await screen.findByText('LoRa Devices: 3')).toBeInTheDocument();


### PR DESCRIPTION
## Summary
- add API endpoints `/db-stats` and `/lora-scan`
- integrate LoRa scan widget with new endpoint
- adjust LoRa widget tests
- cover API endpoints with tests

## Testing
- `pre-commit run --files src/piwardrive/service.py tests/test_service.py webui/src/components/LoRaScan.jsx webui/tests/extraWidgets.test.jsx` *(fails: command not found)*
- `pip install -r requirements.txt -r requirements-dev.txt` *(fails to build dbus-python)*
- `pytest -q` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685de7616b9483338e0cbe17aafe5307