### PR TITLE
Fix AppConfig fields and add YAML roundtrip test

### DIFF
--- a/src/piwardrive/core/config.py
+++ b/src/piwardrive/core/config.py
@@ -431,6 +431,8 @@ class AppConfig:
     remote_sync_timeout: int = DEFAULTS["remote_sync_timeout"]
     remote_sync_retries: int = DEFAULTS["remote_sync_retries"]
     remote_sync_interval: int = DEFAULTS["remote_sync_interval"]
+    handshake_cache_seconds: float = DEFAULTS["handshake_cache_seconds"]
+    log_tail_cache_seconds: float = DEFAULTS["log_tail_cache_seconds"]
     wigle_api_name: str = DEFAULTS["wigle_api_name"]
     wigle_api_key: str = DEFAULTS["wigle_api_key"]
     gps_movement_threshold: float = DEFAULTS["gps_movement_threshold"]

--- a/tests/test_core_config_extra.py
+++ b/tests/test_core_config_extra.py
@@ -30,6 +30,15 @@ def test_export_invalid_extension(tmp_path):
         config.export_config(cfg, str(bad))
 
 
+def test_yaml_export_import(tmp_path):
+    cfg = config.Config(**config.DEFAULTS)
+    cfg.remote_sync_url = "http://localhost"
+    path = tmp_path / "cfg.yaml"
+    config.export_config(cfg, str(path))
+    loaded = config.import_config(str(path))
+    assert loaded.theme == cfg.theme
+
+
 def test_apply_env_overrides_invalid_theme(monkeypatch):
     base = {"theme": "Dark"}
     monkeypatch.setenv("PW_THEME", "Blueish")


### PR DESCRIPTION
## Summary
- include cache timeout settings when constructing `AppConfig`
- test YAML round trip in config extra tests

## Testing
- `pytest tests/test_core_config_extra.py -q`
- `pytest tests/test_config.py::test_env_override_integer -q`

------
https://chatgpt.com/codex/tasks/task_e_685e03d7cb4483339612559c44586aa1