### PR TITLE
Add SIGINT workflow documentation

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -27,6 +27,7 @@ PiWardrive's primary interface is a React-based web dashboard served by
    geofencing
    status_service
    remote_sync
+   sigint_workflow
    aggregation_service
    architecture
    function_flows

--- a/docs/sigint_workflow.rst
+++ b/docs/sigint_workflow.rst
@@ -1,0 +1,30 @@
+SIGINT Workflow
+---------------
+.. note::
+   Please read the legal notice in the project `README.md` before using PiWardrive.
+
+The command-line tools packaged with :mod:`sigint_suite` allow quick collection
+of wireless metadata. Results can be post-processed by plugins and hooks before
+they are written to JSON files or saved in a SQLite database. The database can
+then be uploaded to a remote host or consumed by the aggregation service.
+
+.. mermaid::
+
+   flowchart TD
+       subgraph CLI Tools
+           A[wifi-scan]
+           B[bluetooth-scan]
+           C[imsi-scan]
+           D[band-scan]
+           E[scan-all]
+       end
+       CLI Tools --> F[Scanner modules]
+       F --> G{Plugins / hooks?}
+       G -->|yes| H[Custom logic]
+       G -->|no| I[Records]
+       H --> I
+       I --> J{Export}
+       J --> K[JSON/CSV/YAML]
+       J --> L[SQLite DB]
+       L --> M[remote_sync.sync_database_to_server]
+       M --> N[Aggregation service]


### PR DESCRIPTION
## Summary
- add docs page showing SIGINT command flow
- link new page from documentation index

## Testing
- `pytest -q` *(fails: 33 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_685e00587a5c8333b8643edda245b93a