### PR TITLE
Add SIGINT scan flow diagram

### DIFF
--- a/docs/function_flows.rst
+++ b/docs/function_flows.rst
@@ -39,3 +39,20 @@ utils.run_async_task
        run_async_task->>Future: add_done_callback()
        run_async_task-->>Caller: return Future
 
+Scheduled SIGINT scans
+----------------------
+
+Like ``PollScheduler.register_widget`` above, scheduled tasks invoke the
+SIGINT suite scanners and persist their results.
+
+.. mermaid::
+
+   sequenceDiagram
+       participant Scheduler
+       participant Scanners
+       participant Persistence
+
+       Scheduler->>Scanners: scan_wifi(), scan_bluetooth(), ...
+       Scanners-->>Scheduler: results
+       Scheduler->>Persistence: save results
+


### PR DESCRIPTION
## Summary
- document scheduled SIGINT scan flow

## Testing
- `pytest -q` *(fails: 33 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_685e005e62748333a5b181d50ed3463c