### PR TITLE
Refactor export helpers and heatmap logic

### DIFF
--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -99,3 +99,17 @@ def test_export_map_kml(tmp_path) -> None:
 
     with zipfile.ZipFile(kmz) as zf:
         assert "doc.kml" in zf.namelist()
+
+
+def test_export_map_kml_compute_position(tmp_path) -> None:
+    aps = [{
+        "ssid": "A",
+        "observations": [
+            {"lat": 1.0, "lon": 1.0, "rssi": -30},
+            {"lat": 2.0, "lon": 2.0, "rssi": -40},
+        ],
+    }]
+    out = tmp_path / "pos.kml"
+    exp.export_map_kml([], aps, [], str(out), compute_position=True)
+    text = out.read_text()
+    assert "1.428571" in text

--- a/tests/test_heatmap.py
+++ b/tests/test_heatmap.py
@@ -21,8 +21,7 @@ def test_histogram_points():
     hist = [[0, 1], [2, 0]]
     pts = heatmap.histogram_points(hist, (0.0, 1.0), (0.0, 1.0))
     assert len(pts) == 2
-    values = {(round(lat, 1), round(lon, 1), cnt) for lat, lon, cnt in pts}
-    assert (0.75, 0.25, 2) in values or (0.25, 0.75, 1) in values
+    assert set(pts) == {(0.25, 0.75, 1), (0.75, 0.25, 2)}
 
 
 def test_density_map_expands_counts():


### PR DESCRIPTION
## Summary
- refactor heatmap helpers and reduce complexity
- simplify record filtering and shapefile/KML exporters
- add compute_position test and adjust histogram_points expectations

## Testing
- `pytest tests/test_export.py tests/test_heatmap.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6861363ec4448333b3aaf7f111c4a928