### PR TITLE
Improve parse_packets with profiling hooks

### DIFF
--- a/src/piwardrive/lora_scanner.py
+++ b/src/piwardrive/lora_scanner.py
@@ -4,10 +4,13 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import subprocess
+import re
+import subprocess  # nosec B404
 from dataclasses import dataclass
 from typing import List, Sequence
-import re
+
+profile = globals().get("profile", lambda f: f)  # type: ignore[no-redef]
+
 
 PACKET_RE = re.compile(r"(\w+)=([\w.:-]+)")
 
@@ -18,7 +21,9 @@ def scan_lora(interface: str = "lora0") -> List[str]:
     """Invoke an external LoRa scanning tool and return raw lines."""
     cmd = ["lora-scan", "--iface", interface]
     try:
-        proc = subprocess.run(cmd, capture_output=True, text=True, check=True)
+        proc = subprocess.run(  # nosec B603
+            cmd, capture_output=True, text=True, check=True
+        )
         return proc.stdout.splitlines()
     except Exception as exc:  # pragma: no cover - runtime errors
         logger.error("LoRa scan failed: %s", exc)
@@ -53,7 +58,10 @@ class LoRaPacket:
     raw: str
 
 
-def parse_packets(lines: Sequence[str]) -> List[LoRaPacket]:
+@profile
+def parse_packets(
+    lines: Sequence[str], packet_re: re.Pattern[str] = PACKET_RE
+) -> List[LoRaPacket]:
     """Return :class:`LoRaPacket` objects parsed from ``lines``."""
 
     def _to_float(val: str | None) -> float | None:
@@ -63,8 +71,9 @@ def parse_packets(lines: Sequence[str]) -> List[LoRaPacket]:
             return None
 
     packets: List[LoRaPacket] = []
+    findall = packet_re.findall
     for line in lines:
-        fields = dict(PACKET_RE.findall(line))
+        fields = dict(findall(line))
         pkt = LoRaPacket(
             timestamp=fields.get("time"),
             freq=_to_float(fields.get("freq")),
@@ -74,6 +83,36 @@ def parse_packets(lines: Sequence[str]) -> List[LoRaPacket]:
             raw=line,
         )
         packets.append(pkt)
+    return packets
+
+
+@profile
+def parse_packets_pandas(lines: Sequence[str]) -> List[LoRaPacket]:
+    """Parse packets using pandas for better throughput on large inputs."""
+    if not lines:
+        return []
+
+    import pandas as pd  # local import to avoid optional dependency
+
+    def _to_float(val: str | None) -> float | None:
+        try:
+            return float(val) if val is not None else None
+        except ValueError:
+            return None
+
+    df = pd.DataFrame([dict(PACKET_RE.findall(line)) for line in lines])
+    packets: List[LoRaPacket] = []
+    for raw, row in zip(lines, df.to_dict(orient="records")):
+        packets.append(
+            LoRaPacket(
+                timestamp=row.get("time"),
+                freq=_to_float(row.get("freq")),
+                rssi=_to_float(row.get("rssi")),
+                snr=_to_float(row.get("snr")),
+                devaddr=row.get("devaddr"),
+                raw=raw,
+            )
+        )
     return packets
 
 
@@ -93,6 +132,7 @@ def plot_signal_trend(packets: Sequence[LoRaPacket], path: str) -> None:
 
     try:
         import matplotlib
+
         matplotlib.use("Agg")
         import matplotlib.pyplot as plt
     except Exception:  # pragma: no cover - optional dependency

--- a/tests/test_lora_scanner.py
+++ b/tests/test_lora_scanner.py
@@ -1,9 +1,8 @@
-import os
-import sys
 import asyncio
+import sys
 from types import ModuleType
-import pytest
 
+import pytest
 
 from piwardrive import lora_scanner
 
@@ -14,10 +13,24 @@ def test_parse_packets():
         "time=2024-01-01T00:00:01Z freq=868.1 rssi=-118 snr=6.8 devaddr=ABC",
     ]
     packets = lora_scanner.parse_packets(lines)
-    assert len(packets) == 2
-    assert packets[0].freq == 868.1
-    assert packets[0].rssi == -120
-    assert packets[0].devaddr == "ABC"
+    assert len(packets) == 2  # nosec B101
+    assert packets[0].freq == 868.1  # nosec B101
+    assert packets[0].rssi == -120  # nosec B101
+    assert packets[0].devaddr == "ABC"  # nosec B101
+
+
+def test_parse_packets_pandas():
+    lines = [
+        "time=2024-01-01T00:00:00Z freq=868.1 rssi=-120 snr=7.5 devaddr=ABC",
+        "time=2024-01-01T00:00:01Z freq=868.1 rssi=-118 snr=6.8 devaddr=ABC",
+    ]
+    import importlib
+
+    if importlib.util.find_spec("pandas") is None:
+        pytest.skip("pandas not installed")
+
+    packets = lora_scanner.parse_packets_pandas(lines)
+    assert [p.raw for p in packets] == lines  # nosec B101
 
 
 def test_plot_signal_trend(tmp_path, monkeypatch):
@@ -42,7 +55,7 @@ def test_plot_signal_trend(tmp_path, monkeypatch):
     monkeypatch.setitem(sys.modules, "matplotlib.pyplot", pyplot)
 
     lora_scanner.plot_signal_trend(packets, str(path))
-    assert path.is_file()
+    assert path.is_file()  # nosec B101
 
 
 def test_async_scan_lora(monkeypatch):
@@ -55,7 +68,7 @@ def test_async_scan_lora(monkeypatch):
 
     monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
     lines = asyncio.run(lora_scanner.async_scan_lora("l0"))
-    assert lines == ["a", "b"]
+    assert lines == ["a", "b"]  # nosec B101
 
 
 def test_async_parse_packets():
@@ -64,7 +77,7 @@ def test_async_parse_packets():
         "time=2024-01-01T00:00:01Z freq=868.1 rssi=-118 snr=6.8 devaddr=ABC",
     ]
     packets = asyncio.run(lora_scanner.async_parse_packets(lines))
-    assert len(packets) == 2
+    assert len(packets) == 2  # nosec B101
 
 
 def test_main(capsys, monkeypatch):
@@ -76,5 +89,4 @@ def test_main(capsys, monkeypatch):
     finally:
         sys.argv = argv
     out = capsys.readouterr().out
-    assert "x" in out
-
+    assert "x" in out  # nosec B101


### PR DESCRIPTION
## Summary
- add optional line_profiler hook and use it with parse_packets
- implement pandas-based `parse_packets_pandas`
- benchmark both parsers using cProfile
- mark Bandit noise as nosec and improve tests

## Testing
- `pre-commit run --files src/piwardrive/lora_scanner.py tests/test_lora_scanner.py benchmarks/packet_parse_benchmark.py`
- `pytest -q tests/test_lora_scanner.py`

------
https://chatgpt.com/codex/tasks/task_e_685dea68d9ac833397443f06e828a308