### PR TITLE
Add server health check script

### DIFF
--- a/scripts/check_server.js
+++ b/scripts/check_server.js
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+// Simple health probe for the PiWardrive server.
+// Performs an HTTP request to /api/status and exits non-zero on failure.
+
+async function run(argv = process.argv.slice(2), helpers = {}) {
+  const opts = { fetch: global.fetch, ...helpers };
+  let url = "http://127.0.0.1:8000";
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === "--url") url = argv[++i];
+  }
+  if (!url.endsWith("/")) url += "/";
+  const target = url + "api/status";
+  const resp = await opts.fetch(target);
+  if (!resp.ok) throw new Error(`status ${resp.status}`);
+  return true;
+}
+
+if (require.main === module) {
+  run().catch((err) => {
+    console.error(err.message);
+    process.exit(1);
+  });
+}
+
+module.exports = { run };

--- a/webui/README.md
+++ b/webui/README.md
@@ -109,6 +109,16 @@ Example:
 PW_HEALTH_FILE=/var/log/piwardrive/health.json npm start
 ```
 
+## Simple Health Probe
+
+Use `scripts/check_server.js` to confirm the server is reachable. The
+script queries `/api/status` and exits with a non-zero status code when
+the response is not successful.
+
+```bash
+node scripts/check_server.js --url http://localhost:8000
+```
+
 
 ## 6. Development Mode
 


### PR DESCRIPTION
## Summary
- add a `scripts/check_server.js` utility to check `/api/status`
- document the check script in the Web UI README

## Testing
- `pre-commit run --files scripts/check_server.js webui/README.md` *(fails: npm test and npm lint due to invalid package.json)*
- `npm test` *(fails: JSON parse error in package.json)*
- `pytest -k "" -q` *(fails: 32 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68617b6b56148333adece41582768498