### PR TITLE
Persist OBD connection and close on shutdown

### DIFF
--- a/src/piwardrive/service.py
+++ b/src/piwardrive/service.py
@@ -808,6 +808,7 @@ async def main() -> None:
     config = uvicorn.Config(app, host="127.0.0.1", port=8000)
     server = uvicorn.Server(config)
     await server.serve()
+    vehicle_sensors.close_obd()
 
 
 if __name__ == "__main__":
@@ -816,4 +817,5 @@ if __name__ == "__main__":
     finally:
         from utils import shutdown_async_loop
 
+        vehicle_sensors.close_obd()
         shutdown_async_loop()

--- a/src/piwardrive/vehicle_sensors.py
+++ b/src/piwardrive/vehicle_sensors.py
@@ -13,12 +13,42 @@ except Exception:  # pragma: no cover - library not available
     obd = None
 
 
-def read_speed_obd(port: Optional[str] = None) -> float | None:
-    """Return vehicle speed in km/h using an OBD-II adapter."""
+_OBD_CONN: "obd.OBD | None" = None
+
+
+def _get_conn(port: Optional[str] = None) -> "obd.OBD | None":
+    """Return a cached OBD connection or attempt to create one."""
+    global _OBD_CONN
+
     if obd is None:
         return None
+
+    if _OBD_CONN is None or not getattr(_OBD_CONN, "is_connected", lambda: True)():
+        try:
+            _OBD_CONN = obd.OBD(port)
+        except Exception as exc:  # pragma: no cover - runtime errors
+            logger.error("Failed to connect to OBD: %s", exc)
+            _OBD_CONN = None
+    return _OBD_CONN if _OBD_CONN and getattr(_OBD_CONN, "is_connected", lambda: True)() else None
+
+
+def close_obd() -> None:
+    """Close the cached OBD connection if open."""
+    global _OBD_CONN
+
+    if _OBD_CONN is not None:
+        try:
+            _OBD_CONN.close()
+        except Exception as exc:  # pragma: no cover - runtime errors
+            logger.error("OBD close failed: %s", exc)
+        _OBD_CONN = None
+
+def read_speed_obd(port: Optional[str] = None) -> float | None:
+    """Return vehicle speed in km/h using an OBD-II adapter."""
+    conn = _get_conn(port)
+    if conn is None:
+        return None
     try:
-        conn = obd.OBD(port)
         rsp = conn.query(obd.commands.SPEED)
         return float(rsp.value.to("km/h")) if rsp.value is not None else None
     except Exception as exc:  # pragma: no cover - runtime errors
@@ -28,10 +58,10 @@ def read_speed_obd(port: Optional[str] = None) -> float | None:
 
 def read_rpm_obd(port: Optional[str] = None) -> float | None:
     """Return engine RPM using an OBD-II adapter."""
-    if obd is None:
+    conn = _get_conn(port)
+    if conn is None:
         return None
     try:
-        conn = obd.OBD(port)
         rsp = conn.query(obd.commands.RPM)
         return float(rsp.value.to("rpm")) if rsp.value is not None else None
     except Exception as exc:  # pragma: no cover - runtime errors
@@ -41,10 +71,10 @@ def read_rpm_obd(port: Optional[str] = None) -> float | None:
 
 def read_engine_load_obd(port: Optional[str] = None) -> float | None:
     """Return calculated engine load percentage via an OBD-II adapter."""
-    if obd is None:
+    conn = _get_conn(port)
+    if conn is None:
         return None
     try:
-        conn = obd.OBD(port)
         rsp = conn.query(obd.commands.ENGINE_LOAD)
         return float(rsp.value.to("percent")) if rsp.value is not None else None
     except Exception as exc:  # pragma: no cover - runtime errors


### PR DESCRIPTION
## Summary
- keep a persistent OBD connection in `vehicle_sensors`
- reuse the connection for speed/RPM/engine load sensors
- close OBD connection when the service exits

## Testing
- `pytest -q tests/test_vehicle_sensors.py`

------
https://chatgpt.com/codex/tasks/task_e_685f572710488333bcb4e8aac84edf5d