### PR TITLE
Expand CLI docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -462,6 +462,7 @@ for a full list. A JSON schema describing all fields is provided at
 ## Additional Documentation
 
 Comprehensive guides and API references live in the `docs/` directory. Run `make html` there to build the Sphinx site. High level summaries are collected in [REFERENCE.md](REFERENCE.md).
+Detailed examples for each command line helper are available in [docs/cli_tools.rst](docs/cli_tools.rst).
 
 ## Contributing
 

--- a/docs/cli_tools.rst
+++ b/docs/cli_tools.rst
@@ -11,6 +11,10 @@ Several helper scripts are installed alongside the React dashboard and optional 
         piwardrive-prefetch 37.7 -122.5 37.8 -122.4 --zoom 15
 
     The arguments define the bounding box (``lat1 lon1 lat2 lon2``) and optional zoom level.
+    Provide ``--folder`` and ``--concurrency`` to control where tiles are saved
+    and how many downloads run in parallel::
+
+        piwardrive-prefetch 35.0 -120.2 35.1 -120.1 --folder ~/tiles --concurrency 8
 
 ``piwardrive-prefetch-batch``
     Prefetch multiple areas from a file::
@@ -18,6 +22,9 @@ Several helper scripts are installed alongside the React dashboard and optional 
         piwardrive-prefetch-batch boxes.txt --zoom 15
 
     Each line in ``boxes.txt`` should contain ``lat1 lon1 lat2 lon2``.
+    You can also specify an output folder and concurrency level::
+
+        piwardrive-prefetch-batch boxes.txt --folder ~/tiles --concurrency 4
 
 ``service-status``
     Show the active systemd services used by PiWardrive::
@@ -25,16 +32,26 @@ Several helper scripts are installed alongside the React dashboard and optional 
         service-status
 
     Returns ``active`` or ``inactive`` for ``gpsd``, ``kismet`` and ``bettercap``.
+    Pass service names as arguments to check custom units::
+
+        service-status nginx sshd
 
 ``piwardrive-service``
     Start the FastAPI status server described in :doc:`status_service`::
 
         piwardrive-service
 
+    The server listens on ``0.0.0.0:8000`` by default.
+
 ``log-follow``
     Tail a log file and print new entries to the console::
 
         log-follow /var/log/syslog
+
+    Control the number of initial lines and polling interval with ``--lines``
+    and ``--interval``::
+
+        log-follow /var/log/kismet.log --lines 20 --interval 0.5
         
 ``config-cli``
     View or modify configuration values. Operates on the local
@@ -44,11 +61,20 @@ Several helper scripts are installed alongside the React dashboard and optional 
         config-cli get theme
         config-cli set map_use_offline true
 
+    Interact with a running server by supplying its base URL::
+
+        config-cli --url http://localhost:8000 get theme
+
 ``piwardrive-maintain-tiles``
     Run cache cleanup from the command line. Combine ``--purge``,
     ``--limit`` and ``--vacuum`` to control which maintenance operations
     run::
 
         piwardrive-maintain-tiles --purge --limit --vacuum --offline offline.mbtiles
+
+    For example, delete tiles older than a week without touching the
+    MBTiles archive::
+
+        piwardrive-maintain-tiles --purge --max-age-days 7
 
 See ``--help`` on each command for additional options.


### PR DESCRIPTION
## Summary
- extend examples for each CLI command
- link CLI usage doc from README

## Testing
- `make lint` *(fails: InvalidConfigError)*
- `make test` *(fails: missing dependencies)*
- `make docs`

------
https://chatgpt.com/codex/tasks/task_e_686132d26e84833388cb6c9b367d0b6c