### PR TITLE
Add generics and typing updates

### DIFF
--- a/src/piwardrive/scheduler.py
+++ b/src/piwardrive/scheduler.py
@@ -20,7 +20,10 @@ class PollScheduler:
         self._durations: Dict[str, float] = {}
 
     def schedule(
-        self, name: str, callback: Callable[[float], Any], interval: float
+        self,
+        name: str,
+        callback: Callable[[float], Awaitable[Any] | Any],
+        interval: float,
     ) -> None:
         """Register ``callback`` to run every ``interval`` seconds."""
         self.cancel(name)


### PR DESCRIPTION
## Summary
- add missing generics and return types across diagnostics and scheduler
- type FastAPI handlers in the aggregation service

## Testing
- `mypy src/piwardrive/diagnostics.py src/piwardrive/scheduler.py src/piwardrive/aggregation_service.py`
- `flake8 src/piwardrive/aggregation_service.py src/piwardrive/diagnostics.py src/piwardrive/scheduler.py`
- `bandit -q -r src/piwardrive/aggregation_service.py src/piwardrive/diagnostics.py src/piwardrive/scheduler.py`
- `black src/piwardrive/aggregation_service.py src/piwardrive/scheduler.py --check`
- `isort src/piwardrive/aggregation_service.py src/piwardrive/scheduler.py --check`
- `black src/piwardrive/diagnostics.py --check`
- `isort src/piwardrive/diagnostics.py --check`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_685e04289e7483339c0a30cfc4d578de