### PR TITLE
Fix sensor utility type hints

### DIFF
--- a/src/piwardrive/gpsd_client.py
+++ b/src/piwardrive/gpsd_client.py
@@ -3,11 +3,14 @@
 import logging
 import os
 import threading
+from typing import Any, cast
 
+gpsd: Any
 try:
-    import gpsd
+    import gpsd as _gpsd
+    gpsd = _gpsd
 except Exception as exc:  # pragma: no cover - optional dependency
-    gpsd = None  # type: ignore
+    gpsd = None
     logging.getLogger(__name__).error("gpsd library not available: %s", exc)
 
 
@@ -34,7 +37,7 @@ class GPSDClient:
         if not self._connected:
             self._connect()
 
-    def _get_packet(self):
+    def _get_packet(self) -> Any | None:
         with self._lock:
             self._ensure_connection()
             if not self._connected or gpsd is None:
@@ -53,7 +56,7 @@ class GPSDClient:
             return None
         try:
             if hasattr(pkt, "position"):
-                return pkt.position()  # type: ignore[no-any-return]
+                return cast(tuple[float, float], pkt.position())
             lat = getattr(pkt, "lat", None)
             lon = getattr(pkt, "lon", None)
             if lat is not None and lon is not None:

--- a/src/piwardrive/gpsd_client_async.py
+++ b/src/piwardrive/gpsd_client_async.py
@@ -6,7 +6,8 @@ import asyncio
 import json
 import logging
 import os
-from typing import Any
+from types import TracebackType
+from typing import Any, Optional, Type
 
 
 class AsyncGPSDClient:
@@ -24,7 +25,12 @@ class AsyncGPSDClient:
         await self._ensure_connection()
         return self
 
-    async def __aexit__(self, exc_type, exc, tb) -> None:
+    async def __aexit__(
+        self,
+        exc_type: Type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
         await self.close()
 
     async def _connect(self) -> None:

--- a/src/piwardrive/orientation_sensors.py
+++ b/src/piwardrive/orientation_sensors.py
@@ -12,17 +12,21 @@ check for ``None`` to gracefully handle setups without these sensors.
 from __future__ import annotations
 
 import logging
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - type checking only
+    import dbus as dbus_type
+    from mpu6050 import mpu6050 as mpu6050_type
 
 try:  # pragma: no cover - optional DBus dependency
-    import dbus  # type: ignore
+    import dbus
 except Exception:  # pragma: no cover - missing dependency
-    dbus = None  # type: ignore
+    dbus = None
 
 try:  # pragma: no cover - optional hardware dependency
-    from mpu6050 import mpu6050  # type: ignore
+    from mpu6050 import mpu6050
 except Exception:  # pragma: no cover - missing dependency
-    mpu6050 = None  # type: ignore
+    mpu6050 = None
 
 logger = logging.getLogger(__name__)
 
@@ -112,7 +116,7 @@ def read_mpu6050(address: int = 0x68) -> Optional[Dict[str, Any]]:
     if mpu6050 is None:
         return None
     try:
-        sensor = mpu6050(address)  # type: ignore
+        sensor = mpu6050(address)
         return {
             "accelerometer": sensor.get_accel_data(),
             "gyroscope": sensor.get_gyro_data(),

--- a/src/piwardrive/vehicle_sensors.py
+++ b/src/piwardrive/vehicle_sensors.py
@@ -10,7 +10,7 @@ logger = logging.getLogger(__name__)
 try:
     import obd  # pragma: no cover - optional
 except Exception:  # pragma: no cover - library not available
-    obd = None  # type: ignore
+    obd = None
 
 
 def read_speed_obd(port: Optional[str] = None) -> float | None:
@@ -18,7 +18,7 @@ def read_speed_obd(port: Optional[str] = None) -> float | None:
     if obd is None:
         return None
     try:
-        conn = obd.OBD(port)  # type: ignore
+        conn = obd.OBD(port)
         rsp = conn.query(obd.commands.SPEED)
         return float(rsp.value.to("km/h")) if rsp.value is not None else None
     except Exception as exc:  # pragma: no cover - runtime errors
@@ -31,7 +31,7 @@ def read_rpm_obd(port: Optional[str] = None) -> float | None:
     if obd is None:
         return None
     try:
-        conn = obd.OBD(port)  # type: ignore
+        conn = obd.OBD(port)
         rsp = conn.query(obd.commands.RPM)
         return float(rsp.value.to("rpm")) if rsp.value is not None else None
     except Exception as exc:  # pragma: no cover - runtime errors
@@ -44,7 +44,7 @@ def read_engine_load_obd(port: Optional[str] = None) -> float | None:
     if obd is None:
         return None
     try:
-        conn = obd.OBD(port)  # type: ignore
+        conn = obd.OBD(port)
         rsp = conn.query(obd.commands.ENGINE_LOAD)
         return float(rsp.value.to("percent")) if rsp.value is not None else None
     except Exception as exc:  # pragma: no cover - runtime errors


### PR DESCRIPTION
## Summary
- cleanup unused type ignores
- add annotations for optional deps and async exit
- cast GPSD position call and annotate packet return

## Testing
- `flake8 src/piwardrive/orientation_sensors.py src/piwardrive/vehicle_sensors.py src/piwardrive/gpsd_client.py src/piwardrive/gpsd_client_async.py`
- `mypy src/piwardrive/orientation_sensors.py src/piwardrive/vehicle_sensors.py src/piwardrive/gpsd_client.py src/piwardrive/gpsd_client_async.py`
- `pytest -q` *(fails: missing optional test dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685e042364748333a32602c629c03494