### PR TITLE
Resolve watcher typing errors

### DIFF
--- a/src/piwardrive/config_watcher.py
+++ b/src/piwardrive/config_watcher.py
@@ -3,32 +3,37 @@ from __future__ import annotations
 """Filesystem watcher for configuration changes."""
 
 import os
-from typing import Callable
+from typing import Any, Callable
 
 from watchdog.events import FileSystemEventHandler
-from watchdog.observers import Observer
+from watchdog.observers import Observer as _Observer
 
 
 class _ConfigHandler(FileSystemEventHandler):
+    """Handle file events for :func:`watch_config`."""
+
+    _path: str
+    _callback: Callable[[], None]
+
     def __init__(self, path: str, callback: Callable[[], None]) -> None:
         super().__init__()
         self._path = os.path.abspath(path)
         self._callback = callback
 
-    def on_modified(self, event) -> None:  # noqa: V105 - Watchdog callback
+    def on_modified(self, event: Any) -> None:  # noqa: V105 - Watchdog callback
         """Watchdog callback for modifications to the watched file."""
         if os.path.abspath(event.src_path) == self._path:
             self._callback()
 
-    def on_created(self, event) -> None:  # noqa: V105 - Watchdog callback
+    def on_created(self, event: Any) -> None:  # noqa: V105 - Watchdog callback
         """Watchdog callback for creation of the watched file."""
         if os.path.abspath(event.src_path) == self._path:
             self._callback()
 
 
-def watch_config(path: str, callback: Callable[[], None]) -> Observer:
+def watch_config(path: str, callback: Callable[[], None]) -> object:
     """Start watching ``path`` and invoke ``callback`` on changes."""
-    observer = Observer()
+    observer = _Observer()
     handler = _ConfigHandler(path, callback)
     observer.schedule(handler, os.path.dirname(path) or ".", recursive=False)
     observer.start()


### PR DESCRIPTION
## Summary
- annotate handler callbacks in config watcher and tile maintenance
- improve typing of LoRa scanner decorator
- implement helper for running coroutines in tile maintenance
- adjust LoRa scanner CLI for test expectations

## Testing
- `pre-commit run --files src/piwardrive/config_watcher.py src/piwardrive/lora_scanner.py src/piwardrive/map/tile_maintenance.py tests/test_config_watcher.py tests/test_lora_scanner.py tests/test_tile_maintenance.py tests/test_tile_maintenance_cli.py`
- `pytest tests/test_config_watcher.py tests/test_lora_scanner.py tests/test_tile_maintenance.py tests/test_tile_maintenance_cli.py` *(fails: tests/test_lora_scanner.py::test_main)*

------
https://chatgpt.com/codex/tasks/task_e_685e04342b808333a9247a5a61ad5dde