### PR TITLE
Add config-cli tests

### DIFF
--- a/tests/test_cli_tools.py
+++ b/tests/test_cli_tools.py
@@ -1,0 +1,77 @@
+import importlib
+import json
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _stub_pydantic(monkeypatch):
+    """Provide a minimal pydantic stub so config imports succeed."""
+    module = SimpleNamespace(
+        BaseModel=object,
+        Field=lambda *a, **k: None,
+        ValidationError=Exception,
+    )
+    module.field_validator = lambda *a, **k: (lambda f: f)
+    monkeypatch.setitem(sys.modules, "pydantic", module)
+
+
+def _import_cli():
+    for name in ["piwardrive.cli.config_cli", "piwardrive.scripts.config_cli"]:
+        if name in sys.modules:
+            del sys.modules[name]
+    return importlib.import_module("piwardrive.cli.config_cli")
+
+
+def test_config_cli_get_local(monkeypatch, capsys):
+    cli = _import_cli()
+    monkeypatch.setattr(cli.cfg, "load_config", lambda: cli.cfg.Config(theme="Blue"))
+    cli.main(["get", "theme"])
+    assert capsys.readouterr().out.strip() == json.dumps("Blue")
+
+
+def test_config_cli_set_local(monkeypatch, capsys):
+    cli = _import_cli()
+    cfg_obj = cli.cfg.Config(map_auto_prefetch=False)
+    monkeypatch.setattr(cli.cfg, "load_config", lambda: cfg_obj)
+    saved = {}
+
+    def fake_save(c):
+        saved["cfg"] = c
+
+    monkeypatch.setattr(cli.cfg, "save_config", fake_save)
+    cli.main(["set", "map_auto_prefetch", "true"])
+    assert saved["cfg"].map_auto_prefetch is True
+    assert capsys.readouterr().out.strip() == "true"
+
+
+def test_config_cli_get_api(monkeypatch, capsys):
+    cli = _import_cli()
+
+    async def fake_get(url):
+        assert url == "http://api"
+        return {"theme": "Dark"}
+
+    monkeypatch.setattr(cli, "_api_get", fake_get)
+    cli.main(["--url", "http://api", "get", "theme"])
+    assert capsys.readouterr().out.strip() == json.dumps("Dark")
+
+
+def test_config_cli_set_api(monkeypatch, capsys):
+    cli = _import_cli()
+
+    async def fake_get(url):
+        assert url == "http://api"
+        return {"theme": "Dark"}
+
+    async def fake_update(url, updates):
+        assert url == "http://api"
+        assert updates == {"theme": "Light"}
+        return {"theme": "Light"}
+
+    monkeypatch.setattr(cli, "_api_get", fake_get)
+    monkeypatch.setattr(cli, "_api_update", fake_update)
+    cli.main(["--url", "http://api", "set", "theme", "Light"])
+    assert capsys.readouterr().out.strip() == json.dumps("Light")


### PR DESCRIPTION
## Summary
- add `tests/test_cli_tools.py` with unit tests for `config-cli`
- cover `get` and `set` operations with and without API usage

## Testing
- `pytest tests/test_cli_tools.py -vv`

------
https://chatgpt.com/codex/tasks/task_e_6860afe660448333a318a45e8f6d8efd