### PR TITLE
Fix unused imports in orientation_sensors

### DIFF
--- a/src/piwardrive/orientation_sensors.py
+++ b/src/piwardrive/orientation_sensors.py
@@ -15,8 +15,8 @@ import logging
 from typing import TYPE_CHECKING, Any, Dict, Optional
 
 if TYPE_CHECKING:  # pragma: no cover - type checking only
-    import dbus as dbus_type
-    from mpu6050 import mpu6050 as mpu6050_type
+    import dbus as dbus_type  # noqa: F401
+    from mpu6050 import mpu6050 as mpu6050_type  # noqa: F401
 
 try:  # pragma: no cover - optional DBus dependency
     import dbus


### PR DESCRIPTION
## Summary
- annotate type-only imports in orientation_sensors with `# noqa`

## Testing
- `pre-commit run --files src/piwardrive/orientation_sensors.py` *(fails: no tests ran)*


------
https://chatgpt.com/codex/tasks/task_e_685ff47f71c083339f5465c22edeea24