### PR TITLE
Add tile prefetching diagram

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,6 +8,8 @@ PiWardrive Documentation
 PiWardrive's primary interface is a React-based web dashboard served by
 :doc:`status_service`.
 
+See :doc:`tile_prefetching` for a diagram of the automatic tile prefetch flow.
+
 
 .. toctree::
    :maxdepth: 1

--- a/docs/tile_prefetching.rst
+++ b/docs/tile_prefetching.rst
@@ -7,16 +7,16 @@ The diagram below illustrates how PiWardrive predicts upcoming map tiles based o
 
 .. mermaid::
 
-   sequenceDiagram
-       participant MapScreen
-       participant RoutePrefetcher
-       participant Tiles
-       participant TileMaintainer
+    sequenceDiagram
+        participant MapScreen
+        participant RoutePrefetcher
+        participant Tiles
+        participant TileMaintainer
 
-       MapScreen->>MapScreen: store GPS in track_points
-       MapScreen->>RoutePrefetcher: _predict_points()
-       RoutePrefetcher-->>MapScreen: heading + destination
-       MapScreen->>Tiles: prefetch_tiles()
-       Tiles-->>MapScreen: tile images
-       MapScreen->>TileMaintainer: enforce_cache_limit()
+        MapScreen->>MapScreen: store GPS in map_screen.track_points
+        MapScreen->>RoutePrefetcher: _predict_points()
+        RoutePrefetcher-->>MapScreen: heading + destination
+        MapScreen->>Tiles: map_screen.prefetch_tiles()
+        Tiles-->>MapScreen: tile images
+        MapScreen->>TileMaintainer: enforce_cache_limit()
 


### PR DESCRIPTION
## Summary
- document the tile prefetching flow with a Mermaid diagram
- reference the diagram from the docs index

## Testing
- `pre-commit run --files docs/tile_prefetching.rst docs/index.rst`
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6860ab5258288333b71c061a6dfacfc0