### PR TITLE
Add coverage generation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,5 +37,13 @@ jobs:
       - name: Run pre-commit
         run: pre-commit run --all-files
 
-      - name: Run tests
-        run: pytest -q
+      - name: Run tests with coverage
+        run: |
+          pytest --cov=src --cov-report=xml -q
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: coverage.xml
+          fail_ci_if_error: true

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,6 +4,7 @@ types-ujson==5.10.0.20240511
 types-PyYAML==6.0.12.20240311
 types-requests==2.31.0.20240406
 pytest==8.4.0
+pytest-cov==6.2.1
 radon==6.0.1
 pydocstyle==6.3.0
 pre-commit==3.7.1


### PR DESCRIPTION
## Summary
- include pytest-cov in dev requirements
- upload coverage data in CI via Codecov

## Testing
- `pre-commit run --files .github/workflows/ci.yml requirements-dev.txt`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6860abe34fd88333988de74273cdde58