### PR TITLE
Fix unused vars in docs config

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,3 +13,11 @@ extensions = [
 html_theme = os.getenv("PW_DOC_THEME", "alabaster")
 html_title = project
 sys.path.insert(0, os.path.abspath(".."))
+
+__all__ = [
+    "project",
+    "author",
+    "extensions",
+    "html_theme",
+    "html_title",
+]


### PR DESCRIPTION
## Summary
- ensure docs/conf.py globals are marked for export

## Testing
- `SKIP=pytest pre-commit run --files docs/conf.py`

------
https://chatgpt.com/codex/tasks/task_e_6860ad44e0548333abf1c37f711b41c0