### PR TITLE
Add wireless tool configuration docs

### DIFF
--- a/docs/deployment.rst
+++ b/docs/deployment.rst
@@ -24,6 +24,7 @@ SD Card Image
        pip install -r requirements.txt
 
 4. Enable ``kismet``, ``bettercap`` and ``gpsd`` so they start on boot (``systemctl enable <svc>``).
+   See :ref:`wireless-tools` for example configuration files.
 5. Grant your user permission to manage systemd units over DBus by creating a ``polkit`` rule allowing ``org.freedesktop.systemd1.manage-units``.
 6. (Optional) copy ``examples/piwardrive.service`` into ``/etc/systemd/system/``
    and enable it with ``sudo systemctl enable --now piwardrive.service`` to

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -78,6 +78,21 @@ enable SSH for remote access. A quality power supply is required when using
 external Wi‑Fi adapters and an SSD. Insufficient power may lead to USB errors or
 file system corruption.
 
+.. _wireless-tools:
+
+Kismet and BetterCAP
+--------------------
+
+Sample ``kismet.conf``::
+
+   suiduser=pi
+   log_prefix=/mnt/ssd/kismet_logs
+   source=wlan0:name=wlan0
+
+Run BetterCAP with a simple caplet::
+
+   sudo bettercap -iface wlan0 --caplet /usr/local/etc/bettercap/alfa.cap
+
 Troubleshooting
 ---------------
 


### PR DESCRIPTION
## Summary
- show sample `kismet.conf` and BetterCAP command
- reference the new example from deployment instructions

## Testing
- `pre-commit run --files docs/installation.rst docs/deployment.rst` *(fails: npm test and npm lint)*
- `make docs` *(fails: sphinx-build missing)*
- `pytest -q` *(fails: missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_68617b6ab2fc8333b3104b6733aa65fa