### PR TITLE
Add async caching for service fetches

### DIFF
--- a/src/piwardrive/integrations/wigle.py
+++ b/src/piwardrive/integrations/wigle.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from typing import Any, Dict, List
 from types import SimpleNamespace
 
+from piwardrive.core.utils import async_ttl_cache, WIGLE_CACHE_SECONDS
+
 try:  # pragma: no cover - optional dependency
     import aiohttp
 except Exception:  # pragma: no cover - aiohttp not installed
@@ -15,6 +17,7 @@ except Exception:  # pragma: no cover - aiohttp not installed
     )
 
 
+@async_ttl_cache(lambda: WIGLE_CACHE_SECONDS)
 async def fetch_wigle_networks(
     api_name: str,
     api_key: str,

--- a/tests/test_wigle_integration.py
+++ b/tests/test_wigle_integration.py
@@ -56,3 +56,27 @@ def test_fetch_wigle_networks(monkeypatch, add_dummy_module):
     assert nets == [
         {"bssid": "AA:BB:CC", "ssid": "Net", "encryption": "WPA2", "lat": 1.0, "lon": 2.0}
     ]
+
+
+def test_fetch_wigle_networks_cache(monkeypatch, add_dummy_module):
+    add_dummy_module("persistence")
+    add_dummy_module("utils")
+    calls: list[int] = []
+    data = {"results": []}
+
+    class Session(FakeSession):
+        def get(self, *_a, **_k):
+            calls.append(1)
+            return super().get(*_a, **_k)
+
+    monkeypatch.setattr(wi.aiohttp, "ClientSession", lambda *a, **k: Session(data))
+    times = [0.0, 1.0, 40.0]
+    import piwardrive.core.utils as cu
+
+    monkeypatch.setattr(cu.time, "time", lambda: times.pop(0))
+
+    asyncio.run(wi.fetch_wigle_networks("u", "k", 1.0, 2.0))
+    asyncio.run(wi.fetch_wigle_networks("u", "k", 1.0, 2.0))
+    assert len(calls) == 1
+    asyncio.run(wi.fetch_wigle_networks("u", "k", 1.0, 2.0))
+    assert len(calls) == 2


### PR DESCRIPTION
## Summary
- implement `async_ttl_cache` helper and use on service fetch helpers
- cache Kismet and WiGLE queries in memory
- cover new caches with tests

## Testing
- `pytest -q` *(fails: ImportError: No module named 'watchdog')*

------
https://chatgpt.com/codex/tasks/task_e_685e0191a86c8333960735c7ab647f3e