### PR TITLE
Document widget plugin directory

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -57,6 +57,7 @@ The UI renders directly to the framebuffer without X. Use the top tabs to switch
 ## Widgets and Plugins
 
 Dashboard widgets display metrics such as CPU temperature, handshake counts and service status. Custom widgets may be placed in `~/.config/piwardrive/plugins` and are discovered automatically at startup. Each widget subclasses `widgets.base.DashboardWidget` and implements an `update()` method. A built-in battery widget is available when the hardware exposes charge information.
+See `docs/widget_plugins.rst` for the expected directory structure.
 
 ## Diagnostics and Persistence
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,6 +17,7 @@ PiWardrive's primary interface is a React-based web dashboard served by
    security
    environment
    widgets
+   widget_plugins
    diagnostics
    persistence
    gps_polling

--- a/docs/widget_plugins.rst
+++ b/docs/widget_plugins.rst
@@ -1,0 +1,25 @@
+Widget Plugin Directory
+=======================
+.. note::
+   Please read the legal notice in the project `README.md` before using PiWardrive.
+
+Custom widgets can be installed without modifying the PiWardrive source. The
+loader scans ``~/.config/piwardrive/plugins`` when :mod:`widgets` is imported.
+
+Layout
+------
+
+The directory may contain standalone ``.py`` files, packages or compiled
+extensions. Each module is checked for subclasses of
+:class:`widgets.base.DashboardWidget` which are registered by name.
+
+Example structure::
+
+    ~/.config/piwardrive/plugins
+    ├── my_widget.py
+    └── speed_widget
+        └── __init__.py
+
+The plugin directory timestamp is cached so repeated imports do not hit the
+filesystem. Call :func:`widgets.clear_plugin_cache` after adding or removing
+files to refresh the cache.


### PR DESCRIPTION
## Summary
- add docs/widget_plugins.rst describing the plugin directory layout
- link to the new docs from index and reference

## Testing
- `pre-commit run --files REFERENCE.md docs/index.rst docs/widget_plugins.rst`
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6860abce093c833384d8de1ebd19fa0e