### PR TITLE
Remove final Kivy code paths

### DIFF
--- a/src/piwardrive/core/utils.py
+++ b/src/piwardrive/core/utils.py
@@ -15,15 +15,15 @@ from contextlib import asynccontextmanager
 from datetime import datetime
 from pathlib import Path
 from typing import (
+    TYPE_CHECKING,
     Any,
+    Awaitable,
     Callable,
     Coroutine,
     Iterable,
     Sequence,
     TypedDict,
     TypeVar,
-    Awaitable,
-    TYPE_CHECKING,
 )
 
 from piwardrive import config as pw_config
@@ -36,22 +36,6 @@ try:  # pragma: no cover - optional dependency
 except Exception:  # pragma: no cover - fallback when sigint_suite is missing
     BluetoothDevice = dict[str, Any]
 from concurrent.futures import Future
-
-try:  # pragma: no cover - allow running without Kivy
-    from kivy.app import App as _RealApp
-except Exception:
-    _RealApp = None
-
-if _RealApp is not None:
-    App = _RealApp
-else:
-
-    class _AppStub:
-        @staticmethod
-        def get_running_app() -> None:
-            return None
-
-    App = _AppStub
 from enum import IntEnum
 
 import psutil
@@ -232,16 +216,12 @@ ERROR_PREFIX = "E"
 
 def network_scanning_disabled() -> bool:
     """Return ``True`` if scanning is globally disabled."""
-    app = App.get_running_app()
-    if app is not None:
-        disabled = bool(getattr(app, "disable_scanning", False))
-    else:
-        disabled = os.getenv("PW_DISABLE_SCANNING", "0").lower() in {
-            "1",
-            "true",
-            "yes",
-            "on",
-        }
+    disabled = os.getenv("PW_DISABLE_SCANNING", "0").lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
     if disabled:
         logging.debug("Network scanning disabled")
     return disabled
@@ -292,12 +272,6 @@ def report_error(message: str) -> None:
     ``message`` should include a numeric error code prefix like ``[E001]``.
     """
     logging.error(message)
-    try:
-        app = App.get_running_app()
-        if app and hasattr(app, "show_alert"):
-            app.show_alert("Error", message)
-    except Exception as exc:  # pragma: no cover - app may not be running
-        logging.exception("Failed to display error alert: %s", exc)
 
 
 T = TypeVar("T")
@@ -1184,7 +1158,6 @@ def load_kml(path: str) -> list[dict[str, Any]]:
 
 
 __all__ = [
-    "App",
     "ErrorCode",
     "network_scanning_disabled",
     "shutdown_async_loop",

--- a/src/piwardrive/error_reporting.py
+++ b/src/piwardrive/error_reporting.py
@@ -1,16 +1,5 @@
 import logging
 
-try:
-    from kivy.app import App
-except Exception:  # pragma: no cover - allow running without Kivy
-
-    class _App:
-        @staticmethod
-        def get_running_app() -> None:
-            return None
-
-    App = _App
-
 ERROR_PREFIX = "E"
 
 
@@ -20,14 +9,8 @@ def format_error(code: int, message: str) -> str:
 
 
 def report_error(message: str) -> None:
-    """Log the error and display an alert via the running app if possible."""
+    """Log the error."""
     logging.error(message)
-    try:
-        app = App.get_running_app()
-        if app and hasattr(app, "show_alert"):
-            app.show_alert("Error", message)
-    except Exception as exc:  # pragma: no cover - app may not be running
-        logging.exception("Failed to display error alert: %s", exc)
 
 
-__all__ = ["App", "ERROR_PREFIX", "format_error", "report_error"]
+__all__ = ["ERROR_PREFIX", "format_error", "report_error"]

--- a/src/piwardrive/route_prefetch.py
+++ b/src/piwardrive/route_prefetch.py
@@ -7,8 +7,6 @@ import math
 import os
 from typing import Any
 
-from kivy.app import App
-
 from piwardrive.scheduler import PollScheduler
 from piwardrive.utils import haversine_distance
 
@@ -57,10 +55,12 @@ class RoutePrefetcher:
         interval: int = 3600,
         lookahead: int = 5,
         delta: float = 0.01,
+        offline_tile_path: str | None = None,
     ) -> None:
         self._map_screen = map_screen
         self._lookahead = lookahead
         self._delta = delta
+        self._offline_tile_path = offline_tile_path
         scheduler.schedule("route_prefetch", lambda _dt: self._run(), interval)
 
     # --------------------------------------------------------------
@@ -99,11 +99,8 @@ class RoutePrefetcher:
             )
             mv = getattr(self._map_screen.ids, "mapview", None)
             zoom = getattr(mv, "zoom", 16)
-            app = App.get_running_app()
-            folder = (
-                os.path.dirname(getattr(app, "offline_tile_path", ""))
-                or "/mnt/ssd/tiles"
-            )
+            path = self._offline_tile_path or ""
+            folder = os.path.dirname(path) or "/mnt/ssd/tiles"
             self._map_screen.prefetch_tiles(bbox, zoom=zoom, folder=folder)
         except Exception as exc:  # pragma: no cover - unexpected errors
             logger.exception("RoutePrefetcher failed: %s", exc)

--- a/src/piwardrive/utils.py
+++ b/src/piwardrive/utils.py
@@ -6,9 +6,9 @@ from typing import TYPE_CHECKING
 
 import requests  # type: ignore
 
-from .error_reporting import App, format_error, report_error
+from .error_reporting import format_error, report_error
 
-__all__ = ["App", "format_error", "report_error"]
+__all__ = ["format_error", "report_error"]
 
 try:  # pragma: no cover - optional dependencies may be missing
     from .core.utils import *  # type: ignore  # noqa: F401,F403

--- a/src/piwardrive/widgets/log_viewer.py
+++ b/src/piwardrive/widgets/log_viewer.py
@@ -5,6 +5,7 @@ import re
 from typing import Any, List
 
 from piwardrive.simpleui import DropdownMenu, Label, ScrollView
+from piwardrive.utils import tail_file
 
 try:  # pragma: no cover - optional App stub for tests
     from piwardrive.simpleui import App as _SimpleApp  # type: ignore
@@ -17,7 +18,6 @@ except Exception:  # pragma: no cover - fallback when missing
 
 
 App = _SimpleApp
-from piwardrive.utils import tail_file
 
 
 class LogViewer(ScrollView):
@@ -42,7 +42,7 @@ class LogViewer(ScrollView):
         self.bind(filter_regex=self._compile_filter)
         self.bind(error_regex=self._compile_error)
         self.log_paths = [self.log_path]
-        self._menu: MDDropdownMenu | None = None
+        self._menu: DropdownMenu | None = None
 
     def _compile_filter(self, *_args: Any) -> None:
         self._filter_re = re.compile(self.filter_regex) if self.filter_regex else None
@@ -84,10 +84,7 @@ class LogViewer(ScrollView):
         """Display a dropdown menu to select ``log_path``."""
         app = App.get_running_app()
         paths = getattr(app, "log_paths", self.log_paths)
-        try:  # pragma: no cover - prefer real KivyMD menu if available
-            from kivymd.uix.menu import MDDropdownMenu  # type: ignore
-        except Exception:  # pragma: no cover - fallback stub
-            from piwardrive.simpleui import DropdownMenu as MDDropdownMenu
+        MDDropdownMenu = DropdownMenu
         items = [
             {
                 "text": os.path.basename(p),

--- a/tests/test_error_reporting.py
+++ b/tests/test_error_reporting.py
@@ -1,16 +1,10 @@
 import logging
-import os
-import sys
 from typing import Any
-from unittest import mock
 
 from piwardrive.utils import report_error
 
 
-def test_report_error_logs_and_alerts(caplog: Any) -> None:
-    app = mock.Mock()
-    with mock.patch("utils.App.get_running_app", return_value=app):
-        with caplog.at_level(logging.ERROR):
-            report_error("boom")
-    assert app.show_alert.call_count == 1
+def test_report_error_logs(caplog: Any) -> None:
+    with caplog.at_level(logging.ERROR):
+        report_error("boom")
     assert "boom" in caplog.text

--- a/tests/test_log_viewer.py
+++ b/tests/test_log_viewer.py
@@ -1,10 +1,9 @@
 """Tests for the log viewer widget."""
 
+import logging
 import os
 import sys
 from types import ModuleType, SimpleNamespace
-
-import pytest
 
 modules = {
     "kivy": ModuleType("kivy"),
@@ -16,6 +15,7 @@ modules = {
     "kivy.uix.behaviors": ModuleType("kivy.uix.behaviors"),
     "kivymd.uix.boxlayout": ModuleType("kivymd.uix.boxlayout"),
     "kivymd.uix.menu": ModuleType("kivymd.uix.menu"),
+    "piwardrive.utils": ModuleType("piwardrive.utils"),
 }
 
 
@@ -83,6 +83,10 @@ modules["kivy.uix.scrollview"].ScrollView = _ScrollView
 modules["kivy.uix.behaviors"].DragBehavior = type("DragBehavior", (), {})
 modules["kivymd.uix.boxlayout"].MDBoxLayout = object
 modules["kivymd.uix.menu"].MDDropdownMenu = DummyMenu
+modules["piwardrive.utils"].tail_file = (
+    lambda path, n: open(path).read().splitlines()[-n:]
+)
+modules["piwardrive.utils"].report_error = lambda msg: logging.error(msg)
 modules["kivy"].__path__ = []
 modules["kivy"].app = modules["kivy.app"]
 modules["kivy"].clock = modules["kivy.clock"]
@@ -122,6 +126,10 @@ def test_log_viewer_path_menu(monkeypatch: Any) -> None:
     app = SimpleNamespace(log_paths=["/a", "/b"])
     monkeypatch.setattr(
         "piwardrive.widgets.log_viewer.App.get_running_app", lambda: app
+    )
+    monkeypatch.setattr(
+        "piwardrive.widgets.log_viewer.DropdownMenu",
+        DummyMenu,
     )
     lv = LogViewer()
     lv.show_path_menu(None)

--- a/tests/test_route_prefetch.py
+++ b/tests/test_route_prefetch.py
@@ -1,11 +1,7 @@
-import os
 import sys
 from types import SimpleNamespace
 
-# minimal Kivy stub for testing without the real dependency
-sys.modules["kivy.app"] = SimpleNamespace(
-    App=type("App", (), {"get_running_app": staticmethod(lambda: None)})
-)
+import pytest
 
 
 # lightweight scheduler and utils modules for import
@@ -25,10 +21,6 @@ def _haversine(a, b):
 
 sys.modules["scheduler"] = SimpleNamespace(PollScheduler=object)
 sys.modules["utils"] = SimpleNamespace(haversine_distance=_haversine)
-
-import pytest
-
-from piwardrive import route_prefetch  # noqa: E402
 
 
 class DummyScheduler:
@@ -59,12 +51,21 @@ class DummyMap:
 def test_route_prefetcher_runs(monkeypatch):
     sched = DummyScheduler()
     m = DummyMap()
-    monkeypatch.setattr(
-        route_prefetch.App,
-        "get_running_app",
-        lambda: SimpleNamespace(offline_tile_path="/tiles/off.mbtiles"),
+    monkeypatch.setitem(
+        sys.modules,
+        "piwardrive.utils",
+        SimpleNamespace(haversine_distance=_haversine),
     )
-    route_prefetch.RoutePrefetcher(sched, m, interval=1, lookahead=1)
+    import importlib
+
+    route_prefetch = importlib.import_module("piwardrive.route_prefetch")
+    route_prefetch.RoutePrefetcher(
+        sched,
+        m,
+        interval=1,
+        lookahead=1,
+        offline_tile_path="/tiles/off.mbtiles",
+    )
     assert ("route_prefetch", 1) in sched.scheduled
     assert m.called
     assert m.zoom == 16
@@ -75,12 +76,21 @@ def test_route_prefetcher_no_points(monkeypatch):
     sched = DummyScheduler()
     m = DummyMap()
     m.track_points = []
-    monkeypatch.setattr(
-        route_prefetch.App,
-        "get_running_app",
-        lambda: SimpleNamespace(offline_tile_path="/tiles/off.mbtiles"),
+    monkeypatch.setitem(
+        sys.modules,
+        "piwardrive.utils",
+        SimpleNamespace(haversine_distance=_haversine),
     )
-    route_prefetch.RoutePrefetcher(sched, m, interval=1, lookahead=1)
+    import importlib
+
+    route_prefetch = importlib.import_module("piwardrive.route_prefetch")
+    route_prefetch.RoutePrefetcher(
+        sched,
+        m,
+        interval=1,
+        lookahead=1,
+        offline_tile_path="/tiles/off.mbtiles",
+    )
     # callback executed but nothing prefetched
     assert ("route_prefetch", 1) in sched.scheduled
     assert not m.called
@@ -89,12 +99,21 @@ def test_route_prefetcher_no_points(monkeypatch):
 def test_predict_points(monkeypatch):
     sched = DummyScheduler()
     m = DummyMap()
-    monkeypatch.setattr(
-        route_prefetch.App,
-        "get_running_app",
-        lambda: SimpleNamespace(offline_tile_path="/tiles/off.mbtiles"),
+    monkeypatch.setitem(
+        sys.modules,
+        "piwardrive.utils",
+        SimpleNamespace(haversine_distance=_haversine),
     )
-    rp = route_prefetch.RoutePrefetcher(sched, m, interval=1, lookahead=1)
+    import importlib
+
+    route_prefetch = importlib.import_module("piwardrive.route_prefetch")
+    rp = route_prefetch.RoutePrefetcher(
+        sched,
+        m,
+        interval=1,
+        lookahead=1,
+        offline_tile_path="/tiles/off.mbtiles",
+    )
     pts = rp._predict_points()
     assert pts
     lat, lon = pts[0]


### PR DESCRIPTION
## Summary
- drop `kivy` imports and stubs from utilities
- refactor `RoutePrefetcher` to use config path instead of `App`
- simplify log viewer dropdown menu handling
- adjust tests for new APIs

## Testing
- `pre-commit run --files src/piwardrive/core/utils.py src/piwardrive/error_reporting.py src/piwardrive/route_prefetch.py src/piwardrive/widgets/log_viewer.py src/piwardrive/utils.py tests/test_error_reporting.py tests/test_route_prefetch.py tests/test_log_viewer.py` *(fails: npm lint/test)*
- `PYTHONPATH=src pytest tests/test_route_prefetch.py tests/test_log_viewer.py tests/test_error_reporting.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68613666c5908333b82dec3640a741e4