### PR TITLE
Add test for compute_health_stats empty input

### DIFF
--- a/tests/test_compute_health_stats_empty.py
+++ b/tests/test_compute_health_stats_empty.py
@@ -1,0 +1,20 @@
+import sys
+from types import ModuleType
+
+# Minimal stubs so imports in analysis succeed
+fake_aiosqlite = ModuleType("aiosqlite")
+fake_aiosqlite.Connection = object  # type: ignore[attr-defined]
+sys.modules.setdefault("aiosqlite", fake_aiosqlite)
+
+fake_pydantic = ModuleType("pydantic")
+fake_pydantic.BaseModel = object  # type: ignore[attr-defined]
+fake_pydantic.Field = lambda *a, **k: None  # type: ignore[attr-defined]
+fake_pydantic.ValidationError = type("VE", (), {})  # type: ignore[attr-defined]
+fake_pydantic.field_validator = lambda *a, **k: (lambda f: f)  # type: ignore[attr-defined]
+sys.modules.setdefault("pydantic", fake_pydantic)
+
+from piwardrive import analysis  # noqa: E402
+
+
+def test_compute_health_stats_empty() -> None:
+    assert analysis.compute_health_stats([]) == {}


### PR DESCRIPTION
## Summary
- verify that compute_health_stats handles an empty list

## Testing
- `pytest -q tests/test_compute_health_stats_empty.py`

------
https://chatgpt.com/codex/tasks/task_e_685f57dc34ec83339a0ced138cc3dae7