### PR TITLE
Add orientation calibration instructions

### DIFF
--- a/docs/orientation.rst
+++ b/docs/orientation.rst
@@ -46,10 +46,55 @@ Use :func:`orientation_sensors.update_orientation_map` to add or override
 entries. :func:`orientation_sensors.orientation_to_angle` converts an orientation
 string into a numeric angle using this mapping.
 
+
+Running ``calibrate_orientation.py``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ``calibrate-orientation`` guides you through positioning the device at
 0°, 90°, 180° and 270°.  The resulting mapping is written to
 ``orientation_map.json`` and can be applied with
 :func:`orientation_sensors.update_orientation_map`.
+
+Use the command installed with the package or execute the script from the
+repository root::
+
+    python scripts/calibrate_orientation.py --output orientation_map.json
+
+Follow the on-screen instructions and press Enter after placing the device
+at each angle. A typical session without sensors available looks like::
+
+    Rotate the device to 0.0 degrees and press Enter...
+    {"time": "2025-06-29 03:17:09,621", "level": "ERROR", "name": "root", "message": "Orientation not available, skipping"}
+    Rotate the device to 90.0 degrees and press Enter...
+    {"time": "2025-06-29 03:17:10,757", "level": "ERROR", "name": "root", "message": "Orientation not available, skipping"}
+    Rotate the device to 180.0 degrees and press Enter...
+    {"time": "2025-06-29 03:17:11,545", "level": "ERROR", "name": "root", "message": "Orientation not available, skipping"}
+    Rotate the device to 270.0 degrees and press Enter...
+    {"time": "2025-06-29 03:17:12,404", "level": "ERROR", "name": "root", "message": "Orientation not available, skipping"}
+    {"time": "2025-06-29 03:17:12,407", "level": "INFO", "name": "root", "message": "Saved mapping to orientation_map.json"}
+
+The resulting JSON contains the orientation-to-angle mapping::
+
+    {
+      "normal": 0.0,
+      "bottom-up": 180.0,
+      "right-up": 90.0,
+      "left-up": 270.0,
+      "portrait": 0.0,
+      "portrait-upside-down": 180.0,
+      "landscape-left": 90.0,
+      "landscape-right": 270.0,
+      "upside-down": 180.0
+    }
+
+Load this mapping in your application and activate it with
+:func:`orientation_sensors.update_orientation_map`::
+
+    import json
+    from piwardrive import orientation_sensors as osens
+
+    with open("orientation_map.json") as fh:
+        custom_map = json.load(fh)
+    osens.update_orientation_map(custom_map, clear=True)
 
 Refer to :func:`orientation_sensors.get_orientation_dbus` and
 :func:`orientation_sensors.read_mpu6050` for reading the sensor values.


### PR DESCRIPTION
## Summary
- add a new section in `orientation.rst` explaining how to run `calibrate_orientation.py`
- show example output from a run and how to load the JSON mapping

## Testing
- `pytest -q` *(fails: 23 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6860afd6532c8333b12a79c6bcdabba5