### PR TITLE
Remove unused stub in utils

### DIFF
--- a/src/piwardrive/utils.py
+++ b/src/piwardrive/utils.py
@@ -21,11 +21,6 @@ except Exception:
     # core utils couldn't be imported; define minimal stubs so optional
     # features can be patched in tests without import errors.
 
-    # pragma: no cover - placeholder
-    def _stub(*_args: object, **_kwargs: object) -> None:
-        """Placeholder for optional functionality."""
-        raise NotImplementedError
-
     if not TYPE_CHECKING:
         # The following stubs match the names used by the builtin widgets. They
         # are replaced by monkeypatching in the unit tests when the real


### PR DESCRIPTION
## Summary
- drop `_stub` definition from `utils`

## Testing
- `pre-commit run --files src/piwardrive/utils.py` *(fails: mypy missing stubs, pytest missing deps)*
- `pytest -q` *(fails: missing modules like numpy, fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_6860ad517e1c8333853cee0f29fef039