### PR TITLE
Add orientation sensor tests using dummy modules

### DIFF
--- a/tests/test_orientation_sensors.py
+++ b/tests/test_orientation_sensors.py
@@ -1,25 +1,33 @@
-import os
+"""Tests for :mod:`piwardrive.orientation_sensors` using dummy modules."""
+
+from __future__ import annotations
+
+import importlib
 import sys
-import types
 
 import piwardrive.orientation_sensors as osens  # noqa: E402
 
 
+def _reload() -> None:
+    """Reload the orientation_sensors module with current ``sys.modules``."""
+    importlib.reload(osens)
+
+
 def test_orientation_to_angle() -> None:
-    assert osens.orientation_to_angle("normal") == 0.0
-    assert osens.orientation_to_angle("left-up") == 270.0
-    assert osens.orientation_to_angle("unknown") is None
+    assert osens.orientation_to_angle("normal") == 0.0  # nosec B101
+    assert osens.orientation_to_angle("left-up") == 270.0  # nosec B101
+    assert osens.orientation_to_angle("unknown") is None  # nosec B101
 
 
 def test_orientation_to_angle_custom_map() -> None:
     custom_map = {"flip": 45.0}
-    assert osens.orientation_to_angle("flip", custom_map) == 45.0
+    assert osens.orientation_to_angle("flip", custom_map) == 45.0  # nosec B101
 
 
 def test_update_orientation_map() -> None:
     osens.update_orientation_map({"flip": 45.0})
     try:
-        assert osens.orientation_to_angle("flip") == 45.0
+        assert osens.orientation_to_angle("flip") == 45.0  # nosec B101
     finally:
         osens.reset_orientation_map()
 
@@ -27,51 +35,90 @@ def test_update_orientation_map() -> None:
 def test_update_orientation_map_clone() -> None:
     local_map = osens.clone_orientation_map()
     osens.update_orientation_map({"flip": 45.0}, mapping=local_map)
-    assert osens.orientation_to_angle("flip", local_map) == 45.0
+    assert osens.orientation_to_angle("flip", local_map) == 45.0  # nosec B101
     # Global mapping should remain unchanged
-    assert osens.orientation_to_angle("flip") is None
+    assert osens.orientation_to_angle("flip") is None  # nosec B101
 
 
-def test_get_orientation_dbus_missing(monkeypatch):
-    monkeypatch.setattr(osens, "dbus", None)
-    assert osens.get_orientation_dbus() is None
+def test_get_orientation_dbus_missing(monkeypatch) -> None:
+    monkeypatch.delitem(sys.modules, "dbus", raising=False)
+    _reload()
+    try:
+        assert osens.get_orientation_dbus() is None  # nosec B101
+    finally:
+        _reload()
 
 
-def test_get_orientation_dbus_success(monkeypatch):
+def test_get_orientation_dbus_success(add_dummy_module) -> None:
     class DummyIface:
-        def HasAccelerometer(self):
+        def HasAccelerometer(self) -> bool:
             return True
 
-        def ClaimAccelerometer(self):
+        def ClaimAccelerometer(self) -> None:
             pass
 
-        def ReleaseAccelerometer(self):
+        def ReleaseAccelerometer(self) -> None:
             pass
 
-        def GetAccelerometerOrientation(self):
+        def GetAccelerometerOrientation(self) -> str:
             return "right-up"
 
     class DummyBus:
-        def get_object(self, _service, _path):
+        def get_object(self, _service: str, _path: str) -> object:
             return object()
 
-    def interface(_obj, _name):
+    def interface(_obj: object, _name: str) -> DummyIface:
         return DummyIface()
 
-    dummy_dbus = types.SimpleNamespace(
+    add_dummy_module(
+        "dbus",
         SystemBus=lambda: DummyBus(),
         Interface=interface,
     )
-    monkeypatch.setattr(osens, "dbus", dummy_dbus)
-    assert osens.get_orientation_dbus() == "right-up"
+    _reload()
+    try:
+        assert osens.get_orientation_dbus() == "right-up"  # nosec B101
+    finally:
+        _reload()
 
 
 def test_get_heading(monkeypatch):
     monkeypatch.setattr(osens, "get_orientation_dbus", lambda: "right-up")
     monkeypatch.setattr(osens, "orientation_to_angle", lambda o, m=None: 90.0)
-    assert osens.get_heading() == 90.0
+    assert osens.get_heading() == 90.0  # nosec B101
 
 
 def test_get_heading_none(monkeypatch):
     monkeypatch.setattr(osens, "get_orientation_dbus", lambda: None)
-    assert osens.get_heading() is None
+    assert osens.get_heading() is None  # nosec B101
+
+
+def test_read_mpu6050_missing(monkeypatch) -> None:
+    monkeypatch.delitem(sys.modules, "mpu6050", raising=False)
+    _reload()
+    try:
+        assert osens.read_mpu6050() is None  # nosec B101
+    finally:
+        _reload()
+
+
+def test_read_mpu6050_success(add_dummy_module) -> None:
+    class DummySensor:
+        def __init__(self, address: int) -> None:
+            self.address = address
+
+        def get_accel_data(self) -> dict:
+            return {"x": 1}
+
+        def get_gyro_data(self) -> dict:
+            return {"y": 2}
+
+    add_dummy_module("mpu6050", mpu6050=lambda addr: DummySensor(addr))
+    _reload()
+    try:
+        assert osens.read_mpu6050() == {  # nosec B101
+            "accelerometer": {"x": 1},
+            "gyroscope": {"y": 2},
+        }
+    finally:
+        _reload()


### PR DESCRIPTION
## Summary
- add new orientation sensor tests with `add_dummy_module`
- simulate DBus and MPU-6050 modules using dummy modules

## Testing
- `pre-commit run --files tests/test_orientation_sensors.py`

------
https://chatgpt.com/codex/tasks/task_e_6860abd1b1808333b16f61fe51771b9d