### PR TITLE
Document optional test dependencies

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,10 @@ pip install -r requirements-dev.txt
 pre-commit install
 ```
 
+Some tests rely on additional scientific packages such as `numpy`, `pandas`
+and `scikit-learn`. Install them via `pip install .[tests]` (or
+`pip install -r requirements.txt`) if you plan to run the full suite.
+
 ## Running checks
 
 Use the following convenience targets during development:

--- a/README.md
+++ b/README.md
@@ -471,6 +471,9 @@ Install the development dependencies and run the tests:
 ```bash
 pip install -r requirements.txt
 pip install -r requirements-dev.txt
+# Some tests rely on additional scientific libraries such as `numpy`.
+# Install them with the optional `tests` extras if needed:
+# pip install .[tests]
 pre-commit run --all-files
 pytest
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,12 @@ c-extensions = [
     "orjson",
     "ujson",
 ]
+tests = [
+    "numpy",
+    "pandas",
+    "scikit-learn",
+    "scipy",
+]
 
 
 


### PR DESCRIPTION
## Summary
- mention extra packages like numpy required by some tests
- add `tests` optional dependency group

## Testing
- `pytest tests/test_kalman.py::test_kalman_filter_reduces_variance -q`

------
https://chatgpt.com/codex/tasks/task_e_6861364055a4833384a848d78634ed7d