### PR TITLE
Add remote_sync metrics counters

### DIFF
--- a/docs/remote_sync.rst
+++ b/docs/remote_sync.rst
@@ -114,3 +114,11 @@ Example invocation::
         --url http://10.0.0.2:9000/ \
         --services piwardrive piwardrive-webui
 
+Collecting Metrics
+------------------
+
+Set the environment variable ``PW_REMOTE_SYNC_METRICS=1`` or call
+``remote_sync.enable_metrics()`` to track upload statistics. When
+enabled, ``remote_sync.get_metrics()`` returns ``success_total`` and
+``failure_total`` counters along with the duration of the last sync.
+

--- a/src/piwardrive/remote_sync.py
+++ b/src/piwardrive/remote_sync.py
@@ -15,6 +15,9 @@ aiohttp = _impl.aiohttp
 tempfile = _impl.tempfile
 json = _impl.json
 
+enable_metrics = _impl.enable_metrics
+get_metrics = _impl.get_metrics
+
 # Public logger instance used by the implementation.
 logger = _impl.logger
 


### PR DESCRIPTION
## Summary
- track success/failure totals and durations for remote sync
- re-export metrics helpers in wrapper
- document metrics in `remote_sync.rst`
- test counters

## Testing
- `pytest tests/test_remote_sync.py::test_sync_metrics_success tests/test_remote_sync.py::test_sync_metrics_failure -q`

------
https://chatgpt.com/codex/tasks/task_e_686132d83790833395fc1d3ec609a904