### PR TITLE
Add full env table

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,8 +428,9 @@ officially supported.
 Settings persist in `~/.config/piwardrive/config.json`. Profiles under
 `~/.config/piwardrive/profiles` can store alternate configurations and may be
 selected via the `PW_PROFILE_NAME` environment variable. Environment variables
-prefixed with `PW_` override any option. See `docs/configuration.rst` and
-`docs/environment.rst` for a full list.
+prefixed with `PW_` override any option. See `docs/configuration.rst` and the
+[Configuration Overrides](docs/environment.rst#configuration-overrides) section
+for a full list.
 
 ## Additional Documentation
 

--- a/docs/environment.rst
+++ b/docs/environment.rst
@@ -63,20 +63,121 @@ Configuration Overrides
 The :mod:`config` module exposes many fields such as
 ``offline_tile_path``, ``kismet_logdir`` and ``bettercap_caplet``.
 Prefix these keys with ``PW_`` to override their default paths at run time.
-Call :func:`config.list_env_overrides` to see the full mapping of
-environment variables to configuration keys.
+All available overrides are summarised below.
 
-.. list-table:: Common overrides
+.. list-table:: All ``PW_`` overrides
    :header-rows: 1
 
    * - Environment variable
      - Configuration key
-   * - ``PW_THEME``
-     - ``theme``
+   * - ``PW_ADMIN_PASSWORD_HASH``
+     - ``admin_password_hash``
+   * - ``PW_BETTERCAP_CAPLET``
+     - ``bettercap_caplet``
+   * - ``PW_CLEANUP_ROTATED_LOGS``
+     - ``cleanup_rotated_logs``
+   * - ``PW_CLOUD_BUCKET``
+     - ``cloud_bucket``
+   * - ``PW_CLOUD_PREFIX``
+     - ``cloud_prefix``
+   * - ``PW_CLOUD_PROFILE``
+     - ``cloud_profile``
+   * - ``PW_COMPRESS_HEALTH_EXPORTS``
+     - ``compress_health_exports``
+   * - ``PW_COMPRESS_OFFLINE_TILES``
+     - ``compress_offline_tiles``
+   * - ``PW_DASHBOARD_LAYOUT``
+     - ``dashboard_layout``
+   * - ``PW_DEBUG_MODE``
+     - ``debug_mode``
+   * - ``PW_DISABLE_SCANNING``
+     - ``disable_scanning``
+   * - ``PW_GPS_MOVEMENT_THRESHOLD``
+     - ``gps_movement_threshold``
+   * - ``PW_HANDSHAKE_CACHE_SECONDS``
+     - ``handshake_cache_seconds``
+   * - ``PW_HEALTH_EXPORT_DIR``
+     - ``health_export_dir``
+   * - ``PW_HEALTH_EXPORT_INTERVAL``
+     - ``health_export_interval``
+   * - ``PW_HEALTH_EXPORT_RETENTION``
+     - ``health_export_retention``
+   * - ``PW_HEALTH_POLL_INTERVAL``
+     - ``health_poll_interval``
+   * - ``PW_KISMET_LOGDIR``
+     - ``kismet_logdir``
+   * - ``PW_LOG_PATHS``
+     - ``log_paths``
+   * - ``PW_LOG_ROTATE_ARCHIVES``
+     - ``log_rotate_archives``
+   * - ``PW_LOG_ROTATE_INTERVAL``
+     - ``log_rotate_interval``
+   * - ``PW_LOG_TAIL_CACHE_SECONDS``
+     - ``log_tail_cache_seconds``
+   * - ``PW_MAP_AUTO_PREFETCH``
+     - ``map_auto_prefetch``
+   * - ``PW_MAP_CLUSTER_APS``
+     - ``map_cluster_aps``
+   * - ``PW_MAP_CLUSTER_CAPACITY``
+     - ``map_cluster_capacity``
+   * - ``PW_MAP_FOLLOW_GPS``
+     - ``map_follow_gps``
+   * - ``PW_MAP_POLL_APS``
+     - ``map_poll_aps``
+   * - ``PW_MAP_POLL_BT``
+     - ``map_poll_bt``
    * - ``PW_MAP_POLL_GPS``
      - ``map_poll_gps``
+   * - ``PW_MAP_POLL_GPS_MAX``
+     - ``map_poll_gps_max``
+   * - ``PW_MAP_POLL_WIGLE``
+     - ``map_poll_wigle``
+   * - ``PW_MAP_SHOW_APS``
+     - ``map_show_aps``
+   * - ``PW_MAP_SHOW_BT``
+     - ``map_show_bt``
+   * - ``PW_MAP_SHOW_GPS``
+     - ``map_show_gps``
+   * - ``PW_MAP_SHOW_HEATMAP``
+     - ``map_show_heatmap``
+   * - ``PW_MAP_SHOW_WIGLE``
+     - ``map_show_wigle``
+   * - ``PW_MAP_USE_OFFLINE``
+     - ``map_use_offline``
    * - ``PW_OFFLINE_TILE_PATH``
      - ``offline_tile_path``
+   * - ``PW_REMOTE_SYNC_INTERVAL``
+     - ``remote_sync_interval``
+   * - ``PW_REMOTE_SYNC_RETRIES``
+     - ``remote_sync_retries``
+   * - ``PW_REMOTE_SYNC_TIMEOUT``
+     - ``remote_sync_timeout``
+   * - ``PW_REMOTE_SYNC_TOKEN``
+     - ``remote_sync_token``
+   * - ``PW_REMOTE_SYNC_URL``
+     - ``remote_sync_url``
+   * - ``PW_REPORTS_DIR``
+     - ``reports_dir``
+   * - ``PW_ROUTE_PREFETCH_INTERVAL``
+     - ``route_prefetch_interval``
+   * - ``PW_ROUTE_PREFETCH_LOOKAHEAD``
+     - ``route_prefetch_lookahead``
+   * - ``PW_THEME``
+     - ``theme``
+   * - ``PW_TILE_CACHE_LIMIT_MB``
+     - ``tile_cache_limit_mb``
+   * - ``PW_TILE_MAINTENANCE_INTERVAL``
+     - ``tile_maintenance_interval``
+   * - ``PW_TILE_MAX_AGE_DAYS``
+     - ``tile_max_age_days``
+   * - ``PW_UI_FONT_SIZE``
+     - ``ui_font_size``
+   * - ``PW_WIDGET_BATTERY_STATUS``
+     - ``widget_battery_status``
+   * - ``PW_WIGLE_API_KEY``
+     - ``wigle_api_key``
+   * - ``PW_WIGLE_API_NAME``
+     - ``wigle_api_name``
 
 SIGINT Suite
 ------------


### PR DESCRIPTION
## Summary
- document every PW_ env var
- add README link to the configuration overrides table

## Testing
- `pre-commit run --files README.md docs/environment.rst`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6860abd89d0083338edf034523d89f79