### PR TITLE
Implement export-shp CLI

### DIFF
--- a/docs/cli_tools.rst
+++ b/docs/cli_tools.rst
@@ -77,4 +77,9 @@ Several helper scripts are installed alongside the React dashboard and optional 
 
         piwardrive-maintain-tiles --purge --max-age-days 7
 
+``export-shp``
+    Write saved access points to a Shapefile::
+
+        export-shp aps.shp
+
 See ``--help`` on each command for additional options.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ check-orientation-sensors = "piwardrive.scripts.check_orientation_sensors:main"
 piwardrive-kiosk = "piwardrive.cli.kiosk:main"
 export-log-bundle = "piwardrive.scripts.export_log_bundle:main"
 piwardrive-maintain-tiles = "piwardrive.scripts.tile_maintenance_cli:main"
+export-shp = "piwardrive.scripts.export_shp:main"
 
 [project.optional-dependencies]
 c-extensions = [

--- a/scripts/export_shp.py
+++ b/scripts/export_shp.py
@@ -1,0 +1,35 @@
+import argparse
+import asyncio
+import logging
+
+from piwardrive.logconfig import setup_logging
+
+try:  # allow tests to substitute a lightweight persistence module
+    from persistence import load_ap_cache  # type: ignore
+except Exception:  # pragma: no cover - fallback
+    from piwardrive.persistence import load_ap_cache
+
+from piwardrive import export
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Export saved Wi-Fi access points to a Shapefile."""
+    parser = argparse.ArgumentParser(
+        description="Export saved access points to a Shapefile"
+    )
+    parser.add_argument("output", help="destination .shp file")
+    parser.add_argument(
+        "--fields",
+        nargs="+",
+        help="subset of fields to include in the output",
+    )
+    args = parser.parse_args(argv)
+
+    setup_logging(stdout=True)
+    records = asyncio.run(load_ap_cache())
+    export.export_records(records, args.output, fmt="shp", fields=args.fields)
+    logging.info("Saved %s", args.output)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation
+    main()


### PR DESCRIPTION
## Summary
- add CLI tool for exporting Wi-Fi records to a Shapefile
- register `export-shp` entry point
- document `export-shp` in the CLI tools guide

## Testing
- `pytest -q` *(fails: ModuleImportError during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68617b6a67548333ac5f7a2e23627211