### PR TITLE
Fix SIGINT suite mypy strict errors

### DIFF
--- a/src/piwardrive/integrations/sigint_suite/bluetooth/scanner.py
+++ b/src/piwardrive/integrations/sigint_suite/bluetooth/scanner.py
@@ -11,7 +11,7 @@ from piwardrive.sigint_suite.models import BluetoothDevice
 logger = logging.getLogger(__name__)
 
 _proc: asyncio.subprocess.Process | None = None
-_reader_task: asyncio.Task | None = None
+_reader_task: asyncio.Task[None] | None = None
 _devices: Dict[str, str] = {}
 
 
@@ -96,7 +96,7 @@ async def async_scan_bluetooth(timeout: int = 10) -> List[BluetoothDevice]:
         else int(os.getenv("BLUETOOTH_SCAN_TIMEOUT", "10"))
     )
     try:
-        from bleak import BleakScanner  # type: ignore
+        from bleak import BleakScanner
 
         found = await BleakScanner.discover(timeout=timeout)
         return [

--- a/src/piwardrive/integrations/sigint_suite/cellular/band_scanner/scanner.py
+++ b/src/piwardrive/integrations/sigint_suite/cellular/band_scanner/scanner.py
@@ -4,7 +4,7 @@ import logging
 import os
 import shlex
 import subprocess
-from typing import List, Optional
+from typing import List, Optional, cast
 
 from piwardrive.sigint_suite.cellular.parsers import parse_band_output
 from piwardrive.sigint_suite.models import BandRecord
@@ -23,7 +23,7 @@ def scan_bands(
     variable to override the executable. The timeout defaults to the
     ``BAND_SCAN_TIMEOUT`` environment variable (``10`` seconds).
     """
-    cmd_str = cmd or os.getenv("BAND_SCAN_CMD", "celltrack")
+    cmd_str = str(cmd or os.getenv("BAND_SCAN_CMD", "celltrack"))
     args = shlex.split(cmd_str)
     timeout = (
         timeout if timeout is not None else int(os.getenv("BAND_SCAN_TIMEOUT", "10"))
@@ -37,7 +37,7 @@ def scan_bands(
 
         return []
 
-    return parse_band_output(output)
+    return cast(List[BandRecord], parse_band_output(output))
 
 
 async def async_scan_bands(
@@ -45,7 +45,7 @@ async def async_scan_bands(
     timeout: int | None = None,
 ) -> List[BandRecord]:
     """Asynchronously scan for cellular bands using ``celltrack``."""
-    cmd_str = cmd or os.getenv("BAND_SCAN_CMD", "celltrack")
+    cmd_str = str(cmd or os.getenv("BAND_SCAN_CMD", "celltrack"))
     args = shlex.split(cmd_str)
     timeout = (
         timeout if timeout is not None else int(os.getenv("BAND_SCAN_TIMEOUT", "10"))
@@ -63,7 +63,7 @@ async def async_scan_bands(
         logger.exception("Band scan failed: %s", exc)
         return []
 
-    return parse_band_output(output)
+    return cast(List[BandRecord], parse_band_output(output))
 
 
 def main() -> None:

--- a/src/piwardrive/integrations/sigint_suite/cellular/tower_tracker/tracker.py
+++ b/src/piwardrive/integrations/sigint_suite/cellular/tower_tracker/tracker.py
@@ -1,6 +1,7 @@
 """Module tracker."""
 import time
 from typing import Dict, List, Optional
+from types import TracebackType
 
 import aiosqlite
 
@@ -17,7 +18,12 @@ class TowerTracker:
         await self._get_conn()
         return self
 
-    async def __aexit__(self, exc_type, exc, tb) -> None:
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
         """Close the underlying database connection."""
         await self.close()
 

--- a/src/piwardrive/integrations/sigint_suite/continuous_scan.py
+++ b/src/piwardrive/integrations/sigint_suite/continuous_scan.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
 import time
-from typing import Callable, Dict, List
+from typing import Any, Callable, Dict, List
 
 from .bluetooth import scan_bluetooth
 from .wifi import scan_wifi
 
-Result = Dict[str, List]
+Result = Dict[str, List[Any]]
 
 
 def scan_once() -> Result:

--- a/src/piwardrive/integrations/sigint_suite/rf/demod.py
+++ b/src/piwardrive/integrations/sigint_suite/rf/demod.py
@@ -1,13 +1,13 @@
 """Simple FM demodulation helpers using an RTL-SDR."""
 
-from typing import List
+from typing import List, cast
 
 import numpy as np
 
 try:
     from rtlsdr import RtlSdr
 except Exception:  # pragma: no cover - import failure handled at runtime
-    RtlSdr = None  # type: ignore
+    RtlSdr = None
 
 
 def fm_demodulate(samples: np.ndarray) -> np.ndarray:
@@ -37,4 +37,4 @@ def demodulate_fm(
     audio = fm_demodulate(samples)
     decim = max(int(sample_rate / audio_rate), 1)
     audio = audio[::decim]
-    return audio.tolist()
+    return cast(List[float], audio.tolist())

--- a/src/piwardrive/integrations/sigint_suite/rf/spectrum.py
+++ b/src/piwardrive/integrations/sigint_suite/rf/spectrum.py
@@ -1,13 +1,13 @@
 """Spectrum scanning utilities using an RTL-SDR."""
 
-from typing import List, Tuple
+from typing import List, Tuple, cast
 
 import numpy as np
 
 try:
     from rtlsdr import RtlSdr
 except Exception:  # pragma: no cover - import failure handled at runtime
-    RtlSdr = None  # type: ignore
+    RtlSdr = None
 
 
 def spectrum_scan(
@@ -32,4 +32,4 @@ def spectrum_scan(
     freqs = (
         np.fft.fftshift(np.fft.fftfreq(len(samples), 1.0 / sample_rate)) + center_freq
     )
-    return freqs.tolist(), power.tolist()
+    return cast(List[float], freqs.tolist()), cast(List[float], power.tolist())

--- a/src/piwardrive/integrations/sigint_suite/wifi/scanner.py
+++ b/src/piwardrive/integrations/sigint_suite/wifi/scanner.py
@@ -141,7 +141,7 @@ async def async_scan_wifi(
     timeout: int | None = None,
 ) -> List[WifiNetwork]:
     """Asynchronously scan for Wi-Fi networks using ``iwlist``."""
-    iwlist_cmd = iwlist_cmd or os.getenv("IWLIST_CMD", "iwlist")
+    iwlist_cmd = str(iwlist_cmd or os.getenv("IWLIST_CMD", "iwlist"))
     priv_cmd = priv_cmd if priv_cmd is not None else os.getenv("IW_PRIV_CMD", "sudo")
 
     cmd: List[str] = []


### PR DESCRIPTION
## Summary
- fix FM demod cast
- cast spectrum output
- clean bluetooth scanner typing
- harden wifi scanner arg typing
- return typed lists from band/imsi scanners
- type __aexit__ in tower tracker
- annotate continuous scan result

## Testing
- `mypy --strict --follow-imports=skip src/piwardrive/integrations/sigint_suite/rf/demod.py`
- `mypy --strict --follow-imports=skip src/piwardrive/integrations/sigint_suite/rf/spectrum.py`
- `mypy --strict --follow-imports=skip src/piwardrive/integrations/sigint_suite/bluetooth/scanner.py`
- `mypy --strict --follow-imports=skip src/piwardrive/integrations/sigint_suite/wifi/scanner.py`
- `mypy --strict --follow-imports=skip src/piwardrive/integrations/sigint_suite/cellular/band_scanner/scanner.py`
- `mypy --strict --follow-imports=skip src/piwardrive/integrations/sigint_suite/cellular/imsi_catcher/scanner.py`
- `mypy --strict --follow-imports=skip src/piwardrive/integrations/sigint_suite/cellular/tower_tracker/tracker.py`
- `mypy --strict --follow-imports=skip src/piwardrive/integrations/sigint_suite/continuous_scan.py`
- `flake8 src/piwardrive/integrations/sigint_suite/...`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_685e043b2f78833380b66c30cd2e6ee1