### PR TITLE
Stream query results to DB

### DIFF
--- a/src/piwardrive/map/vector_tiles.py
+++ b/src/piwardrive/map/vector_tiles.py
@@ -40,4 +40,4 @@ def available_tiles(path: str) -> Iterable[Tuple[int, int, int]]:
     """Yield ``(z, x, y)`` for tiles stored in ``path``."""
     with sqlite3.connect(path) as db:
         cur = db.execute("SELECT zoom_level, tile_column, tile_row FROM tiles")
-        yield from cur.fetchall()
+        yield from cur

--- a/src/piwardrive/sync.py
+++ b/src/piwardrive/sync.py
@@ -1,10 +1,11 @@
 """Module sync."""
+
 from __future__ import annotations
 
 import asyncio
 import json
 import logging
-from typing import Sequence, Any
+from typing import Any, Sequence
 
 import aiohttp
 
@@ -23,7 +24,7 @@ async def upload_data(records: Sequence[dict[str, Any]]) -> bool:
     if cfg.remote_sync_token:
         headers["Authorization"] = f"Bearer {cfg.remote_sync_token}"
 
-    payload = json.dumps(list(records))
+    payload = json.dumps(records)
     for attempt in range(1, cfg.remote_sync_retries + 1):
         try:
             async with aiohttp.ClientSession(timeout=timeout) as session:

--- a/src/remote_sync/__init__.py
+++ b/src/remote_sync/__init__.py
@@ -3,14 +3,13 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import os
-
-import aiohttp
 import sqlite3
 import tempfile
-import json
 
+import aiohttp
 
 logger = logging.getLogger(__name__)
 
@@ -42,21 +41,22 @@ def _make_range_db(src: str, start: int, end: int) -> str:
             )"""
         )
 
-        rows = src_db.execute(
+        cur = src_db.execute(
             "SELECT timestamp, cpu_temp, cpu_percent, memory_percent, disk_percent"
             " FROM health_records WHERE rowid BETWEEN ? AND ?",
             (start, end),
-        ).fetchall()
+        )
         dst_db.executemany(
-            "INSERT INTO health_records VALUES (?, ?, ?, ?, ?)", rows
+            "INSERT INTO health_records VALUES (?, ?, ?, ?, ?)",
+            cur,
         )
 
-        rows = src_db.execute(
+        cur = src_db.execute(
             "SELECT bssid, ssid, encryption, lat, lon, last_time FROM ap_cache "
             "WHERE rowid BETWEEN ? AND ?",
             (start, end),
-        ).fetchall()
-        dst_db.executemany("INSERT INTO ap_cache VALUES (?, ?, ?, ?, ?, ?)", rows)
+        )
+        dst_db.executemany("INSERT INTO ap_cache VALUES (?, ?, ?, ?, ?, ?)", cur)
         dst_db.commit()
 
     return dest


### PR DESCRIPTION
## Summary
- stream range db copies instead of building lists
- iterate MBTiles query directly
- stream export helpers instead of materializing lists
- simplify sync payload construction

## Testing
- `black src/remote_sync/__init__.py src/piwardrive/map/vector_tiles.py src/piwardrive/export.py src/piwardrive/sync.py`
- `isort src/remote_sync/__init__.py src/piwardrive/map/vector_tiles.py src/piwardrive/export.py src/piwardrive/sync.py`
- `flake8 src/remote_sync/__init__.py src/piwardrive/map/vector_tiles.py src/piwardrive/export.py src/piwardrive/sync.py`
- `mypy src/remote_sync/__init__.py src/piwardrive/map/vector_tiles.py src/piwardrive/export.py src/piwardrive/sync.py`
- `pytest tests/test_export.py tests/test_remote_sync.py tests/test_vector_tiles_module.py tests/test_sync.py -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_685dea7662488333915080287fa6b7bc