### PR TITLE
Update deployment docs

### DIFF
--- a/docs/deployment.rst
+++ b/docs/deployment.rst
@@ -45,5 +45,9 @@ Docker Container
 3. Set ``WORKDIR /app`` and define ``CMD ["piwardrive-service"]``.
 4. Map the host's USB devices (Wi‑Fi adapter, GPS dongle) into the container when running ``docker run``.
 5. Persist ``~/.config/piwardrive`` with a volume so logs and configuration survive container restarts.
+6. After building the image with ``docker build``, tag it and push to your registry::
+
+       docker tag <IMAGE_ID> myuser/piwardrive:latest
+       docker push myuser/piwardrive:latest
 
 Both approaches produce a self-contained environment ready to capture Wi‑Fi and GPS data with minimal setup on new hardware.


### PR DESCRIPTION
## Summary
- document Docker tagging and pushing steps after `docker build`

## Testing
- `pre-commit run --files docs/deployment.rst` *(fails: InvalidConfigError)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6860afe9983083338a47e78b89c545fc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated deployment instructions to include steps for tagging and pushing Docker images to a container registry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->