### PR TITLE
Add hardware setup documentation

### DIFF
--- a/docs/hardware_setup.rst
+++ b/docs/hardware_setup.rst
@@ -1,0 +1,28 @@
+Hardware Setup
+==============
+.. note::
+   Please read the legal notice in the project `README.md` before using PiWardrive.
+
+MPU-6050 Wiring
+---------------
+The MPU-6050 orientation sensor connects via I\ :sup:`2`\ C. Wire the module to the Raspberry Pi pins as shown below.
+
+.. mermaid::
+
+   graph TD
+       VCC[MPU-6050 VCC] --> Pi3V3[Pi 3V3]
+       GND[MPU-6050 GND] --> PiGND[Pi GND]
+       SDA[MPU-6050 SDA] --> PiSDA[Pi SDA (GPIO2)]
+       SCL[MPU-6050 SCL] --> PiSCL[Pi SCL (GPIO3)]
+
+GPS Module Wiring
+-----------------
+A typical serial GPS module uses the Pi's UART interface.
+
+.. mermaid::
+
+   graph TD
+       GPSVCC[GPS VCC] --> Pi3V3
+       GPSGND[GPS GND] --> PiGND
+       GPSTX[GPS TX] --> PiRX[Pi RXD (GPIO15)]
+       GPSRX[GPS RX] --> PiTX[Pi TXD (GPIO14)]

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -27,6 +27,7 @@ See :doc:`tile_prefetching` for a diagram of the automatic tile prefetch flow.
    tile_prefetching
    vector_tile_customizer
    bluetooth
+   hardware_setup
    orientation
    geofencing
    status_service

--- a/docs/orientation.rst
+++ b/docs/orientation.rst
@@ -27,6 +27,9 @@ and install the helper library::
    sudo apt install python3-smbus
    pip install mpu6050
 
+Refer to :doc:`hardware_setup` for wiring diagrams of the sensor and a
+typical GPS module.
+
 Orientation Map
 ~~~~~~~~~~~~~~~
 Orientation strings returned by the helpers are mapped to rotation angles using


### PR DESCRIPTION
## Summary
- document wiring diagrams for the MPU‑6050 sensor and a GPS module
- link new page from the docs index
- mention wiring diagrams in the orientation docs

## Testing
- `make lint` *(fails: pre-commit not installed)*
- `make test` *(fails: ModuleNotFoundError: No module named 'numpy', 'fastapi', etc.)*
- `make docs` *(fails: sphinx-build not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686136a5bcd0833380137da4a291688a