### PR TITLE
Add packaging metadata and extras

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,18 @@ readme = "README.md"
 requires-python = ">=3.10"
 license = {file = "LICENSE"}
 authors = [{name = "PiWardrive contributors"}]
+keywords = ["war-driving", "wireless", "raspberry pi", "mapping"]
+classifiers = [
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Operating System :: OS Independent",
+    "Environment :: Console",
+    "Topic :: Utilities",
+]
 
 [project.scripts]
 piwardrive-service = "piwardrive.service:main"
@@ -38,6 +50,12 @@ calibrate-orientation = "piwardrive.scripts.calibrate_orientation:main"
 piwardrive-kiosk = "piwardrive.cli.kiosk:main"
 export-log-bundle = "piwardrive.scripts.export_log_bundle:main"
 piwardrive-maintain-tiles = "piwardrive.scripts.tile_maintenance_cli:main"
+
+[project.optional-dependencies]
+c-extensions = [
+    "orjson",
+    "ujson",
+]
 
 
 

--- a/src/piwardrive/integrations/sigint_suite/pyproject.toml
+++ b/src/piwardrive/integrations/sigint_suite/pyproject.toml
@@ -15,6 +15,18 @@ readme = "README.md"
 requires-python = ">=3.10"
 license = {file = "../LICENSE"}
 authors = [{name = "PiWardrive contributors"}]
+keywords = ["wireless", "scanning", "raspberry pi", "sigint"]
+classifiers = [
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Operating System :: OS Independent",
+    "Environment :: Console",
+    "Topic :: Utilities",
+]
 
 [project.scripts]
 wifi-scan = "sigint_suite.wifi.scanner:main"
@@ -22,4 +34,10 @@ bluetooth-scan = "sigint_suite.bluetooth.scanner:main"
 imsi-scan = "sigint_suite.cellular.imsi_catcher.scanner:main"
 band-scan = "sigint_suite.cellular.band_scanner.scanner:main"
 scan-all = "sigint_suite.scan_all:main"
+
+[project.optional-dependencies]
+c-extensions = [
+    "orjson",
+    "ujson",
+]
 


### PR DESCRIPTION
## Summary
- add project metadata fields like keywords and classifiers
- document optional C extension dependencies

## Testing
- `pytest -q` *(fails: 32 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6860abd7d43083339d1300dfe584aac4