### PR TITLE
Add orientation map example

### DIFF
--- a/docs/orientation.rst
+++ b/docs/orientation.rst
@@ -49,7 +49,8 @@ string into a numeric angle using this mapping.
 ``calibrate-orientation`` guides you through positioning the device at
 0°, 90°, 180° and 270°.  The resulting mapping is written to
 ``orientation_map.json`` and can be applied with
-:func:`orientation_sensors.update_orientation_map`.
+:func:`orientation_sensors.update_orientation_map`.  See
+``examples/orientation_map.json`` for a typical mapping.
 
 Refer to :func:`orientation_sensors.get_orientation_dbus` and
 :func:`orientation_sensors.read_mpu6050` for reading the sensor values.

--- a/examples/orientation_map.json
+++ b/examples/orientation_map.json
@@ -1,0 +1,11 @@
+{
+    "normal": 0.0,
+    "bottom-up": 180.0,
+    "right-up": 90.0,
+    "left-up": 270.0,
+    "portrait": 0.0,
+    "portrait-upside-down": 180.0,
+    "landscape-left": 90.0,
+    "landscape-right": 270.0,
+    "upside-down": 180.0
+}


### PR DESCRIPTION
## Summary
- add orientation_map.json under `examples/`
- reference the example file from `docs/orientation.rst`

## Testing
- `pytest tests/test_orientation_sensors.py tests/test_orientation_sensors_pkg.py -q`
- `pytest -q` *(fails: 32 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6860afd780e483338b6040e4174d484c