### PR TITLE
Fix mypy issues across modules

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,6 +7,7 @@ repos:
     rev: v5.10.1
     hooks:
       - id: isort
+        args: ["--profile=black"]
   - repo: https://github.com/pycqa/flake8
     rev: 7.2.0
     hooks:

--- a/src/piwardrive/config_watcher.py
+++ b/src/piwardrive/config_watcher.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 """Filesystem watcher for configuration changes."""
 
 import os
-from typing import Callable
+from typing import Any, Callable
 
 from watchdog.events import FileSystemEventHandler
 from watchdog.observers import Observer
@@ -26,7 +26,7 @@ class _ConfigHandler(FileSystemEventHandler):
             self._callback()
 
 
-def watch_config(path: str, callback: Callable[[], None]) -> Observer:
+def watch_config(path: str, callback: Callable[[], None]) -> Any:
     """Start watching ``path`` and invoke ``callback`` on changes."""
     observer = Observer()
     handler = _ConfigHandler(path, callback)

--- a/src/piwardrive/exception_handler.py
+++ b/src/piwardrive/exception_handler.py
@@ -17,9 +17,9 @@ try:  # pragma: no cover - FastAPI is an optional dependency
     from fastapi import FastAPI, Request
     from fastapi.responses import JSONResponse
 except Exception:  # pragma: no cover - allow running without FastAPI
-    FastAPI = None  # type: ignore[assignment]
-    Request = None  # type: ignore[assignment]
-    JSONResponse = None  # type: ignore[assignment]
+    FastAPI = None  # type: ignore[misc, assignment]
+    Request = None  # type: ignore[misc, assignment]
+    JSONResponse = None  # type: ignore[misc, assignment]
 
 _installed = False
 

--- a/src/piwardrive/main.py
+++ b/src/piwardrive/main.py
@@ -1,4 +1,5 @@
 """Application entry point providing helpers used by scripts and tests."""
+
 from __future__ import annotations
 
 import asyncio
@@ -9,13 +10,17 @@ from dataclasses import asdict, fields
 from typing import Any, Callable
 
 from piwardrive import diagnostics, exception_handler, remote_sync, utils
-from piwardrive.config import (CONFIG_PATH, Config, config_mtime, load_config,
-                               save_config)
+from piwardrive.config import (
+    CONFIG_PATH,
+    Config,
+    config_mtime,
+    load_config,
+    save_config,
+)
 from piwardrive.config_watcher import watch_config
 from piwardrive.di import Container
 from piwardrive.logconfig import setup_logging
-from piwardrive.persistence import (AppState, _db_path, load_app_state,
-                                    save_app_state)
+from piwardrive.persistence import AppState, _db_path, load_app_state, save_app_state
 from piwardrive.scheduler import PollScheduler
 from piwardrive.security import hash_password
 
@@ -81,7 +86,7 @@ class PiWardriveApp:
             diagnostics.start_profiling()
         self._config_stamp = config_mtime()
         self._updating_config = False
-        self._config_observer = watch_config(
+        self._config_observer: Any = watch_config(
             CONFIG_PATH, lambda: self._reload_config_event(0)
         )
 
@@ -144,9 +149,7 @@ class PiWardriveApp:
             utils.report_error(f"Failed to export logs: {exc}")
             return ""
 
-    async def export_log_bundle(
-        self, path: str | None = None, lines: int = 200
-    ) -> str:
+    async def export_log_bundle(self, path: str | None = None, lines: int = 200) -> str:
         """Write the last ``lines`` from each configured log to ``path``."""
         import zipfile
 

--- a/src/piwardrive/service.py
+++ b/src/piwardrive/service.py
@@ -7,9 +7,6 @@ import logging
 import os
 import typing
 from dataclasses import asdict
-
-logger = logging.getLogger(__name__)
-
 from typing import TYPE_CHECKING
 
 try:  # pragma: no cover - optional FastAPI dependency
@@ -25,7 +22,7 @@ try:  # pragma: no cover - optional FastAPI dependency
     from fastapi.responses import Response, StreamingResponse  # noqa: E402
     from fastapi.security import HTTPBasic, HTTPBasicCredentials
 except Exception:
-    FastAPI = type(
+    FastAPI = type(  # type: ignore[misc, assignment]
         "FastAPI",
         (),
         {
@@ -34,20 +31,32 @@ except Exception:
             "delete": lambda *a, **k: (lambda f: f),
             "websocket": lambda *a, **k: (lambda f: f),
         },
-    )
+    )  # type: ignore[misc, assignment]
 
     def _noop(*_a, **_k) -> None:
         return None
 
-    Depends = _noop
-    HTTPException = type("HTTPException", (Exception,), {})
-    WebSocket = object
-    WebSocketDisconnect = Exception
-    Body = _noop
-    Request = object
-    StreamingResponse = Response = object
-    HTTPBasic = type("HTTPBasic", (), {"__init__": lambda self, **k: None})
-    HTTPBasicCredentials = type("HTTPBasicCredentials", (), {})
+    Depends = _noop  # type: ignore[misc, assignment]
+    HTTPException = type(  # type: ignore[misc]
+        "HTTPException",
+        (Exception,),
+        {},
+    )  # type: ignore[misc, assignment]
+    WebSocket = object  # type: ignore[misc, assignment]
+    WebSocketDisconnect = Exception  # type: ignore[misc, assignment]
+    Body = _noop  # type: ignore[misc, assignment]
+    Request = object  # type: ignore[misc, assignment]
+    StreamingResponse = Response = object  # type: ignore[misc, assignment]
+    HTTPBasic = type(  # type: ignore[misc]
+        "HTTPBasic",
+        (),
+        {"__init__": lambda self, **k: None},
+    )  # type: ignore[misc, assignment]
+    HTTPBasicCredentials = type(  # type: ignore[misc]
+        "HTTPBasicCredentials",
+        (),
+        {},
+    )  # type: ignore[misc, assignment]
 
 if TYPE_CHECKING:  # pragma: no cover - type hints only
     from fastapi import (
@@ -61,6 +70,7 @@ if TYPE_CHECKING:  # pragma: no cover - type hints only
     )
     from fastapi.responses import Response, StreamingResponse
     from fastapi.security import HTTPBasic, HTTPBasicCredentials
+
 import asyncio
 import importlib
 import json
@@ -68,15 +78,20 @@ import tempfile
 import time
 from collections.abc import Mapping, Sequence
 from pathlib import Path
-from typing import Any, Tuple, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Tuple
 
 from piwardrive.logconfig import DEFAULT_LOG_PATH
 
 try:  # allow tests to stub out ``persistence``
     from persistence import load_ap_cache  # type: ignore
-    from persistence import (DashboardSettings, _db_path, get_table_counts,
-                             load_dashboard_settings, load_recent_health,
-                             save_dashboard_settings)
+    from persistence import (
+        DashboardSettings,
+        _db_path,
+        get_table_counts,
+        load_dashboard_settings,
+        load_recent_health,
+        save_dashboard_settings,
+    )
 except Exception:  # pragma: no cover - fall back to real module
     from piwardrive.persistence import (
         load_recent_health,
@@ -137,8 +152,13 @@ get_network_throughput = getattr(
 get_gps_fix_quality = getattr(_utils, "get_gps_fix_quality", lambda *_a, **_k: None)
 get_gps_accuracy = getattr(_utils, "get_gps_accuracy", lambda *_a, **_k: None)
 
+
+async def _default_async_scan_lora(*_a: Any, **_k: Any) -> list[str]:
+    return []
+
+
 async_scan_lora: Callable[[str], Awaitable[list[str]]] = getattr(
-    _lora_scanner, "async_scan_lora", lambda *_a, **_k: []
+    _lora_scanner, "async_scan_lora", _default_async_scan_lora
 )
 
 
@@ -230,7 +250,7 @@ async def _collect_widget_metrics() -> dict:
             batt_percent = batt.percent
             batt_plugged = batt.power_plugged
     except Exception:  # pragma: no cover - optional dependency
-        pass
+        logging.debug("battery info unavailable", exc_info=True)
 
     return {
         "cpu_temp": get_cpu_temp(),
@@ -603,7 +623,7 @@ async def export_access_points(
 
         records.extend(load_sigint_data("wifi"))
     except Exception:
-        pass
+        logging.debug("sigint integration failed", exc_info=True)
     return await _export_layer(records, fmt.lower(), "aps")
 
 

--- a/src/piwardrive/widgets/signal_strength.py
+++ b/src/piwardrive/widgets/signal_strength.py
@@ -7,24 +7,21 @@ from piwardrive.localization import _
 from piwardrive.simpleui import Card as MDCard
 from piwardrive.simpleui import Label as MDLabel
 from piwardrive.simpleui import dp
-from piwardrive.utils import (fetch_kismet_devices_async, get_avg_rssi,
-                              run_async_task)
+from piwardrive.utils import fetch_kismet_devices_async, get_avg_rssi, run_async_task
 
 from .base import DashboardWidget
 
 
 class SignalStrengthWidget(DashboardWidget):
     """Display average RSSI from Kismet devices."""
-    
+
     update_interval = 5.0
 
     def __init__(self, **kwargs: Any) -> None:
         """Initialize label widget and queue the first RSSI poll."""
         super().__init__(**kwargs)
         self.card = MDCard(orientation="vertical", padding=dp(8), radius=[8])
-        self.label = MDLabel(
-            text=f"{_('rssi')}: {_('not_available')}", halign="center"
-        )
+        self.label = MDLabel(text=f"{_('rssi')}: {_('not_available')}", halign="center")
         self.card.add_widget(self.label)
         self.add_widget(self.card)
         self.update()

--- a/src/service.py
+++ b/src/service.py
@@ -12,17 +12,17 @@ from __future__ import annotations
 import importlib
 import os
 import sys
-from types import ModuleType
 
 SRC_PATH = os.path.join(os.path.dirname(__file__), "src")
 if SRC_PATH not in sys.path:
     sys.path.insert(0, SRC_PATH)
 
-from typing import Any, Callable  # noqa: E402
 from types import ModuleType  # noqa: E402
+from typing import Any, Callable  # noqa: E402
 
 from piwardrive import orientation_sensors  # noqa: F401,E402
 from piwardrive import service as _p  # noqa: E402
+
 # Re-export everything from the real module
 from piwardrive.service import *  # noqa: F401,F403,E402
 


### PR DESCRIPTION
## Summary
- fix type hints in config watcher, exception handler, and service modules
- clean up widget imports and service fallback handlers
- update pre-commit isort configuration for Black compatibility

## Testing
- `pre-commit run --files src/piwardrive/service.py src/piwardrive/widgets/signal_strength.py src/piwardrive/main.py src/service.py src/piwardrive/config_watcher.py src/piwardrive/exception_handler.py`
- `mypy src/piwardrive/logconfig.py src/piwardrive/analysis.py src/piwardrive/advanced_localization.py src/piwardrive/utils.py src/piwardrive/web/webui_server.py src/piwardrive/scripts/service_status.py src/piwardrive/widgets/health_analysis.py src/piwardrive/widgets/signal_strength.py src/piwardrive/main.py src/service.py src/piwardrive/config_watcher.py src/piwardrive/exception_handler.py src/piwardrive/service.py`

------
https://chatgpt.com/codex/tasks/task_e_685e044388cc833389867c6329db1615