### PR TITLE
Add uvicorn startup test

### DIFF
--- a/tests/test_aggregation_service_main_new.py
+++ b/tests/test_aggregation_service_main_new.py
@@ -1,0 +1,11 @@
+import asyncio
+from unittest.mock import AsyncMock
+import importlib
+
+def test_main_starts_uvicorn(monkeypatch):
+    server_mock = AsyncMock()
+    monkeypatch.setattr("uvicorn.Config", lambda *a, **k: object())
+    monkeypatch.setattr("uvicorn.Server", lambda cfg: server_mock)
+    module = importlib.import_module("piwardrive.aggregation_service")
+    asyncio.run(module.main())
+    server_mock.serve.assert_awaited()


### PR DESCRIPTION
## Summary
- add pytest to confirm uvicorn Server serve coroutine is awaited

## Testing
- `pytest -q tests/test_aggregation_service_main_new.py`
- `pytest -q` *(fails: 17 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_685f57fcfc9c8333ac3b126acabdb6d3