### PR TITLE
Fix flake8 blank line issues

### DIFF
--- a/main.py
+++ b/main.py
@@ -13,4 +13,3 @@ from piwardrive.main import PiWardriveApp  # noqa: E402
 
 
 __all__ = ["PiWardriveApp"]
-

--- a/src/piwardrive/main.py
+++ b/src/piwardrive/main.py
@@ -90,7 +90,6 @@ class PiWardriveApp:
             CONFIG_PATH, lambda: self._reload_config_event(0)
         )
 
-
     async def export_logs(self, path: str | None = None, lines: int = 200) -> str:
         """Write the last ``lines`` from ``app.log`` to ``path`` and return it."""
         from logconfig import DEFAULT_LOG_PATH

--- a/src/remote_sync/__init__.py
+++ b/src/remote_sync/__init__.py
@@ -14,7 +14,13 @@ import aiohttp
 
 logger = logging.getLogger(__name__)
 
-_METRICS_ENABLED = os.getenv("PW_REMOTE_SYNC_METRICS") not in {None, "", "0", "false", "False"}
+_METRICS_ENABLED = os.getenv("PW_REMOTE_SYNC_METRICS") not in {
+    None,
+    "",
+    "0",
+    "false",
+    "False",
+}
 _SUCCESS_TOTAL = 0
 _FAILURE_TOTAL = 0
 _LAST_DURATION = float("nan")


### PR DESCRIPTION
## Summary
- remove trailing blank line in `main.py`
- tidy up spacing for `export_logs` function in `src/piwardrive/main.py`
- split long constant definition in `src/remote_sync/__init__.py`

## Testing
- `flake8`

------
https://chatgpt.com/codex/tasks/task_e_6861363d7a9c8333b03f5df048143b5b