### PR TITLE
Add orientationSensors TypeScript declarations

### DIFF
--- a/webui/src/orientationSensors.d.ts
+++ b/webui/src/orientationSensors.d.ts
@@ -1,0 +1,38 @@
+export interface OrientationMap {
+  [orientation: string]: number;
+}
+
+export const DEFAULT_ORIENTATION_MAP: OrientationMap;
+
+export function orientationToAngle(
+  orientation: string | undefined,
+  orientationMap?: OrientationMap
+): number | undefined;
+
+export function cloneOrientationMap(): OrientationMap;
+
+export function resetOrientationMap(): void;
+
+export interface UpdateOrientationMapOptions {
+  clear?: boolean;
+  mapping?: OrientationMap | null;
+}
+
+export function updateOrientationMap(
+  newMap: OrientationMap,
+  options?: UpdateOrientationMapOptions
+): OrientationMap;
+
+export let dbus: any;
+export let mpu6050: any;
+
+export function getOrientationDbus(): string | null;
+
+export interface Mpu6050Reading {
+  accelerometer: any;
+  gyroscope: any;
+}
+
+export function readMpu6050(address?: number): Mpu6050Reading | null;
+
+export function getHeading(orientationMap?: OrientationMap): number | null | undefined;


### PR DESCRIPTION
## Summary
- add `orientationSensors.d.ts` to type exported functions

## Testing
- `npm test` *(fails: Invalid package.json)*
- `pytest -q` *(fails: missing dependencies)*
- `pre-commit run --files webui/src/orientationSensors.d.ts` *(fails: InvalidConfigError)*

------
https://chatgpt.com/codex/tasks/task_e_6860afe23c2c8333bf42b64d04a84ed6