### PR TITLE
Fix unused import in orientation sensors

### DIFF
--- a/src/piwardrive/orientation_sensors.py
+++ b/src/piwardrive/orientation_sensors.py
@@ -9,8 +9,6 @@ external MPU‑6050 sensor using the optional ``mpu6050`` package.  Again,
 check for ``None`` to gracefully handle setups without these sensors.
 """
 
-from __future__ import annotations
-
 import logging
 from typing import Any, Dict, Optional
 


### PR DESCRIPTION
## Summary
- remove unused `from __future__ import annotations`

## Testing
- `flake8 src/piwardrive/orientation_sensors.py`
- `ruff check src/piwardrive/orientation_sensors.py`
- `mypy src/piwardrive/orientation_sensors.py`
- `pytest tests/test_orientation_sensors.py::test_get_heading`
- `pytest tests/test_orientation_sensors_pkg.py::test_orientation_to_angle_pkg`


------
https://chatgpt.com/codex/tasks/task_e_6860ad61dd708333b5b72389833b7ec1