### PR TITLE
Add aggregation service installer

### DIFF
--- a/docs/aggregation_service.rst
+++ b/docs/aggregation_service.rst
@@ -18,9 +18,10 @@ By default data is stored under ``~/piwardrive-aggregation``.  Set the
 Installation
 ------------
 
-Run ``scripts/install_aggregation_service.sh`` on the target server.  The
-script creates an ``agg-env`` virtual environment, installs the required Python
-packages and writes ``/etc/systemd/system/piwardrive-aggregation.service``.
+Run ``scripts/install_aggregation_service.sh`` from the repository root on the
+target server.  The helper creates an ``agg-env`` virtual environment,
+installs the required Python packages and writes
+``/etc/systemd/system/piwardrive-aggregation.service``.
 Enable the unit with::
 
     sudo systemctl enable --now piwardrive-aggregation.service

--- a/scripts/install_aggregation_service.sh
+++ b/scripts/install_aggregation_service.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Install PiWardrive aggregation server service and dependencies
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+VENV_DIR="$HOME/agg-env"
+SERVICE_PATH="/etc/systemd/system/piwardrive-aggregation.service"
+
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "Python 3 is required" >&2
+    exit 1
+fi
+
+if [ ! -d "$VENV_DIR" ]; then
+    python3 -m venv "$VENV_DIR"
+fi
+# shellcheck disable=SC1090
+source "$VENV_DIR/bin/activate"
+
+pip install --upgrade pip
+pip install fastapi aiosqlite 'uvicorn[standard]'
+# Install the local package for analysis helpers
+pip install "$SCRIPT_DIR/.."
+
+deactivate
+
+cat <<EOF_UNIT | sudo tee "$SERVICE_PATH" >/dev/null
+[Unit]
+Description=PiWardrive Aggregation Service
+After=network.target
+
+[Service]
+Type=simple
+User=$USER
+WorkingDirectory=$HOME
+ExecStart=$VENV_DIR/bin/python -m piwardrive.aggregation_service
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target
+EOF_UNIT
+
+echo "Service written to $SERVICE_PATH"
+
+echo "Enable the service with: sudo systemctl enable --now piwardrive-aggregation.service"
+


### PR DESCRIPTION
## Summary
- add `scripts/install_aggregation_service.sh` for a simple install process
- document the helper in Aggregation Service docs

## Testing
- `pytest tests/test_aggregation_service.py -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6860afc4eb0c83339530d549d0bb0d6a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an installation script to automate setup of the aggregation service and its dependencies, including system service configuration.

* **Documentation**
  * Clarified and updated installation instructions for the aggregation service to improve accuracy and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->