### PR TITLE
Add plugin cache clear test

### DIFF
--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -15,14 +15,18 @@ def _setup_kivy(add_dummy_module):
     add_dummy_module(
         "kivymd.uix.card",
         MDCard=type(
-            "MDCard", (), {"__init__": lambda self, **kw: None, "add_widget": lambda self, w: None}
+            "MDCard",
+            (),
+            {"__init__": lambda self, **kw: None, "add_widget": lambda self, w: None},
         ),
     )
     add_dummy_module(
         "kivymd.uix.label",
         MDLabel=type("MDLabel", (), {"__init__": lambda self, **kw: None, "text": ""}),
     )
-    import importlib, sys
+    import importlib
+    import sys
+
     sys.modules.setdefault("widgets", importlib.import_module("piwardrive.widgets"))
     sys.modules["widgets.base"] = importlib.import_module("piwardrive.widgets.base")
 
@@ -32,13 +36,39 @@ def test_load_hello_plugin(tmp_path, monkeypatch, add_dummy_module):
     plugin_dir = tmp_path / ".config" / "piwardrive" / "plugins"
     plugin_dir.mkdir(parents=True)
 
-    src = Path(__file__).resolve().parents[1] / "examples" / "plugins" / "hello_plugin.py"
+    src = (
+        Path(__file__).resolve().parents[1] / "examples" / "plugins" / "hello_plugin.py"
+    )
     dest = plugin_dir / "hello_plugin.py"
     dest.write_text(src.read_text())
 
     monkeypatch.setenv("HOME", str(tmp_path))
     import sys
+
     sys.modules.pop("piwardrive.widgets", None)
     sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
     widgets = importlib.import_module("piwardrive.widgets")
     assert "HelloPluginWidget" in widgets.list_plugins()
+
+
+def test_clear_plugin_cache_loads_new(tmp_path, monkeypatch, add_dummy_module):
+    _setup_kivy(add_dummy_module)
+    plugin_dir = tmp_path / ".config" / "piwardrive" / "plugins"
+    plugin_dir.mkdir(parents=True)
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import sys
+
+    sys.modules.pop("piwardrive.widgets", None)
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+    widgets = importlib.import_module("piwardrive.widgets")
+
+    plugin_file = plugin_dir / "tmp_plugin.py"
+    plugin_file.write_text(
+        "from piwardrive.widgets.base import DashboardWidget\n"
+        "class TmpPluginWidget(DashboardWidget):\n"
+        "    pass\n"
+    )
+
+    widgets.clear_plugin_cache()
+    assert "TmpPluginWidget" in widgets.list_plugins()


### PR DESCRIPTION
## Summary
- extend plugin test coverage for clear_plugin_cache

## Testing
- `pre-commit run --files tests/test_plugins.py` *(with npm-test and npm-lint skipped)*
- `pytest tests/test_plugins.py::test_clear_plugin_cache_loads_new -q`

------
https://chatgpt.com/codex/tasks/task_e_68617b660250833391ceb8deacf0080a