### PR TITLE
Add npm test pre-commit hook and document Node requirement

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,3 +28,9 @@ repos:
         language: system
         types: [python]
         args: ["-q"]
+
+      - id: npm-test
+        name: npm test
+        entry: bash -c 'cd webui && npm test'
+        language: system
+        pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -221,6 +221,13 @@ Follow these steps to configure the Python and React development environment.
      nodejs npm
    ```
 
+> PiWardrive's frontend and tests rely on **Node.js 18+**. Verify the tools
+> are installed and meet the version requirement:
+> ```bash
+> node --version
+> npm --version
+> ```
+
 3. **Create and activate a Python venv**
    ```bash
    python3 -m venv venv


### PR DESCRIPTION
## Summary
- test `webui` with npm during pre-commit
- call out Node.js 18+ as a requirement in the setup docs

## Testing
- `pre-commit run --files .pre-commit-config.yaml README.md` *(fails: `vitest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860abdd17e88333a5336078db7c5638