### PR TITLE
Add docs for pip-installed widget plugins

### DIFF
--- a/docs/widget_plugins.rst
+++ b/docs/widget_plugins.rst
@@ -31,3 +31,27 @@ By default plugins are loaded from ``~/.config/piwardrive/plugins``. Set
 ``PIWARDIVE_PLUGIN_DIR`` to override this location before importing
 :mod:`widgets`. The value must point to a directory containing your plugin
 modules and takes precedence over the default path.
+
+Packaging for pip
+-----------------
+
+Plugins can also be distributed as a standard Python package and installed with
+``pip``.  Define an entry point under ``piwardrive.widgets`` so the loader can
+discover your widget class without copying files manually.
+
+Example project layout::
+
+    mywidget/
+    ├── pyproject.toml
+    └── mywidget
+        ├── __init__.py
+        └── plugin.py
+
+The ``pyproject.toml`` should declare the entry point group::
+
+    [project.entry-points."piwardrive.widgets"]
+    speed = "mywidget.plugin:SpeedWidget"
+
+Installing the package with ``pip install .`` registers ``SpeedWidget`` and it
+becomes available from :mod:`widgets` just like plugins placed in the local
+directory.


### PR DESCRIPTION
## Summary
- document packaging widget plugins as a pip module

## Testing
- `pre-commit run --files docs/widget_plugins.rst`
- `make docs`
- `pytest -q` *(fails: ModuleNotFoundError for numerous deps)*

------
https://chatgpt.com/codex/tasks/task_e_68617b614d2483338894fd1168446fa0