### PR TITLE
Deprecate Kivy GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,19 +29,19 @@ graph LR
 - Import from `piwardrive` directly when running tools or tests.
 
 ## Data Inputs
+
 - Kismet
 - Bettercap
 - GPSD
 - SDR
 - Orientation sensors (gyroscope, accelerometer, OBD‑II adapter)
-  - ``dbus`` + ``iio-sensor-proxy`` or an external MPU‑6050 are optional;
+  - `dbus` + `iio-sensor-proxy` or an external MPU‑6050 are optional;
     the app falls back gracefully when absent
   - Wi-Fi scans record the current antenna heading along with RSSI when
     orientation data is available
 
-
-
 ## U/I Features
+
 - Service controls for Kismet and BetterCAP
 - Interactive map with offline tile prefetch and rotation
 - Predictive route tile caching
@@ -56,15 +56,15 @@ graph LR
 - Plugin widgets dynamically loaded in the web UI
 - Offline-capable PWA frontend
 
-
 ## Data Handling
+
 - Multi-format exports (GPX/KML/CSV/JSON/GeoJSON/Shapefile)
 - Diagnostics and log rotation. See `docs/logging.rst` for log levels and file locations.
 - Remote database sync (`remote_sync.py`) with a central aggregation service
   for combined statistics and map overlays
 - Observations stored in SQLite for later analysis
 - CLI SIGINT tools under `src/piwardrive/sigint_suite/` (set `SIGINT_DEBUG=1` for debug logs)
-  
+
 The scheduler drives periodic tasks while diagnostics records system health. Screens host widgets that show metrics on the dashboard, while helper routines control external services like Kismet and BetterCAP.
 
 ### Scanning and Logging
@@ -108,19 +108,21 @@ sequenceDiagram
     Clock-->>Scheduler: event handle
 ```
 
-Schedulers expose basic metrics via ``get_metrics()`` including the next
+Schedulers expose basic metrics via `get_metrics()` including the next
 scheduled run time and duration of the last callback execution. These values
 aid troubleshooting periodic jobs during development.
 
 ## Quick Start
 
 ### Hardware
+
 - Raspberry Pi 5 with 7" touchscreen
 - SSD mounted at `/mnt/ssd`
 - GPS dongle on `/dev/ttyACM0`
 - External Wi-Fi adapter (monitor mode)
 
 ### Software
+
 - Raspberry Pi OS Bookworm or Bullseye
 - Python 3.10+
 - System packages: `kismet`, `gpsd`, `bettercap`, `evtest`, `git`, `build-essential`, `cmake`
@@ -138,7 +140,6 @@ sudo apt update
 sudo apt install -y r-base r-base-dev
 
 ```
-
 
 #### Quickstart Script
 
@@ -159,39 +160,45 @@ source gui-env/bin/activate
    sudo apt update && sudo apt install -y \
        git build-essential cmake kismet bettercap gpsd evtest python3-venv
    ```
+
 3. Clone the repository and switch into the project directory:
 
    ```bash
    git clone git@github.com:Trashytalk/piwardrive.git
    cd piwardrive
    ```
+
 4. Create and activate the virtual environment:
 
    ```bash
    python3 -m venv gui-env
    source gui-env/bin/activate
    ```
+
 5. Install Python dependencies and the project itself:
 
    ```bash
    pip install -r requirements.txt
    pip install .
    ```
+
 6. (Optional) mount an external SSD by editing `/etc/fstab`::
 
-   /dev/sda1  /mnt/ssd  ext4  defaults,nofail  0  2
+   /dev/sda1 /mnt/ssd ext4 defaults,nofail 0 2
 
 7. Enable `kismet`, `bettercap` and `gpsd` to start on boot:
 
    ```bash
    sudo systemctl enable kismet bettercap gpsd
    ```
+
 8. (Optional) copy `examples/piwardrive.service` into `/etc/systemd/system/` and enable it to run the API on boot:
 
    ```bash
    sudo cp examples/piwardrive.service /etc/systemd/system/
    sudo systemctl enable --now piwardrive.service
    ```
+
 9. Start the application manually if the service is not enabled:
 
    ```bash
@@ -215,6 +222,7 @@ Activate the virtual environment and run `pip install <package>` for any that ap
 Follow these steps to configure the Python and React development environment.
 
 1. **Enter your project directory**
+
    ```bash
    cd ~/piwardrive
    ```
@@ -232,24 +240,28 @@ Follow these steps to configure the Python and React development environment.
 
 > PiWardrive's frontend and tests rely on **Node.js 18+**. Verify the tools
 > are installed and meet the version requirement:
+>
 > ```bash
 > node --version
 > npm --version
 > ```
 
 3. **Create and activate a Python venv**
+
    ```bash
    python3 -m venv venv
    source venv/bin/activate
    ```
 
 4. **Upgrade pip/setuptools and install Python deps**
+
    ```bash
    pip install --upgrade pip setuptools wheel meson ninja
    pip install -r requirements.txt
    ```
 
 5. **Build the React frontend**
+
    ```bash
    cd webui
    npm install         # only on first run or when package.json changes
@@ -258,16 +270,19 @@ Follow these steps to configure the Python and React development environment.
    ```
 
 6. **Install the package in editable mode**
+
    ```bash
    pip install --editable .
    ```
 
 7. **Start the ASGI server**
+
    ```bash
    uvicorn piwardrive.webui_server:app --reload
    ```
 
 8. **Verify**
+
    ```bash
    # Visit the React UI
    http://127.0.0.1:8000/
@@ -291,8 +306,8 @@ npm start  # starts the Node server
 # or use the Python version
 # python -m piwardrive.webui_server
 ```
-To autostart the dashboard on boot copy `examples/piwardrive-webui.service` into `/etc/systemd/system/` and enable it with `sudo systemctl enable --now piwardrive-webui.service`.
 
+To autostart the dashboard on boot copy `examples/piwardrive-webui.service` into `/etc/systemd/system/` and enable it with `sudo systemctl enable --now piwardrive-webui.service`.
 
 Alternatively serve `webui/dist` with any webserver while running
 `piwardrive-service` for the API. During development you can run
@@ -305,15 +320,17 @@ Launch Chromium in kiosk mode with the helper command:
 ```bash
 piwardrive-kiosk
 ```
+
 The command runs `piwardrive-webui` in the background and opens Chromium with
 `--kiosk` pointing to the dashboard. Chromium must run inside a graphical
-environment. Ensure an X server is available and ``$DISPLAY`` is set.
-Headless setups can use ``Xvfb``.
+environment. Ensure an X server is available and `$DISPLAY` is set.
+Headless setups can use `Xvfb`.
 
-Combine the web UI service with the example ``kiosk.service`` unit to
+Combine the web UI service with the example `kiosk.service` unit to
 launch the browser automatically on boot. This setup fully replaces the
-on-device Kivy GUI so the Pi's touch screen displays the React dashboard
-in full‑screen mode.
+legacy Kivy GUI so the Pi's touch screen displays the React dashboard in
+full‑screen mode. The Kivy interface is deprecated and no longer
+maintained.
 
 ### Optional C Extensions
 
@@ -351,25 +368,24 @@ configuration and compiled assets persist between container restarts.
 
 #### Automated Aspects
 
-* **Health Monitoring & Log Rotation** – `HealthMonitor` polls `diagnostics.self_test()` on a schedule while `rotate_logs` trims old log files automatically.
-* **Tile Cache Maintenance** – stale tiles are purged and MBTiles databases vacuumed at intervals defined by `tile_maintenance_interval`.
-* **Configuration Reloads** – a filesystem watcher detects updates to `config.json` and applies them along with any `PW_` overrides without restarting.
-* **Plugin Discovery** – new widgets placed under `~/.config/piwardrive/plugins` are loaded automatically on startup. The `/plugins` API route lists any discovered classes so you can verify custom widgets were detected.
+- **Health Monitoring & Log Rotation** – `HealthMonitor` polls `diagnostics.self_test()` on a schedule while `rotate_logs` trims old log files automatically.
+- **Tile Cache Maintenance** – stale tiles are purged and MBTiles databases vacuumed at intervals defined by `tile_maintenance_interval`.
+- **Configuration Reloads** – a filesystem watcher detects updates to `config.json` and applies them along with any `PW_` overrides without restarting.
+- **Plugin Discovery** – new widgets placed under `~/.config/piwardrive/plugins` are loaded automatically on startup. The `/plugins` API route lists any discovered classes so you can verify custom widgets were detected.
 
 #### Manual Steps
 
-* **Installation** – run `scripts/quickstart.sh` or follow the manual steps to clone the repo, create a virtualenv and install dependencies.
-* **Launching the App** – activate the environment and start PiWardrive with `python -m piwardrive.main`.
-* **Systemd Service Setup** – copy `examples/piwardrive.service` to `/etc/systemd/system/` and enable it with `sudo systemctl enable --now piwardrive.service` to launch the backend on boot.
-* **Running the Status API** – start the FastAPI service manually with `piwardrive-service` to expose remote metrics.
-* **Browser Kiosk Mode** – build the React frontend (see above) and launch it with `piwardrive-kiosk` to start the server and open Chromium automatically.
-* **Map Tile Prefetch** – use `piwardrive-prefetch` to download map tiles without launching the dashboard.
-* **Syncing Data** – set `remote_sync_url` (and optionally `remote_sync_interval`)
+- **Installation** – run `scripts/quickstart.sh` or follow the manual steps to clone the repo, create a virtualenv and install dependencies.
+- **Launching the App** – activate the environment and start PiWardrive with `python -m piwardrive.main`.
+- **Systemd Service Setup** – copy `examples/piwardrive.service` to `/etc/systemd/system/` and enable it with `sudo systemctl enable --now piwardrive.service` to launch the backend on boot.
+- **Running the Status API** – start the FastAPI service manually with `piwardrive-service` to expose remote metrics.
+- **Browser Kiosk Mode** – build the React frontend (see above) and launch it with `piwardrive-kiosk` to start the server and open Chromium automatically.
+- **Map Tile Prefetch** – use `piwardrive-prefetch` to download map tiles without launching the dashboard.
+- **Syncing Data** – set `remote_sync_url` (and optionally `remote_sync_interval`)
   in `~/.config/piwardrive/config.json` and trigger uploads via `/sync` or call
   `remote_sync.sync_database_to_server` directly.
-* **Offline Vector Tile Customizer** – `piwardrive-mbtiles` builds and styles offline tile sets.
-* **Configuration Wizard** – run `python -m piwardrive.setup_wizard` to interactively create profiles or edit `~/.config/piwardrive/config.json` by hand.
-
+- **Offline Vector Tile Customizer** – `piwardrive-mbtiles` builds and styles offline tile sets.
+- **Configuration Wizard** – run `python -m piwardrive.setup_wizard` to interactively create profiles or edit `~/.config/piwardrive/config.json` by hand.
 
 ### Example systemd unit
 
@@ -392,12 +408,14 @@ WantedBy=multi-user.target
 ## Kiosk Setup on Pi OS Lite
 
 1. **Install prerequisites**
+
    ```bash
    sudo apt update
    sudo apt install -y xserver-xorg xinit matchbox-window-manager chromium-browser
    ```
 
 2. **Create `~/kiosk.sh`**
+
    ```bash
    #!/bin/sh
    xset -dpms
@@ -407,6 +425,7 @@ WantedBy=multi-user.target
    ```
 
 3. **Create `~/.xsession`**
+
    ```bash
    exec sh /home/pi/kiosk.sh
    ```
@@ -417,6 +436,7 @@ WantedBy=multi-user.target
    `~/.xsession` and in turn launches Chromium in kiosk mode.
 
 5. **(Optional) `piwardrive.service`**
+
    ```ini
    [Unit]
    Description=PiWardrive Backend
@@ -434,6 +454,7 @@ WantedBy=multi-user.target
    ```
 
 6. **Enable services and reboot**
+
    ```bash
    sudo systemctl enable kiosk.service
    sudo systemctl enable piwardrive.service  # optional

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -4,7 +4,7 @@ This document consolidates the key information from `README.md`, the `piwardrive
 
 ## Overview
 
-PiWardrive provides a headless mapping and diagnostic interface delivered through a React dashboard. Kivy/KivyMD remains available for touchscreen deployments but the web UI is now the default. Start it with ``python -m piwardrive.webui_server`` after building the frontend. PiWardrive manages Wi‑Fi and Bluetooth scanning via Kismet and BetterCAP while polling GPS data and system metrics. Structured logs default to `~/.config/piwardrive/app.log` but `logconfig.setup_logging` can also output to `stdout` or additional handlers. A lightweight SIGINT suite for command-line scanning lives under `src/piwardrive/sigint_suite/`.
+PiWardrive provides a headless mapping and diagnostic interface delivered through a React dashboard. The old Kivy/KivyMD GUI is deprecated and no longer maintained—the React web UI is the only supported interface. Start it with `python -m piwardrive.webui_server` after building the frontend. PiWardrive manages Wi‑Fi and Bluetooth scanning via Kismet and BetterCAP while polling GPS data and system metrics. Structured logs default to `~/.config/piwardrive/app.log` but `logconfig.setup_logging` can also output to `stdout` or additional handlers. A lightweight SIGINT suite for command-line scanning lives under `src/piwardrive/sigint_suite/`.
 
 ## Hardware and OS Requirements
 
@@ -52,6 +52,7 @@ cd ~/piwardrive
 source gui-env/bin/activate
 piwardrive
 ```
+
 The UI renders directly to the framebuffer without X. Use the top tabs to switch between Map, Stats, Split, Console, Settings and Dashboard screens. Widgets can be dragged on the Dashboard and their layout is persisted.
 
 ## Widgets and Plugins
@@ -67,23 +68,24 @@ The `diagnostics` module gathers system metrics and rotates logs according to th
 
 Running `piwardrive-service` starts a FastAPI server on `0.0.0.0:8000`. The `/status` endpoint returns recent health records and `/logs` tails the configured log file (`app.log` by default). Set `PW_API_PASSWORD_HASH` to require HTTP basic authentication. The optional React frontend under `webui/` consumes this API and can be built with `npm run build`.
 
-
 ## GPS and Bluetooth Polling
 
 The application polls `gpsd` at a configurable interval, increasing the delay when movement stops to conserve power. Bluetooth scanning is also optional and can be toggled or scheduled via configuration variables.
 
 ## Mobile Builds
 
-PiWardrive no longer distributes helper scripts or configuration for building mobile packages. Previous Buildozer and `kivy-ios` setups have been removed.
+PiWardrive no longer distributes helper scripts or configuration for building mobile packages. The former Kivy-based tooling has been removed.
 
 ## Building the CKML Extension
 
 The project includes small C extensions `ckml` and `cgeom`. Build them with:
+
 ```bash
 pip install build
 python -m build
 pip install dist/*.whl
 ```
+
 See `docs/ckml_build.rst` for troubleshooting compiler issues.
 
 ## R Integration
@@ -109,8 +111,7 @@ The `docs/` directory contains mermaid diagrams showing scanning, logging and di
 
 ## SIGINT Suite
 
-Under `src/piwardrive/sigint_suite/` you will find lightweight command-line tools for scanning Wi‑Fi and Bluetooth. The `src/piwardrive/sigint_suite/scripts/start_imsi_mode.sh` helper runs one Wi‑Fi and Bluetooth scan and writes JSON results under `src/piwardrive/sigint_suite/exports/`. Override `EXPORT_DIR` to change the location. Ensure `iwlist` and either `bluetoothctl` or the Python ``bleak`` library are installed (`./src/piwardrive/sigint_suite/scripts/setup_all.sh` can install them).
-
+Under `src/piwardrive/sigint_suite/` you will find lightweight command-line tools for scanning Wi‑Fi and Bluetooth. The `src/piwardrive/sigint_suite/scripts/start_imsi_mode.sh` helper runs one Wi‑Fi and Bluetooth scan and writes JSON results under `src/piwardrive/sigint_suite/exports/`. Override `EXPORT_DIR` to change the location. Ensure `iwlist` and either `bluetoothctl` or the Python `bleak` library are installed (`./src/piwardrive/sigint_suite/scripts/setup_all.sh` can install them).
 
 ## Environment Variables
 
@@ -193,16 +194,16 @@ The application recognises numerous `PW_*` variables. Any option in `config.py` 
 
 Several entry points are installed with the package:
 
-- ``piwardrive-prefetch`` – Download map tiles for a bounding box without starting the GUI. Example::
+- `piwardrive-prefetch` – Download map tiles for a bounding box without starting the GUI. Example::
 
-    piwardrive-prefetch 37.7 -122.5 37.8 -122.4 --zoom 15
+  piwardrive-prefetch 37.7 -122.5 37.8 -122.4 --zoom 15
 
-- ``piwardrive-prefetch-batch`` – Prefetch tiles for multiple bounding boxes from a file.
+- `piwardrive-prefetch-batch` – Prefetch tiles for multiple bounding boxes from a file.
 
-- ``service-status`` – Print the systemd state of ``gpsd``, ``kismet`` and ``bettercap``.
-- ``piwardrive-service`` – Launch the FastAPI status server (equivalent to ``python -m piwardrive.service``).
+- `service-status` – Print the systemd state of `gpsd`, `kismet` and `bettercap`.
+- `piwardrive-service` – Launch the FastAPI status server (equivalent to `python -m piwardrive.service`).
 
-Use ``--help`` on each command for additional options.
+Use `--help` on each command for additional options.
 
 ## Security
 
@@ -210,16 +211,15 @@ Password helpers in :mod:`security` derive a PBKDF2-HMAC-SHA256 hash with a rand
 
     python -c "import security,sys; print(security.hash_password(sys.argv[1]))" mypass
 
-Store the resulting hash in ``config.json`` or ``PW_ADMIN_PASSWORD_HASH`` and avoid committing plaintext secrets. ``verify_password`` recomputes the hash and returns ``True`` only on success.
-
+Store the resulting hash in `config.json` or `PW_ADMIN_PASSWORD_HASH` and avoid committing plaintext secrets. `verify_password` recomputes the hash and returns `True` only on success.
 
 ## Additional Features
 
 New modules extend PiWardrive with optional capabilities:
 
 - `remote_sync` – upload the SQLite database to a remote server using
-  ``remote_sync.sync_database_to_server``.  Configure ``remote_sync_url``,
-  ``remote_sync_timeout``, ``remote_sync_retries`` and ``remote_sync_interval`` in ``config.json``.
+  `remote_sync.sync_database_to_server`. Configure `remote_sync_url`,
+  `remote_sync_timeout`, `remote_sync_retries` and `remote_sync_interval` in `config.json`.
 - `vector_tiles` – load offline vector map tiles from MBTiles files.
 - `vector_tile_customizer` – build and style MBTiles for offline use.
 - `network_analytics` – heuristics to flag suspicious Wi‑Fi access points, such
@@ -232,7 +232,7 @@ New modules extend PiWardrive with optional capabilities:
 - `cloud_export` – helper to upload files to AWS S3 via the CLI.
 - `vehicle_sensors` – read speed, RPM and engine load from an OBD‑II adapter.
 - `orientation_sensors` – track device orientation via DBus
-  (``iio-sensor-proxy``) or an MPU‑6050 sensor. Functions return ``None`` when
+  (`iio-sensor-proxy`) or an MPU‑6050 sensor. Functions return `None` when
   the optional dependencies are missing.
 - `setup_wizard` – interactive configuration for external services.
 

--- a/docs/mobile_build.rst
+++ b/docs/mobile_build.rst
@@ -2,6 +2,5 @@ Mobile Builds
 =============
 
 PiWardrive previously included configuration files to build Android and
-iOS apps using Buildozer and ``kivy-ios``. These files and helper
-scripts have been removed so mobile builds are no longer officially
-supported.
+iOS apps using Buildozer. These scripts and the old Kivy GUI are no
+longer maintained, so mobile builds are no longer officially supported.

--- a/docs/persistence.rst
+++ b/docs/persistence.rst
@@ -10,7 +10,8 @@ this location. Health monitor metrics are stored as
 :class:`HealthRecord` rows and can be queried with ``load_recent_health``.
 The same file stores ``AppState`` which remembers the last active screen and
 the start time of the previous session. When PiWardrive launches these values
-are restored so the React dashboard (or optional Kivy interface) picks up where it left off.
+are restored so the React dashboard picks up where it left off. The former Kivy
+interface is deprecated and no longer maintained.
 Database connections are
 cached so repeated calls do not reinitialise the schema, reducing disk I/O.
 The connection is placed into write-ahead logging mode using

--- a/docs/web_ui.rst
+++ b/docs/web_ui.rst
@@ -85,6 +85,6 @@ The command launches ``piwardrive-webui`` in the background and then executes
 ``chromium-browser --kiosk http://localhost:8000`` (falling back to
 ``chromium`` when ``chromium-browser`` is unavailable).
 Copy ``examples/kiosk.service`` alongside ``piwardrive-webui.service`` to start
-Chromium automatically on boot, replacing the on-device Kivy interface with the
-browser dashboard.
+Chromium automatically on boot, displaying the browser dashboard in place of the
+deprecated Kivy GUI.
 An active X server is required; headless systems may use ``Xvfb``.


### PR DESCRIPTION
## Summary
- note that the Kivy interface is deprecated
- revise docs to use the React dashboard wording
- clarify that mobile build scripts were removed

## Testing
- `SKIP=npm-lint,npm-test pre-commit run --files README.md REFERENCE.md docs/persistence.rst docs/web_ui.rst docs/mobile_build.rst`
- `pytest -q` *(fails: 32 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6861366c28f4833382f16c07547b67e4