### PR TITLE
Add server TypeScript declarations

### DIFF
--- a/server/server.d.ts
+++ b/server/server.d.ts
@@ -1,0 +1,18 @@
+export interface ServerOptions {
+  distDir?: string;
+  healthFile?: string;
+}
+
+export function verifyPassword(password: string, hashed: string): boolean;
+
+export type BasicAuthHandler = (
+  req: any,
+  res: any,
+  next: (err?: any) => void,
+) => void;
+
+export const basicAuth: BasicAuthHandler;
+
+export function parseWidgets(): string[];
+
+export function createServer(options?: ServerOptions): any;

--- a/webui/package.json
+++ b/webui/package.json
@@ -2,6 +2,7 @@
   "name": "piwardrive-web",
   "version": "0.1.0",
   "private": true,
+  "types": "../server/server.d.ts",
   "scripts": {
     "vite": "vite",
     "dev": "nodemon ../server/index.js",
@@ -42,7 +43,7 @@
     "@vitest/coverage-v8": "^3.2.4",
     "eslint": "^8.57.0",
     "eslint-plugin-react": "^7.33.2",
-    "prettier": "^3.2.5"
+    "prettier": "^3.2.5",
     "nodemon": "^3.0.3"
   },
   "eslintConfig": {


### PR DESCRIPTION
## Summary
- provide a `server/server.d.ts` typing helpers and `createServer`
- expose the declarations via the `types` field in `webui/package.json`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `npm ci` *(fails to resolve dependencies)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68617b614cc08333b1f77c6dcdb5acac