### PR TITLE
Add configurable reports dir and use doc settings

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,15 +1,15 @@
 """Sphinx configuration for building the project documentation."""
 
-project = "PiWardrive"
-author = "TRASHYTALK"
+import os
+import sys
+
+project = os.getenv("PW_DOC_PROJECT", "PiWardrive")
+author = os.getenv("PW_DOC_AUTHOR", "TRASHYTALK")
 extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.graphviz",
     "sphinxcontrib.mermaid",
 ]
-html_theme = "alabaster"
-
-import os
-import sys
-
+html_theme = os.getenv("PW_DOC_THEME", "alabaster")
+html_title = project
 sys.path.insert(0, os.path.abspath(".."))

--- a/src/piwardrive/core/config.py
+++ b/src/piwardrive/core/config.py
@@ -99,6 +99,7 @@ class Config:
     log_rotate_interval: int = 3600  # noqa: V107
     log_rotate_archives: int = 3  # noqa: V107
     cleanup_rotated_logs: bool = True  # noqa: V107
+    reports_dir: str = REPORTS_DIR  # noqa: V107
     health_export_interval: int = HEALTH_EXPORT_INTERVAL  # noqa: V107
     health_export_dir: str = HEALTH_EXPORT_DIR  # noqa: V107
     compress_health_exports: bool = COMPRESS_HEALTH_EXPORTS  # noqa: V107
@@ -168,6 +169,7 @@ class FileConfigModel(BaseModel):
     log_rotate_interval: Optional[int] = Field(default=None, ge=1)
     log_rotate_archives: Optional[int] = Field(default=None, ge=1)
     cleanup_rotated_logs: Optional[bool] = None
+    reports_dir: Optional[str] = Field(default=None, min_length=1)
     health_export_interval: Optional[int] = Field(default=None, ge=1)
     health_export_dir: Optional[str] = Field(default=None, min_length=1)
     compress_health_exports: Optional[bool] = None
@@ -207,6 +209,7 @@ class ConfigModel(FileConfigModel):
     log_paths: List[str] = Field(default_factory=list)
     health_export_interval: int = Field(default=6, ge=1)
     health_export_dir: str = DEFAULTS["health_export_dir"]
+    reports_dir: str = DEFAULTS["reports_dir"]
     compress_health_exports: bool = DEFAULTS["compress_health_exports"]
     health_export_retention: int = Field(default=7, ge=1)
     map_auto_prefetch: bool = DEFAULTS["map_auto_prefetch"]
@@ -413,6 +416,7 @@ class AppConfig:
     log_rotate_interval: int = DEFAULTS["log_rotate_interval"]
     log_rotate_archives: int = DEFAULTS["log_rotate_archives"]
     cleanup_rotated_logs: bool = DEFAULTS["cleanup_rotated_logs"]
+    reports_dir: str = DEFAULTS["reports_dir"]
     health_export_interval: int = DEFAULTS["health_export_interval"]
     health_export_dir: str = DEFAULTS["health_export_dir"]
     compress_health_exports: bool = DEFAULTS["compress_health_exports"]

--- a/src/piwardrive/diagnostics.py
+++ b/src/piwardrive/diagnostics.py
@@ -19,9 +19,13 @@ import psutil
 
 from piwardrive import cloud_export, config, r_integration, utils
 from piwardrive.interfaces import DataCollector, SelfTestCollector
-from piwardrive.persistence import (HealthRecord, load_recent_health,
-                                    purge_old_health, save_health_record,
-                                    vacuum)
+from piwardrive.persistence import (
+    HealthRecord,
+    load_recent_health,
+    purge_old_health,
+    save_health_record,
+    vacuum,
+)
 from piwardrive.scheduler import PollScheduler
 from piwardrive.utils import run_async_task
 
@@ -292,9 +296,10 @@ class HealthMonitor:
         if not records:
             return
 
-        os.makedirs(config.REPORTS_DIR, exist_ok=True)
+        cfg = config.AppConfig.load()
+        os.makedirs(cfg.reports_dir, exist_ok=True)
         date = datetime.now().strftime("%Y%m%d")
-        csv_path = os.path.join(config.REPORTS_DIR, f"health_{date}.csv")
+        csv_path = os.path.join(cfg.reports_dir, f"health_{date}.csv")
         with open(csv_path, "w", newline="", encoding="utf-8") as fh:
             writer = csv.DictWriter(
                 fh,
@@ -309,7 +314,7 @@ class HealthMonitor:
             writer.writeheader()
             writer.writerows(asdict(r) for r in records)
 
-        plot_path = os.path.join(config.REPORTS_DIR, f"health_{date}.png")
+        plot_path = os.path.join(cfg.reports_dir, f"health_{date}.png")
 
         try:
             result = await asyncio.to_thread(
@@ -319,7 +324,7 @@ class HealthMonitor:
             logging.exception("HealthMonitor summary failed: %s", exc)
             return
 
-        json_path = os.path.join(config.REPORTS_DIR, f"health_{date}.json")
+        json_path = os.path.join(cfg.reports_dir, f"health_{date}.json")
         with open(json_path, "w", encoding="utf-8") as fh:
             json.dump(result, fh)
 
@@ -327,14 +332,15 @@ class HealthMonitor:
         import piwardrive.scripts.health_export as health_export
 
         try:
-            os.makedirs(config.HEALTH_EXPORT_DIR, exist_ok=True)
+            cfg = config.AppConfig.load()
+            os.makedirs(cfg.health_export_dir, exist_ok=True)
             ts = datetime.now().strftime("%Y%m%d-%H%M%S")
-            path = os.path.join(config.HEALTH_EXPORT_DIR, f"health_{ts}.json")
+            path = os.path.join(cfg.health_export_dir, f"health_{ts}.json")
             await asyncio.to_thread(
                 health_export.main,
                 [path, "--format", "json", "--limit", "10000"],
             )
-            if config.COMPRESS_HEALTH_EXPORTS:
+            if cfg.compress_health_exports:
                 with open(path, "rb") as fin, gzip.open(path + ".gz", "wb") as fout:
                     shutil.copyfileobj(fin, fout)
                 os.remove(path)
@@ -346,11 +352,12 @@ class HealthMonitor:
             logging.exception("HealthMonitor export failed: %s", exc)
 
     def _cleanup_exports(self) -> None:
-        if config.HEALTH_EXPORT_RETENTION <= 0:
+        cfg = config.AppConfig.load()
+        if cfg.health_export_retention <= 0:
             return
-        cutoff = datetime.now().timestamp() - config.HEALTH_EXPORT_RETENTION * 86400
-        for fname in os.listdir(config.HEALTH_EXPORT_DIR):
-            fpath = os.path.join(config.HEALTH_EXPORT_DIR, fname)
+        cutoff = datetime.now().timestamp() - cfg.health_export_retention * 86400
+        for fname in os.listdir(cfg.health_export_dir):
+            fpath = os.path.join(cfg.health_export_dir, fname)
             try:
                 if os.path.isfile(fpath) and os.path.getmtime(fpath) < cutoff:
                     os.remove(fpath)


### PR DESCRIPTION
## Summary
- make Sphinx doc settings configurable via environment variables
- add `reports_dir` to configuration models so the reports location can be customized
- use the configured paths in diagnostics

## Testing
- `pre-commit run --files docs/conf.py src/piwardrive/core/config.py src/piwardrive/diagnostics.py` *(fails: Library stubs not installed, missing packages)*

------
https://chatgpt.com/codex/tasks/task_e_685ff489a8b08333952698d080648a37