### PR TITLE
Add remote sync example

### DIFF
--- a/docs/remote_sync.rst
+++ b/docs/remote_sync.rst
@@ -48,7 +48,8 @@ Client Configuration
 2. ``remote_sync_timeout`` and ``remote_sync_retries`` control how long PiWardrive
    waits for a response and how many times it retries on failure.
    ``remote_sync_interval`` schedules automatic uploads when greater than
-   ``0`` and represents the frequency in minutes.
+   ``0`` and represents the frequency in minutes.  See
+   ``examples/remote_sync.json`` for a snippet with common values.
 3. Restart PiWardrive or reload the configuration to apply the changes.
 
 Uploading Data

--- a/examples/remote_sync.json
+++ b/examples/remote_sync.json
@@ -1,0 +1,7 @@
+{
+    "remote_sync_url": "http://10.0.0.2:9000/",
+    "remote_sync_token": "",
+    "remote_sync_timeout": 10,
+    "remote_sync_retries": 5,
+    "remote_sync_interval": 60
+}


### PR DESCRIPTION
## Summary
- add `examples/remote_sync.json` with typical values
- reference the example in the docs

## Testing
- `pre-commit run --files docs/remote_sync.rst examples/remote_sync.json`
- `pytest` *(fails: 32 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6860abd9dcc88333b2ac6b21d52b28c4