### PR TITLE
Add robust_request and widget tests

### DIFF
--- a/tests/test_robust_request.py
+++ b/tests/test_robust_request.py
@@ -1,0 +1,45 @@
+import types
+from typing import Any
+
+import piwardrive.utils as utils
+
+
+def test_robust_request_retries(monkeypatch):
+    calls = []
+
+    def fake_get(url: str, *, timeout: int) -> str:
+        calls.append(url)
+        if len(calls) < 3:
+            raise Exception("boom")
+        return "ok"
+
+    def fake_retry(func: Any, *, attempts: int = 1, delay: float = 0) -> Any:
+        assert attempts == 3
+        result = None
+        for _ in range(attempts):
+            try:
+                result = func()
+                break
+            except Exception:
+                continue
+        return result
+
+    monkeypatch.setattr(utils, "retry_call", fake_retry, raising=False)
+    monkeypatch.setattr(utils.requests, "get", fake_get)
+    resp = utils.robust_request("http://example.com")
+    assert resp == "ok"
+    assert len(calls) == 3
+
+
+def test_orientation_widget_update(monkeypatch):
+    from piwardrive.widgets import orientation_widget as ow
+
+    widget = object.__new__(ow.OrientationWidget)
+    widget.label = ow.MDLabel()
+
+    monkeypatch.setattr(ow.orientation_sensors, "get_orientation_dbus", lambda: "right-up")
+    monkeypatch.setattr(ow.orientation_sensors, "orientation_to_angle", lambda _: 90.0)
+    ow.OrientationWidget.update(widget)
+
+    assert "right-up" in widget.label.text
+    assert "90" in widget.label.text


### PR DESCRIPTION
## Summary
- add regression tests for `utils.robust_request`
- test that `OrientationWidget.update` uses sensor output

## Testing
- `pytest -q tests/test_robust_request.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_685f580c322483338ae3d4ddbe5a4dc0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added tests to verify the retry logic for network requests.
  * Added tests to ensure correct display of orientation sensor data in the widget.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->