### PR TITLE
Remove unused widgets alias endpoint

### DIFF
--- a/src/piwardrive/service.py
+++ b/src/piwardrive/service.py
@@ -311,12 +311,6 @@ async def list_widgets(_auth: None = AUTH_DEP) -> dict[str, list[str]]:
     return {"widgets": list(getattr(widgets_mod, "__all__", []))}
 
 
-# Alias without the "/api" prefix for mounting under ``/api``
-
-
-@GET("/widgets")
-async def list_widgets_alias(_auth: None = AUTH_DEP) -> dict[str, list[str]]:
-    return await list_widgets(_auth)
 
 
 @GET("/widget-metrics")


### PR DESCRIPTION
## Summary
- remove unused `/widgets` alias route

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for 'numpy', 'fastapi', 'aiosqlite', ...)*

------
https://chatgpt.com/codex/tasks/task_e_685ff4a6deac83339224b9ea629cea2f