### PR TITLE
Add test environment startup script

### DIFF
--- a/scripts/start_test_env.sh
+++ b/scripts/start_test_env.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Launch containers/services needed for integration tests.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${SCRIPT_DIR}/.."
+
+cd "$REPO_ROOT"
+
+if ! command -v docker >/dev/null 2>&1; then
+    echo "docker is required" >&2
+    exit 1
+fi
+
+# Use docker compose (plugin or standalone)
+if command -v docker-compose >/dev/null 2>&1; then
+    compose() { docker-compose "$@"; }
+else
+    compose() { docker compose "$@"; }
+fi
+
+echo "Starting integration test environment..."
+compose up -d
+
+echo "Services are running. Stop them with 'docker compose down'."

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,17 @@
+# Integration Test Environment
+
+Some integration tests rely on services defined in `docker-compose.yml`. The
+helper script below starts the required containers in detached mode.
+
+```bash
+./scripts/start_test_env.sh
+```
+
+Run the script from the repository root before executing the tests. When finished
+stop the services with:
+
+```bash
+docker compose down
+```
+
+See `docker-compose.yml` for the list of containers started.


### PR DESCRIPTION
## Summary
- add `scripts/start_test_env.sh` to spin up containers used by integration tests
- document how to use the script in `tests/README.md`

## Testing
- `pre-commit run --files scripts/start_test_env.sh tests/README.md` *(fails: InvalidConfigError)*
- `pytest -q` *(fails: import errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_686132eecd9c833396e97c78fa369494