### PR TITLE
Fix unused helper warnings

### DIFF
--- a/tests/test_health_monitor.py
+++ b/tests/test_health_monitor.py
@@ -13,7 +13,7 @@ aiohttp_mod.ClientTimeout = lambda *a, **k: None  # type: ignore[attr-defined]
 aiohttp_mod.ClientError = Exception  # type: ignore[attr-defined]
 sys.modules["aiohttp"] = aiohttp_mod
 from piwardrive import diagnostics  # noqa: E402
-from piwardrive.scheduler import PollScheduler
+from piwardrive.scheduler import PollScheduler  # noqa: E402
 
 
 class DummyScheduler:
@@ -27,7 +27,7 @@ class DummyScheduler:
             cb(0)
 
     def cancel(self, name: str) -> None:
-        pass
+        pass  # pragma: no cover - not used
 
 
 def test_health_monitor_polls_self_test() -> None:

--- a/tests/test_tile_maintenance.py
+++ b/tests/test_tile_maintenance.py
@@ -44,7 +44,7 @@ class DummyScheduler:
         cb(0)
 
     def cancel(self, name: str) -> None:
-        pass
+        pass  # pragma: no cover - not used
 
 
 def test_tile_maintenance_runs(tmp_path: Path, monkeypatch):


### PR DESCRIPTION
## Summary
- mark unused `cancel` helpers with no cover comments
- silence E402 in health monitor test

## Testing
- `pytest -q` *(fails: ImportError during collection)*

------
https://chatgpt.com/codex/tasks/task_e_685ff49ec93c8333bd71c4d3d714a741