### PR TITLE
Fix Bandit issues

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,7 @@ vispy==0.15.2
 cryptography==45.0.4
 pyshp==2.3.1
 fastapi==0.115.12
+defusedxml==0.7.1
 uvicorn[standard]==0.34.3
 httpx==0.28.1
 aiohttp==3.12.13

--- a/src/piwardrive/core/utils.py
+++ b/src/piwardrive/core/utils.py
@@ -103,7 +103,9 @@ else:  # pragma: no cover - fallback without requests_cache
 
     class _DummySession:
         def get(self, *args: Any, **kwargs: Any) -> Any:
-            return requests.get(*args, **kwargs)
+            """Fallback ``requests.get`` with a default timeout."""
+            timeout = kwargs.pop("timeout", 5)
+            return requests.get(*args, timeout=timeout, **kwargs)
 
     HTTP_SESSION = _DummySession()
 
@@ -1060,7 +1062,7 @@ def _parse_coord_text(text: str) -> list[tuple[float, float]]:
 
 def load_kml(path: str) -> list[dict[str, Any]]:
     """Parse a ``.kml`` or ``.kmz`` file and return a list of features."""
-    import xml.etree.ElementTree as ET
+    from defusedxml import ElementTree as ET
     import zipfile
 
     def _parse(root: ET.Element) -> list[dict[str, Any]]:

--- a/src/piwardrive/db_browser.py
+++ b/src/piwardrive/db_browser.py
@@ -16,7 +16,8 @@ class _DBHandler(http.server.BaseHTTPRequestHandler):
         cur = conn.execute("SELECT name FROM sqlite_master WHERE type='table'")
         tables = [r[0] for r in cur.fetchall()]
         data = {
-            t: conn.execute(f"SELECT * FROM {t} LIMIT 100").fetchall()
+            # The table names come from sqlite_master and are not user supplied
+            t: conn.execute(f"SELECT * FROM {t} LIMIT 100").fetchall()  # nosec B608
             for t in tables
         }
 
@@ -27,8 +28,8 @@ class _DBHandler(http.server.BaseHTTPRequestHandler):
         conn.close()
 
 
-def launch_browser(db_path: str, port: int = 8080) -> None:
+def launch_browser(db_path: str, port: int = 8080, host: str = "127.0.0.1") -> None:
     """Start a simple HTTP server exposing the contents of ``db_path``."""
     handler = type("Handler", (_DBHandler,), {"db_path": Path(db_path)})
-    server = http.server.HTTPServer(("0.0.0.0", port), handler)
+    server = http.server.HTTPServer((host, port), handler)
     server.serve_forever()

--- a/src/piwardrive/service.py
+++ b/src/piwardrive/service.py
@@ -746,7 +746,7 @@ async def main() -> None:
 
     import uvicorn
 
-    config = uvicorn.Config(app, host="0.0.0.0", port=8000)
+    config = uvicorn.Config(app, host="127.0.0.1", port=8000)
     server = uvicorn.Server(config)
     await server.serve()
 

--- a/src/piwardrive/web/webui_server.py
+++ b/src/piwardrive/web/webui_server.py
@@ -33,7 +33,7 @@ def create_app() -> FastAPI:
 def main() -> None:
     import uvicorn
 
-    uvicorn.run(create_app(), host="0.0.0.0", port=8000)
+    uvicorn.run(create_app(), host="127.0.0.1", port=8000)
 
 
 if __name__ == "__main__":  # pragma: no cover - manual execution

--- a/src/piwardrive/web_server.py
+++ b/src/piwardrive/web_server.py
@@ -34,7 +34,7 @@ def create_app() -> FastAPI:
 
 
 def main() -> None:
-    uvicorn.run(create_app(), host="0.0.0.0", port=8000)
+    uvicorn.run(create_app(), host="127.0.0.1", port=8000)
 
 
 if __name__ == "__main__":  # pragma: no cover - manual execution

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -56,7 +56,7 @@ def test_save_and_load_roundtrip(tmp_path: Path) -> None:
     orig.map_poll_bt = 30
     orig.map_show_bt = True
     orig.ui_font_size = 18
-    orig.offline_tile_path = "/tmp/off.mbtiles"
+    orig.offline_tile_path = str(tmp_path / "off.mbtiles")
     orig.disable_scanning = True
     orig.map_auto_prefetch = True
     orig.map_cluster_capacity = 12
@@ -70,7 +70,7 @@ def test_save_and_load_roundtrip(tmp_path: Path) -> None:
     assert loaded.map_poll_gps_max == 20
     assert loaded.map_poll_bt == 30
     assert loaded.map_show_bt is True
-    assert loaded.offline_tile_path == "/tmp/off.mbtiles"
+    assert loaded.offline_tile_path == str(tmp_path / "off.mbtiles")
     assert loaded.disable_scanning is True
     assert loaded.map_auto_prefetch is True
     assert loaded.ui_font_size == 18

--- a/tests/test_control_service.py
+++ b/tests/test_control_service.py
@@ -25,7 +25,7 @@ def _load_control_service() -> Callable[[Any, str, str], Any]:
     assert func_node is not None
     mod = ast.Module(body=[func_node], type_ignores=[])
     namespace = {'subprocess': subprocess, 'utils': utils}
-    exec(compile(mod, '<control_service>', 'exec'), namespace)
+    exec(compile(mod, '<control_service>', 'exec'), namespace)  # nosec B102
     return cast(Callable[[Any, str, str], Any], namespace['control_service'])
 
 

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -5,6 +5,7 @@ from dataclasses import asdict
 from types import ModuleType, SimpleNamespace
 from typing import Any
 from unittest import mock
+import tempfile
 
 import pytest
 from fastapi import WebSocketDisconnect
@@ -710,8 +711,8 @@ def test_db_stats_endpoint(monkeypatch) -> None:
     with (
         mock.patch("service.get_table_counts", fake_counts),
         mock.patch("piwardrive.service.get_table_counts", fake_counts),
-        mock.patch("service._db_path", lambda: "/tmp/db"),
-        mock.patch("piwardrive.service._db_path", lambda: "/tmp/db"),
+        mock.patch("service._db_path", lambda: tempfile.gettempdir()),
+        mock.patch("piwardrive.service._db_path", lambda: tempfile.gettempdir()),
         mock.patch("service.os.path.getsize", return_value=2048),
         mock.patch("piwardrive.service.os.path.getsize", return_value=2048),
     ):

--- a/tests/test_web_api.py
+++ b/tests/test_web_api.py
@@ -28,7 +28,7 @@ def start_server(tmp_path):
 
 def request_json(port, path, method='GET'):
     req = urllib.request.Request(f'http://127.0.0.1:{port}{path}', method=method)
-    with urllib.request.urlopen(req) as resp:
+    with urllib.request.urlopen(req) as resp:  # nosec B310
         return json.loads(resp.read())
 
 


### PR DESCRIPTION
## Summary
- patch dummy HTTP session to set a default timeout
- parse KML files with defusedxml
- silence bandit false positives in db browser and tests
- restrict web servers to localhost
- fix temp file paths in tests
- add defusedxml dependency

## Testing
- `bandit -r . -ll`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685e0100c4648333b4e9a3e229f61ad0