### PR TITLE
Add aggregation service systemd unit example

### DIFF
--- a/docs/aggregation_service.rst
+++ b/docs/aggregation_service.rst
@@ -25,6 +25,9 @@ Enable the unit with::
 
     sudo systemctl enable --now piwardrive-aggregation.service
 
+The unit installed by the script matches ``examples/piwardrive-aggregation.service``
+which you can also copy manually into ``/etc/systemd/system/``.
+
 Endpoints
 ---------
 

--- a/examples/piwardrive-aggregation.service
+++ b/examples/piwardrive-aggregation.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=PiWardrive Aggregation Service
+After=network.target
+
+[Service]
+Type=simple
+User=pi
+WorkingDirectory=/home/pi/piwardrive
+ExecStart=/home/pi/piwardrive/agg-env/bin/python -m piwardrive.aggregation_service
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- add a sample unit file for running the aggregation service
- mention the example systemd unit in the aggregation service docs

## Testing
- `pip install flake8==7.2.0 mypy==1.16.0 bandit==1.8.5 black==25.1.0 isort==6.0.1 pytest==8.4.0`
- `flake8`
- `pytest` *(fails: 32 errors during collection)*
- `npm test` *(fails: invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6860afdb767483339f4c3801af3a5560