### PR TITLE
Add Python and Node coverage target

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,5 +18,6 @@ Use the following convenience targets during development:
 - `make lint` — run pre-commit on all files.
 - `make test` — run the Python test suite with pytest.
 - `make docs` — build the Sphinx documentation in `docs/_build/html`.
+- `make coverage` — generate combined Python and Node test coverage reports.
 
 Contributions should pass these checks before you submit a pull request.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: lint test docs
+.PHONY: lint test docs coverage
 
 lint:
 	pre-commit run --all-files
@@ -8,3 +8,7 @@ test:
 
 docs:
 	sphinx-build -W -b html docs docs/_build/html
+
+coverage:
+	pytest --cov=src --cov-report=xml -q
+	cd webui && npm test


### PR DESCRIPTION
## Summary
- add new `coverage` target to run Python and Node coverage
- document it in `CONTRIBUTING.md`

## Testing
- `make lint` *(fails: pre-commit not installed)*
- `make test` *(fails: errors during test collection)*
- `make coverage` *(fails: pytest could not load coverage plugin)*

------
https://chatgpt.com/codex/tasks/task_e_686132ece190833389f45541106565ad