### PR TITLE
Add configuration schema generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,7 +447,8 @@ Settings persist in `~/.config/piwardrive/config.json`. Profiles under
 selected via the `PW_PROFILE_NAME` environment variable. Environment variables
 prefixed with `PW_` override any option. See `docs/configuration.rst` and the
 [Configuration Overrides](docs/environment.rst#configuration-overrides) section
-for a full list.
+for a full list. A JSON schema describing all fields is provided at
+`docs/config_schema.json`.
 
 ## Additional Documentation
 

--- a/docs/config_schema.json
+++ b/docs/config_schema.json
@@ -1,0 +1,552 @@
+{
+  "$defs": {
+    "Theme": {
+      "description": "Available UI themes.",
+      "enum": [
+        "Dark",
+        "Light",
+        "Green",
+        "Red"
+      ],
+      "title": "Theme",
+      "type": "string"
+    }
+  },
+  "description": "Extended validation used by :func:`validate_config_data`.",
+  "properties": {
+    "theme": {
+      "$ref": "#/$defs/Theme"
+    },
+    "map_poll_gps": {
+      "exclusiveMinimum": 0,
+      "title": "Map Poll Gps",
+      "type": "integer"
+    },
+    "map_poll_gps_max": {
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Map Poll Gps Max"
+    },
+    "map_poll_aps": {
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Map Poll Aps"
+    },
+    "map_poll_wigle": {
+      "default": 0,
+      "minimum": 0,
+      "title": "Map Poll Wigle",
+      "type": "integer"
+    },
+    "map_show_gps": {
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Map Show Gps"
+    },
+    "map_follow_gps": {
+      "default": true,
+      "title": "Map Follow Gps",
+      "type": "boolean"
+    },
+    "map_show_aps": {
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Map Show Aps"
+    },
+    "map_cluster_aps": {
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Map Cluster Aps"
+    },
+    "map_show_heatmap": {
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Map Show Heatmap"
+    },
+    "map_show_wigle": {
+      "default": false,
+      "title": "Map Show Wigle",
+      "type": "boolean"
+    },
+    "map_cluster_capacity": {
+      "default": 8,
+      "minimum": 1,
+      "title": "Map Cluster Capacity",
+      "type": "integer"
+    },
+    "map_use_offline": {
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Map Use Offline"
+    },
+    "map_auto_prefetch": {
+      "default": false,
+      "title": "Map Auto Prefetch",
+      "type": "boolean"
+    },
+    "disable_scanning": {
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Disable Scanning"
+    },
+    "kismet_logdir": {
+      "anyOf": [
+        {
+          "minLength": 1,
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Kismet Logdir"
+    },
+    "bettercap_caplet": {
+      "anyOf": [
+        {
+          "minLength": 1,
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Bettercap Caplet"
+    },
+    "dashboard_layout": {
+      "items": {},
+      "title": "Dashboard Layout",
+      "type": "array"
+    },
+    "debug_mode": {
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Debug Mode"
+    },
+    "offline_tile_path": {
+      "anyOf": [
+        {
+          "minLength": 1,
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Offline Tile Path"
+    },
+    "health_poll_interval": {
+      "anyOf": [
+        {
+          "minimum": 1,
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Health Poll Interval"
+    },
+    "log_rotate_interval": {
+      "anyOf": [
+        {
+          "minimum": 1,
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Log Rotate Interval"
+    },
+    "log_rotate_archives": {
+      "anyOf": [
+        {
+          "minimum": 1,
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Log Rotate Archives"
+    },
+    "cleanup_rotated_logs": {
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Cleanup Rotated Logs"
+    },
+    "reports_dir": {
+      "default": "/root/.config/piwardrive/reports",
+      "title": "Reports Dir",
+      "type": "string"
+    },
+    "health_export_interval": {
+      "default": 6,
+      "minimum": 1,
+      "title": "Health Export Interval",
+      "type": "integer"
+    },
+    "health_export_dir": {
+      "default": "/root/.config/piwardrive/health_exports",
+      "title": "Health Export Dir",
+      "type": "string"
+    },
+    "compress_health_exports": {
+      "default": true,
+      "title": "Compress Health Exports",
+      "type": "boolean"
+    },
+    "health_export_retention": {
+      "default": 7,
+      "minimum": 1,
+      "title": "Health Export Retention",
+      "type": "integer"
+    },
+    "tile_maintenance_interval": {
+      "anyOf": [
+        {
+          "minimum": 1,
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Tile Maintenance Interval"
+    },
+    "tile_max_age_days": {
+      "anyOf": [
+        {
+          "minimum": 1,
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Tile Max Age Days"
+    },
+    "tile_cache_limit_mb": {
+      "anyOf": [
+        {
+          "minimum": 1,
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Tile Cache Limit Mb"
+    },
+    "compress_offline_tiles": {
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Compress Offline Tiles"
+    },
+    "route_prefetch_interval": {
+      "anyOf": [
+        {
+          "minimum": 1,
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Route Prefetch Interval"
+    },
+    "route_prefetch_lookahead": {
+      "anyOf": [
+        {
+          "minimum": 1,
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Route Prefetch Lookahead"
+    },
+    "widget_battery_status": {
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Widget Battery Status"
+    },
+    "log_paths": {
+      "items": {
+        "type": "string"
+      },
+      "title": "Log Paths",
+      "type": "array"
+    },
+    "ui_font_size": {
+      "default": 16,
+      "minimum": 1,
+      "title": "Ui Font Size",
+      "type": "integer"
+    },
+    "admin_password_hash": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": "",
+      "title": "Admin Password Hash"
+    },
+    "remote_sync_url": {
+      "anyOf": [
+        {
+          "minLength": 1,
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Remote Sync Url"
+    },
+    "remote_sync_token": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Remote Sync Token"
+    },
+    "remote_sync_timeout": {
+      "anyOf": [
+        {
+          "minimum": 1,
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Remote Sync Timeout"
+    },
+    "remote_sync_retries": {
+      "anyOf": [
+        {
+          "minimum": 1,
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Remote Sync Retries"
+    },
+    "remote_sync_interval": {
+      "anyOf": [
+        {
+          "minimum": 1,
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Remote Sync Interval"
+    },
+    "handshake_cache_seconds": {
+      "default": 10.0,
+      "minimum": 0,
+      "title": "Handshake Cache Seconds",
+      "type": "number"
+    },
+    "log_tail_cache_seconds": {
+      "default": 1.0,
+      "minimum": 0,
+      "title": "Log Tail Cache Seconds",
+      "type": "number"
+    },
+    "wigle_api_name": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Wigle Api Name"
+    },
+    "wigle_api_key": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Wigle Api Key"
+    },
+    "gps_movement_threshold": {
+      "anyOf": [
+        {
+          "exclusiveMinimum": 0,
+          "type": "number"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Gps Movement Threshold"
+    },
+    "cloud_bucket": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Cloud Bucket"
+    },
+    "cloud_prefix": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Cloud Prefix"
+    },
+    "cloud_profile": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Cloud Profile"
+    }
+  },
+  "required": [
+    "theme",
+    "map_poll_gps"
+  ],
+  "title": "ConfigModel",
+  "type": "object"
+}

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -28,7 +28,8 @@ Log paths shown in the console screen can be customised via the ``log_paths``
 list.  Provide a JSON array in ``config.json`` or set ``PW_LOG_PATHS`` to a
 JSON encoded list to override the defaults.
 
-See :mod:`config` for defaults and helpers.
+See :mod:`config` for defaults and helpers. A machine-readable schema of all
+fields lives in :download:`config_schema.json <config_schema.json>`.
 
 Environment variables are parsed on startup. Any option in ``Config`` can be
 specified as ``PW_<OPTION>``. Boolean variables accept ``1`` or ``0`` while

--- a/scripts/generate_config_schema.py
+++ b/scripts/generate_config_schema.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+"""Generate JSON schema for :class:`piwardrive.core.config.ConfigModel`."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from piwardrive.core.config import ConfigModel
+
+
+def main(dest: str = "docs/config_schema.json") -> None:
+    """Write ConfigModel schema to ``dest``."""
+    schema = ConfigModel.model_json_schema()
+    Path(dest).write_text(json.dumps(schema, indent=2))
+
+
+if __name__ == "__main__":  # pragma: no cover - manual use
+    main()


### PR DESCRIPTION
## Summary
- add script to generate JSON schema for ConfigModel
- provide docs/config_schema.json
- document schema link in docs and README

## Testing
- `pytest tests/test_config.py::test_load_config_schema_violation -q`
- `pytest tests/test_config.py::test_load_config_defaults_when_missing -q`
- `pytest tests/test_config_validation.py::test_invalid_env_value -q`


------
https://chatgpt.com/codex/tasks/task_e_6860afd1e968833380616b18a1450edf