### PR TITLE
Add Docker compose volumes and usage docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,16 @@ docker build -t piwardrive .
 docker run --device=/dev/ttyUSB0 --rm piwardrive
 ```
 
+To run the dashboard and API via Docker Compose, first build the
+React frontend with `npm run build` and then launch the stack:
+
+```bash
+docker compose up
+```
+
+The compose file mounts `~/.config/piwardrive` and `webui/dist` so your
+configuration and compiled assets persist between container restarts.
+
 ### Automated vs Manual Tasks
 
 #### Automated Aspects

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,3 +5,6 @@ services:
     ports:
       - "8000:8000"
     command: piwardrive-webui
+    volumes:
+      - ~/.config/piwardrive:/root/.config/piwardrive
+      - ./webui/dist:/app/webui/dist


### PR DESCRIPTION
## Summary
- persist configuration and frontend build output via volumes
- document `docker compose up` usage

## Testing
- `pre-commit run --all-files` *(fails: 30 errors during collection)*
- `pytest` *(fails: 32 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6860abdde1748333b538c92e32970ab2