### PR TITLE
Add docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,22 @@
+name: Build Docs
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+
+      - name: Install Sphinx
+        run: pip install sphinx
+
+      - name: Build documentation
+        run: SPHINXOPTS="-W" make -C docs html


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow to build documentation with Sphinx

## Testing
- `pre-commit run --files .github/workflows/docs.yml` *(fails: InvalidConfigError)*
- `pytest -q` *(fails: ModuleNotFoundError: numpy)*

------
https://chatgpt.com/codex/tasks/task_e_6860afcf79808333abb6734be13624c5