### PR TITLE
Fix flake8 errors

### DIFF
--- a/exception_handler.py
+++ b/exception_handler.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import sys
+import importlib
 
 SRC_PATH = os.path.join(os.path.dirname(__file__), "src")
 if SRC_PATH not in sys.path:

--- a/src/piwardrive/core/utils.py
+++ b/src/piwardrive/core/utils.py
@@ -14,8 +14,16 @@ import time
 from contextlib import asynccontextmanager
 from datetime import datetime
 from pathlib import Path
-from typing import (Any, Callable, Coroutine, Iterable, Sequence, TypedDict,
-                    TypeVar)
+from typing import (
+    Any,
+    Callable,
+    Coroutine,
+    Iterable,
+    Sequence,
+    TypedDict,
+    TypeVar,
+    Awaitable,
+)
 
 from piwardrive import config as pw_config
 from piwardrive.gpsd_client import client as gps_client

--- a/src/piwardrive/gpsd_client_async.py
+++ b/src/piwardrive/gpsd_client_async.py
@@ -7,7 +7,7 @@ import json
 import logging
 import os
 from types import TracebackType
-from typing import Any, Optional, Type
+from typing import Any, Type
 
 
 class AsyncGPSDClient:

--- a/src/piwardrive/map/tile_maintenance.py
+++ b/src/piwardrive/map/tile_maintenance.py
@@ -7,8 +7,15 @@ import os
 import sqlite3
 import time
 from concurrent.futures import Future
-from typing import (TYPE_CHECKING, Any, Callable, Coroutine, Optional, TypeVar,
-                    cast)
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Coroutine,
+    Optional,
+    TypeVar,
+    cast,
+)
 
 from piwardrive.scheduler import PollScheduler
 
@@ -48,7 +55,7 @@ else:
 
         _FileSystemEventHandler = object  # type: ignore
 
-    from typing import Any, cast
+    from typing import Any
 
     FileSystemEventHandler = _FileSystemEventHandler
     Observer = cast(Any, _Observer)

--- a/src/piwardrive/orientation_sensors.py
+++ b/src/piwardrive/orientation_sensors.py
@@ -12,11 +12,7 @@ check for ``None`` to gracefully handle setups without these sensors.
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any, Dict, Optional
-
-if TYPE_CHECKING:  # pragma: no cover - type checking only
-    import dbus as dbus_type
-    from mpu6050 import mpu6050 as mpu6050_type
+from typing import Any, Dict, Optional
 
 try:  # pragma: no cover - optional DBus dependency
     import dbus

--- a/src/piwardrive/vehicle_sensors.py
+++ b/src/piwardrive/vehicle_sensors.py
@@ -29,7 +29,11 @@ def _get_conn(port: Optional[str] = None) -> "obd.OBD | None":
         except Exception as exc:  # pragma: no cover - runtime errors
             logger.error("Failed to connect to OBD: %s", exc)
             _OBD_CONN = None
-    return _OBD_CONN if _OBD_CONN and getattr(_OBD_CONN, "is_connected", lambda: True)() else None
+    return (
+        _OBD_CONN
+        if _OBD_CONN and getattr(_OBD_CONN, "is_connected", lambda: True)()
+        else None
+    )
 
 
 def close_obd() -> None:
@@ -42,6 +46,7 @@ def close_obd() -> None:
         except Exception as exc:  # pragma: no cover - runtime errors
             logger.error("OBD close failed: %s", exc)
         _OBD_CONN = None
+
 
 def read_speed_obd(port: Optional[str] = None) -> float | None:
     """Return vehicle speed in km/h using an OBD-II adapter."""


### PR DESCRIPTION
## Summary
- fix undefined imports
- drop unused imports
- resolve cast redefinition
- wrap long OBD return line
- add blank line for flake8

## Testing
- `flake8`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy', 'fastapi', 'aiosqlite', 'watchdog', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_685ff36a7bcc8333be66e050102e9c4e