### PR TITLE
Fix mypy errors

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,8 @@
 flake8==7.2.0
 mypy==1.16.0
+types-ujson==5.10.0.20240511
+types-PyYAML==6.0.12.20240311
+types-requests==2.31.0.20240406
 pytest==8.4.0
 radon==6.0.1
 pydocstyle==6.3.0

--- a/src/piwardrive/core/utils.py
+++ b/src/piwardrive/core/utils.py
@@ -14,8 +14,16 @@ import time
 from contextlib import asynccontextmanager
 from datetime import datetime
 from pathlib import Path
-from typing import (Any, Callable, Coroutine, Iterable, Sequence, TypedDict,
-                    TypeVar)
+from typing import (
+    Any,
+    Awaitable,
+    Callable,
+    Coroutine,
+    Iterable,
+    Sequence,
+    TypedDict,
+    TypeVar,
+)
 
 from piwardrive import config as pw_config
 from piwardrive.gpsd_client import client as gps_client

--- a/src/piwardrive/integrations/sigint_suite/enrichment/oui.py
+++ b/src/piwardrive/integrations/sigint_suite/enrichment/oui.py
@@ -7,7 +7,12 @@ import logging
 import os
 import time
 from functools import lru_cache
-from typing import TYPE_CHECKING, Dict, NoReturn, Optional
+from typing import TYPE_CHECKING, Any, Dict, NoReturn, Optional, cast
+
+try:
+    import requests
+except Exception:  # pragma: no cover - missing dependency
+    requests = cast(Any, None)
 
 if TYPE_CHECKING:  # pragma: no cover - type checking only
     from requests import Response
@@ -15,10 +20,6 @@ if TYPE_CHECKING:  # pragma: no cover - type checking only
 try:  # pragma: no cover - optional dependency
     from piwardrive.utils import HTTP_SESSION, robust_request
 except Exception:  # pragma: no cover - minimal fallback
-    try:
-        import requests
-    except Exception:  # pragma: no cover - missing dependency
-        requests = None
     if requests is not None:
         HTTP_SESSION = requests.Session()
 
@@ -44,14 +45,10 @@ except Exception:  # pragma: no cover - minimal fallback
 
         HTTP_SESSION = _DummySession()
 
-        def robust_request(_url: str) -> NoReturn:  # pragma: no cover - simple stub
+        def robust_request(url: str) -> "Response":  # pragma: no cover - simple stub
             raise RuntimeError("HTTP session unavailable")
 
 else:  # pragma: no cover - optional dependency available
-    try:
-        import requests
-    except Exception:  # pragma: no cover - missing dependency
-        requests = None
     if requests is not None:
         HTTP_SESSION = requests.Session()
 


### PR DESCRIPTION
## Summary
- install missing type stubs
- import `Awaitable`
- harmonize `robust_request` fallback definitions

## Testing
- `mypy src`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_685ff3da409883338b2f1ca37202bb6d