### PR TITLE
Improve widget parser using Python AST

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -33,13 +33,22 @@ function basicAuth(req, res, next) {
 }
 
 function parseWidgets() {
-  const file = path.join(__dirname, '..', 'src', 'piwardrive', 'widgets', '__init__.py');
+  const file = path.join(
+    __dirname,
+    '..',
+    'src',
+    'piwardrive',
+    'widgets',
+    '__init__.py',
+  );
+  const script = path.join(__dirname, 'parse_widgets.py');
   try {
-    const text = fs.readFileSync(file, 'utf8');
-    const start = text.indexOf('__all__');
-    if (start === -1) return [];
-    const section = text.slice(start, text.indexOf(']', start));
-    return Array.from(section.matchAll(/"([^"]+)"/g)).map(m => m[1]);
+    const { spawnSync } = require('child_process');
+    const proc = spawnSync('python3', [script, file], { encoding: 'utf8' });
+    if (proc.status !== 0) {
+      throw new Error(proc.stderr.trim() || 'failed');
+    }
+    return JSON.parse(proc.stdout);
   } catch {
     return [];
   }

--- a/server/parse_widgets.py
+++ b/server/parse_widgets.py
@@ -1,0 +1,29 @@
+import ast
+import json
+import sys
+
+path = sys.argv[1]
+with open(path, 'r') as f:
+    tree = ast.parse(f.read(), filename=path)
+widgets = []
+for node in tree.body:
+    value = None
+    if isinstance(node, ast.Assign):
+        for target in node.targets:
+            if isinstance(target, ast.Name) and target.id == '__all__':
+                value = node.value
+                break
+    elif isinstance(node, ast.AnnAssign):
+        if isinstance(node.target, ast.Name) and node.target.id == '__all__':
+            value = node.value
+    if value is not None:
+        try:
+            widgets = ast.literal_eval(value)
+        except Exception:
+            widgets = []
+        break
+if not isinstance(widgets, list):
+    widgets = []
+widgets = [str(x) for x in widgets]
+print(json.dumps(widgets))
+

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -28,3 +28,26 @@ test('serves contents from PW_HEALTH_FILE', async () => {
     delete process.env.PW_HEALTH_FILE;
   }
 });
+
+function loadWidgets() {
+  const script = path.join(__dirname, '..', 'server', 'parse_widgets.py');
+  const file = path.join(__dirname, '..', 'src', 'piwardrive', 'widgets', '__init__.py');
+  const { spawnSync } = require('child_process');
+  const proc = spawnSync('python3', [script, file], { encoding: 'utf8' });
+  if (proc.status !== 0) throw new Error(proc.stderr.trim() || 'failed');
+  return JSON.parse(proc.stdout);
+}
+
+test('serves widget list', async () => {
+  const app = createServer();
+  const server = app.listen(0);
+  const url = `http://127.0.0.1:${server.address().port}/api/widgets`;
+  try {
+    const res = await fetch(url);
+    assert.equal(res.status, 200);
+    const data = await res.json();
+    assert.deepStrictEqual(data.widgets, loadWidgets());
+  } finally {
+    server.close();
+  }
+});


### PR DESCRIPTION
## Summary
- parse widgets using a small Python helper invoked from Node
- add a Python script to read `__all__` with `ast.literal_eval`
- test server `/api/widgets` endpoint using parsed list

## Testing
- `node --test tests/server.test.js`

------
https://chatgpt.com/codex/tasks/task_e_6861363c8b588333b4d036109bca2a0e