### PR TITLE
Expose orientation map via Node server

### DIFF
--- a/docs/orientation.rst
+++ b/docs/orientation.rst
@@ -100,3 +100,12 @@ Load this mapping in your application and activate it with
 
 Refer to :func:`orientation_sensors.get_orientation_dbus` and
 :func:`orientation_sensors.read_mpu6050` for reading the sensor values.
+
+Orientation Map Endpoint
+~~~~~~~~~~~~~~~~~~~~~~~~
+The Node-based web server exposes ``/api/orientation-map`` which simply
+returns the mapping produced by
+``orientation_sensors.clone_orientation_map()``.  This allows other
+services to retrieve the currently active orientation mapping via HTTP::
+
+   curl http://localhost:8000/api/orientation-map

--- a/server/index.js
+++ b/server/index.js
@@ -70,6 +70,21 @@ function createServer(opts = {}) {
     res.json({ widgets: parseWidgets() });
   });
 
+  app.get('/api/orientation-map', (req, res) => {
+    const script =
+      "import json, piwardrive.orientation_sensors as os; print(json.dumps(os.clone_orientation_map()))";
+    try {
+      const { spawnSync } = require('child_process');
+      const proc = spawnSync('python3', ['-c', script], { encoding: 'utf8' });
+      if (proc.status !== 0) {
+        throw new Error(proc.stderr.trim() || 'failed');
+      }
+      res.json(JSON.parse(proc.stdout));
+    } catch (err) {
+      res.status(500).json({ error: 'orientation map unavailable' });
+    }
+  });
+
   return app;
 }
 


### PR DESCRIPTION
## Summary
- add `/api/orientation-map` route that returns `orientation_sensors.clone_orientation_map()`
- document the endpoint in `orientation.rst`

## Testing
- `pre-commit run --files server/index.js docs/orientation.rst` *(fails: InvalidConfigError)*
- `pytest -q` *(fails: missing dependencies)*
- `sphinx-build -W -b html docs docs/_build/html` *(fails: warnings treated as errors)*

------
https://chatgpt.com/codex/tasks/task_e_686132cdeaf88333bc460344bc92ed93