### PR TITLE
Add invalid JSON config load test

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -105,6 +105,16 @@ def test_load_config_schema_violation(tmp_path: Path) -> None:
     assert asdict(data) == asdict(config.DEFAULT_CONFIG)
 
 
+def test_load_config_invalid_json_monkeypatch(monkeypatch: Any, tmp_path: Path) -> None:
+    cfg_file = tmp_path / "config.json"
+    cfg_file.write_text("{invalid}")
+    monkeypatch.setattr(config, "CONFIG_PATH", str(cfg_file))
+    import piwardrive.core.config as core
+    monkeypatch.setattr(core, "CONFIG_PATH", str(cfg_file))
+    data = config.load_config()
+    assert asdict(data) == asdict(config.DEFAULT_CONFIG)
+
+
 def test_save_config_validation_error(tmp_path: Path) -> None:
     setup_temp_config(tmp_path)
     cfg = config.Config(map_poll_gps=0)


### PR DESCRIPTION
## Summary
- add regression test to ensure load_config returns defaults when a bad JSON file is present

## Testing
- `pytest -q tests/test_config.py::test_load_config_invalid_json_monkeypatch`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'piwardrive.widgets.log_viewer' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_685f57f7a9a083338db4efdb1240e7f6