### PR TITLE
Switch scripts to structured logging

### DIFF
--- a/scripts/calibrate_orientation.py
+++ b/scripts/calibrate_orientation.py
@@ -4,8 +4,11 @@ from __future__ import annotations
 
 import argparse
 import json
+import logging
 from pathlib import Path
 from typing import Dict
+
+from piwardrive.logconfig import setup_logging
 
 from piwardrive import orientation_sensors as osens
 
@@ -14,10 +17,10 @@ def _prompt(angle: float) -> None:
     input(f"Rotate the device to {angle} degrees and press Enter...")
     orient = osens.get_orientation_dbus()
     if orient is None:
-        print("Orientation not available, skipping")
+        logging.error("Orientation not available, skipping")
         return
     osens.update_orientation_map({orient: angle})
-    print(f"Mapped '{orient}' -> {angle}")
+    logging.info("Mapped '%s' -> %s", orient, angle)
 
 
 def main(argv: list[str] | None = None) -> None:
@@ -32,12 +35,14 @@ def main(argv: list[str] | None = None) -> None:
     )
     args = parser.parse_args(argv)
 
+    setup_logging(stdout=True)
+
     mapping: Dict[str, float] = {}
     for angle in (0.0, 90.0, 180.0, 270.0):
         _prompt(angle)
     mapping = osens.clone_orientation_map()
     Path(args.output).write_text(json.dumps(mapping, indent=2))
-    print(f"Saved mapping to {args.output}")
+    logging.info("Saved mapping to %s", args.output)
 
 
 if __name__ == "__main__":  # pragma: no cover - manual invocation

--- a/scripts/export_log_bundle.py
+++ b/scripts/export_log_bundle.py
@@ -1,7 +1,9 @@
 """Module export_log_bundle."""
 import argparse
 import asyncio
+import logging
 
+from piwardrive.logconfig import setup_logging
 try:  # allow tests to substitute a lightweight main module
     from main import PiWardriveApp  # type: ignore
 except Exception:  # pragma: no cover - fallback
@@ -21,10 +23,11 @@ def main(argv: list[str] | None = None) -> None:
     )
     args = parser.parse_args(argv)
 
+    setup_logging(stdout=True)
     app = PiWardriveApp()
     path = asyncio.run(app.export_log_bundle(args.output, args.lines))
     if path:
-        print(path)
+        logging.info("%s", path)
 
 
 if __name__ == "__main__":  # pragma: no cover - manual invocation

--- a/scripts/export_logs.py
+++ b/scripts/export_logs.py
@@ -4,6 +4,8 @@ import argparse
 import asyncio
 import logging
 
+from piwardrive.logconfig import setup_logging
+
 try:  # allow tests to substitute a lightweight main module
     from main import PiWardriveApp  # type: ignore
 except Exception:  # pragma: no cover - fallback
@@ -23,11 +25,11 @@ def main(argv: list[str] | None = None) -> None:
     )
     args = parser.parse_args(argv)
 
+    setup_logging(stdout=True)
     app = PiWardriveApp()
     path = asyncio.run(app.export_logs(args.output, args.lines))
     if path:
         logging.info("Logs exported to %s", path)
-        print(path)
 
 
 if __name__ == "__main__":  # pragma: no cover - manual invocation

--- a/scripts/localize_aps.py
+++ b/scripts/localize_aps.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 import argparse
 import json
+import logging
 from pathlib import Path
+
+from piwardrive.logconfig import setup_logging
 
 from piwardrive.advanced_localization import load_config, load_kismet_data, localize_aps
 
@@ -41,6 +44,7 @@ def main(argv: list[str] | None = None) -> None:
     )
     args = parser.parse_args(argv)
 
+    setup_logging(stdout=True)
     cfg = load_config(args.config)
     data = load_kismet_data(args.database)
     coords = localize_aps(data, cfg)
@@ -48,7 +52,7 @@ def main(argv: list[str] | None = None) -> None:
     if folium is not None:
         _save_map(coords, Path(args.output), cfg.map_zoom_start)
     else:
-        print(json.dumps(coords, indent=2))
+        logging.info(json.dumps(coords, indent=2))
 
 
 if __name__ == "__main__":  # pragma: no cover - manual invocation

--- a/scripts/log_follow.py
+++ b/scripts/log_follow.py
@@ -2,9 +2,12 @@
 import argparse
 import os
 import time
+import logging
 
 from logconfig import DEFAULT_LOG_PATH
 from utils import tail_file
+
+from piwardrive.logconfig import setup_logging
 
 
 def main(argv: list[str] | None = None) -> None:
@@ -32,8 +35,10 @@ def main(argv: list[str] | None = None) -> None:
     )
     args = parser.parse_args(argv)
 
+    setup_logging(stdout=True)
+
     for line in tail_file(args.path, args.lines):
-        print(line)
+        logging.info(line)
 
     try:
         with open(args.path, "r", encoding="utf-8", errors="ignore") as fh:
@@ -41,7 +46,7 @@ def main(argv: list[str] | None = None) -> None:
             while True:
                 line = fh.readline()
                 if line:
-                    print(line, end="")
+                    logging.info(line.rstrip())
                 else:
                     time.sleep(args.interval)
     except KeyboardInterrupt:

--- a/scripts/prefetch_batch.py
+++ b/scripts/prefetch_batch.py
@@ -1,6 +1,9 @@
 """Module prefetch_batch."""
 import argparse
+import logging
 from screens.map_utils import tile_cache
+
+from piwardrive.logconfig import setup_logging
 
 
 def _parse_bboxes(path: str) -> list[tuple[float, float, float, float]]:
@@ -15,12 +18,12 @@ def _parse_bboxes(path: str) -> list[tuple[float, float, float, float]]:
             else:
                 parts = line.split()
             if len(parts) < 4:
-                print(f"Skipping line {lineno}: {line}")
+                logging.error("Skipping line %s: %s", lineno, line)
                 continue
             try:
                 box = tuple(map(float, parts[:4]))
             except ValueError:
-                print(f"Skipping line {lineno}: {line}")
+                logging.error("Skipping line %s: %s", lineno, line)
                 continue
             bboxes.append(box)  # type: ignore[arg-type]
     return bboxes
@@ -46,13 +49,14 @@ def main(argv: list[str] | None = None) -> None:
     )
     args = parser.parse_args(argv)
 
+    setup_logging(stdout=True)
     bboxes = _parse_bboxes(args.input)
     if not bboxes:
-        print("No bounding boxes found")
+        logging.error("No bounding boxes found")
         return
 
     def progress(done: int, total: int) -> None:
-        print(f"{done}/{total}", end="\r", flush=True)
+        logging.info("%s/%s", done, total)
 
     for bbox in bboxes:
         tile_cache.prefetch_tiles(

--- a/scripts/prefetch_cli.py
+++ b/scripts/prefetch_cli.py
@@ -1,6 +1,9 @@
 """Module prefetch_cli."""
 import argparse
+import logging
 from piwardrive.screens.map_utils import tile_cache
+
+from piwardrive.logconfig import setup_logging
 
 
 def main(argv: list[str] | None = None) -> None:
@@ -19,8 +22,10 @@ def main(argv: list[str] | None = None) -> None:
     parser.add_argument("--concurrency", type=int, help="number of concurrent requests")
     args = parser.parse_args(argv)
 
+    setup_logging(stdout=True)
+
     def progress(done: int, total: int) -> None:
-        print(f"{done}/{total}", end="\r", flush=True)
+        logging.info("%s/%s", done, total)
 
     tile_cache.prefetch_tiles(
         (args.min_lat, args.min_lon, args.max_lat, args.max_lon),

--- a/scripts/service_status.py
+++ b/scripts/service_status.py
@@ -1,7 +1,10 @@
 """Command line helper for checking systemd service status."""
 import argparse
 import json
+import logging
 from types import SimpleNamespace
+
+from piwardrive.logconfig import setup_logging
 
 
 def _get_service_statuses(services=None):
@@ -22,8 +25,9 @@ def main(argv: list[str] | None = None) -> None:
         help="Services to check (defaults to kismet, bettercap, gpsd)",
     )
     args = parser.parse_args(argv)
+    setup_logging(stdout=True)
     statuses = diagnostics.get_service_statuses(args.services or None)
-    print(json.dumps(statuses))
+    logging.info(json.dumps(statuses))
 
 
 if __name__ == "__main__":  # pragma: no cover - manual invocation

--- a/scripts/uav_record.py
+++ b/scripts/uav_record.py
@@ -5,10 +5,13 @@ from __future__ import annotations
 import argparse
 import os
 import time
+import logging
 
 from sigint_suite.wifi import scan_wifi
 from sigint_suite.exports import export_json
 from sigint_suite import paths
+
+from piwardrive.logconfig import setup_logging
 
 try:
     from dronekit import connect
@@ -44,6 +47,8 @@ def main(argv: list[str] | None = None) -> None:
     )
     args = parser.parse_args(argv)
 
+    setup_logging(stdout=True)
+
     if connect is None:
         raise RuntimeError(
             "dronekit not installed. Use 'pip install dronekit' to enable UAV support"
@@ -78,7 +83,7 @@ def main(argv: list[str] | None = None) -> None:
     os.makedirs(args.export_dir, exist_ok=True)
     export_json(track, os.path.join(args.export_dir, "uav_track.json"))
     export_json(wifi_records, os.path.join(args.export_dir, "uav_wifi.json"))
-    print(f"Data saved to {args.export_dir}")
+    logging.info("Data saved to %s", args.export_dir)
 
 
 if __name__ == "__main__":  # pragma: no cover - manual use

--- a/scripts/uav_track_playback.py
+++ b/scripts/uav_track_playback.py
@@ -5,12 +5,14 @@ from __future__ import annotations
 import argparse
 import asyncio
 import json
+import logging
 
 from piwardrive.gps_track_playback import playback_track
+from piwardrive.logconfig import setup_logging
 
 
 async def _print_point(lat: float, lon: float) -> None:
-    print(f"{lat:.6f}, {lon:.6f}")
+    logging.info("%0.6f, %0.6f", lat, lon)
 
 
 async def _run(track_file: str, interval: float) -> None:
@@ -29,6 +31,7 @@ def main(argv: list[str] | None = None) -> None:
         help="seconds between points",
     )
     args = parser.parse_args(argv)
+    setup_logging(stdout=True)
     asyncio.run(_run(args.track, args.interval))
 
 

--- a/src/piwardrive/lora_scanner.py
+++ b/src/piwardrive/lora_scanner.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from piwardrive.logconfig import setup_logging
 import subprocess
 from dataclasses import dataclass
 from typing import List, Sequence
@@ -119,13 +120,15 @@ def main() -> None:  # pragma: no cover - CLI helper
     parser.add_argument("--json", action="store_true", help="print as JSON")
     args = parser.parse_args()
 
+    setup_logging(stdout=True)
+
     lines = scan_lora(args.iface)
     if args.json:
         packets = [p.__dict__ for p in parse_packets(lines)]
-        print(json.dumps(packets, indent=2))
+        logging.info(json.dumps(packets, indent=2))
     else:
         for line in lines:
-            print(line)
+            logging.info(line)
 
 
 if __name__ == "__main__":  # pragma: no cover - manual execution

--- a/src/piwardrive/scripts/service_status.py
+++ b/src/piwardrive/scripts/service_status.py
@@ -1,7 +1,10 @@
 """Command line helper for checking systemd service status."""
 import argparse
 import json
+import logging
 from types import SimpleNamespace
+
+from piwardrive.logconfig import setup_logging
 
 
 def _get_service_statuses(services=None):
@@ -22,8 +25,9 @@ def main(argv: list[str] | None = None) -> None:
         help="Services to check (defaults to kismet, bettercap, gpsd)",
     )
     args = parser.parse_args(argv)
+    setup_logging(stdout=True)
     statuses = diagnostics.get_service_statuses(args.services or None)
-    print(json.dumps(statuses))
+    logging.info(json.dumps(statuses))
 
 
 if __name__ == "__main__":  # pragma: no cover - manual invocation

--- a/tests/test_lora_scanner.py
+++ b/tests/test_lora_scanner.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import asyncio
+import json
 from types import ModuleType
 import pytest
 
@@ -75,6 +76,8 @@ def test_main(capsys, monkeypatch):
         lora_scanner.main()
     finally:
         sys.argv = argv
-    out = capsys.readouterr().out
-    assert "x" in out
+    out_lines = [
+        json.loads(l) for l in capsys.readouterr().out.strip().splitlines() if l
+    ]
+    assert any(rec["message"] == "x" for rec in out_lines)
 

--- a/tests/test_service_status_script.py
+++ b/tests/test_service_status_script.py
@@ -9,6 +9,8 @@ import piwardrive.scripts.service_status as ss
 def test_service_status_script_output(monkeypatch, capsys):
     monkeypatch.setattr(ss.diagnostics, "get_service_statuses", lambda svcs=None: {"kismet": True, "gpsd": False})
     ss.main(["kismet", "gpsd"])
-    out = capsys.readouterr().out.strip()
-    assert json.loads(out) == {"kismet": True, "gpsd": False}
+    out_lines = [
+        json.loads(l) for l in capsys.readouterr().out.strip().splitlines() if l
+    ]
+    assert out_lines[-1]["message"] == json.dumps({"kismet": True, "gpsd": False})
 


### PR DESCRIPTION
## Summary
- route CLI scripts through logconfig.setup_logging
- emit info/error logs instead of using print
- update tests for JSON logs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for optional test deps)*

------
https://chatgpt.com/codex/tasks/task_e_685dea40239c83338058bb099e114cdd