### PR TITLE
Add retry logic for OUI downloads

### DIFF
--- a/tests/test_vendor_lookup.py
+++ b/tests/test_vendor_lookup.py
@@ -11,7 +11,9 @@ from piwardrive.sigint_suite import paths
 def _reload_module(monkeypatch, tmp_path):
     monkeypatch.setenv("SIGINT_CONFIG_DIR", str(tmp_path))
     if "piwardrive.sigint_suite.enrichment.oui" in sys.modules:
-        monkeypatch.delitem(sys.modules, "piwardrive.sigint_suite.enrichment.oui", raising=False)
+        monkeypatch.delitem(
+            sys.modules, "piwardrive.sigint_suite.enrichment.oui", raising=False
+        )
     return importlib.import_module("piwardrive.sigint_suite.enrichment.oui")
 
 
@@ -25,7 +27,7 @@ def test_update_oui_file_downloads(monkeypatch, tmp_path):
         def raise_for_status(self):
             pass
 
-    monkeypatch.setattr(oui.HTTP_SESSION, "get", lambda url, timeout=15: Resp())
+    monkeypatch.setattr(oui, "robust_request", lambda url: Resp())
     oui.update_oui_file(max_age=0, path=oui.OUI_PATH)
     assert os.path.isfile(oui.OUI_PATH)
     vendor = oui.lookup_vendor("AA:BB:CC:00:11:22")
@@ -38,7 +40,7 @@ def test_update_oui_file_downloads(monkeypatch, tmp_path):
         called = True
         raise AssertionError
 
-    monkeypatch.setattr(oui.HTTP_SESSION, "get", fail)
+    monkeypatch.setattr(oui, "robust_request", fail)
     vendor2 = oui.lookup_vendor("AA:BB:CC:33:44:55")
     assert vendor2 == "VendorX" and not called
 
@@ -49,8 +51,7 @@ def test_update_oui_file_logs_error(monkeypatch, tmp_path, caplog):
     def fail(*a, **k):
         raise Exception("boom")
 
-    monkeypatch.setattr(oui.HTTP_SESSION, "get", fail)
+    monkeypatch.setattr(oui, "robust_request", fail)
     with caplog.at_level(logging.ERROR):
         oui.update_oui_file(max_age=0, path=oui.OUI_PATH)
     assert "OUI registry download failed" in caplog.text
-


### PR DESCRIPTION
## Summary
- use `robust_request` when updating the IEEE OUI registry
- adjust vendor lookup tests for new helper

## Testing
- `pytest tests/test_vendor_lookup.py::test_update_oui_file_downloads -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sklearn')*

------
https://chatgpt.com/codex/tasks/task_e_685dea5491c0833384ee72c49319498e