### PR TITLE
Expand scheduled SIGINT docs

### DIFF
--- a/docs/function_flows.rst
+++ b/docs/function_flows.rst
@@ -56,3 +56,21 @@ SIGINT suite scanners and persist their results.
        Scanners-->>Scheduler: results
        Scheduler->>Persistence: save results
 
+SIGINT scan data flow
+---------------------
+
+The ``PollScheduler.register_widget`` diagram shows how periodic tasks are
+registered.  Building on that, the flowchart below summarizes how those
+scheduled scans forward wireless metadata to the persistence layer.
+
+.. mermaid::
+
+   flowchart LR
+       S[PollScheduler]
+       S --> WiFi[scan_wifi]
+       S --> BT[scan_bluetooth]
+       S --> IMSI[scan_imsi]
+       WiFi --> P[Persistence]
+       BT --> P
+       IMSI --> P
+


### PR DESCRIPTION
## Summary
- show how scheduled SIGINT scans move data to persistence using a new flowchart

## Testing
- `pre-commit run --files docs/function_flows.rst`

------
https://chatgpt.com/codex/tasks/task_e_6860ab5dc1408333bdb94b2548df7989