### PR TITLE
Add localization doc

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -186,7 +186,8 @@ The application recognises numerous `PW_*` variables. Any option in `config.py` 
 
 `PW_PROFILE_CALLGRIND` – Callgrind output path when profiling.
 
-`PW_LANG` – Two-letter code selecting the interface language.
+`PW_LANG` – Two-letter code selecting the interface language. See
+`docs/localization.rst` for details on adding or updating translations.
 
 ## CLI Tools
 

--- a/docs/localization.rst
+++ b/docs/localization.rst
@@ -1,0 +1,24 @@
+Localization
+============
+.. note::
+   Please read the legal notice in the project `README.md` before using PiWardrive.
+
+PiWardrive translates interface labels using JSON files under ``locales/``.
+Each file is named after a two-letter ISO 639-1 code such as ``en.json`` or
+``es.json``.  ``PW_LANG`` selects the desired language at runtime and defaults
+to ``en``.
+
+Adding a Language
+-----------------
+
+1. Copy ``locales/en.json`` to ``<code>.json`` where ``<code>`` is the new
+   language code. Translate the values while keeping all keys intact.
+2. Update existing locale files whenever new strings are added. ``en.json``
+   should always contain the complete set of keys.
+3. Run ``python scripts/check_locales_sync.py`` to verify that all locale
+   files share the same keys. The script exits with a non-zero status if any
+   differences are found.
+4. Set ``PW_LANG`` or call ``localization.set_locale()`` to switch languages.
+
+These steps keep the translations synchronized and avoid missing strings in the
+UI.


### PR DESCRIPTION
## Summary
- describe how to manage `locales/` files
- mention the guide in the environment variable list

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6860afdee36c83338a24c136c3536e98