### PR TITLE
Add plugin test for example widget

### DIFF
--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,0 +1,44 @@
+import importlib
+from pathlib import Path
+
+
+def _setup_kivy(add_dummy_module):
+    add_dummy_module(
+        "requests",
+        get=lambda *a, **k: None,
+        Session=object,
+        RequestException=Exception,
+    )
+    add_dummy_module("kivy.metrics", dp=lambda x: x)
+    add_dummy_module("kivy.uix.behaviors", DragBehavior=type("DragBehavior", (), {}))
+    add_dummy_module("kivymd.uix.boxlayout", MDBoxLayout=type("MDBoxLayout", (), {}))
+    add_dummy_module(
+        "kivymd.uix.card",
+        MDCard=type(
+            "MDCard", (), {"__init__": lambda self, **kw: None, "add_widget": lambda self, w: None}
+        ),
+    )
+    add_dummy_module(
+        "kivymd.uix.label",
+        MDLabel=type("MDLabel", (), {"__init__": lambda self, **kw: None, "text": ""}),
+    )
+    import importlib, sys
+    sys.modules.setdefault("widgets", importlib.import_module("piwardrive.widgets"))
+    sys.modules["widgets.base"] = importlib.import_module("piwardrive.widgets.base")
+
+
+def test_load_hello_plugin(tmp_path, monkeypatch, add_dummy_module):
+    _setup_kivy(add_dummy_module)
+    plugin_dir = tmp_path / ".config" / "piwardrive" / "plugins"
+    plugin_dir.mkdir(parents=True)
+
+    src = Path(__file__).resolve().parents[1] / "examples" / "plugins" / "hello_plugin.py"
+    dest = plugin_dir / "hello_plugin.py"
+    dest.write_text(src.read_text())
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import sys
+    sys.modules.pop("piwardrive.widgets", None)
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+    widgets = importlib.import_module("piwardrive.widgets")
+    assert "HelloPluginWidget" in widgets.list_plugins()


### PR DESCRIPTION
## Summary
- add `test_plugins.py` to ensure example plugin loads
- check that `HelloPluginWidget` is discovered by `list_plugins`

## Testing
- `pytest tests/test_plugins.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6860abdebd6c83338c5f63219c7b101c