### PR TITLE
Add PW_SERVICE_PORT setting

### DIFF
--- a/docs/deployment.rst
+++ b/docs/deployment.rst
@@ -50,6 +50,9 @@ Docker Container
        docker tag <IMAGE_ID> myuser/piwardrive:latest
        docker push myuser/piwardrive:latest
 
+``piwardrive-service`` listens on port ``8000`` by default. Override this by
+setting ``PW_SERVICE_PORT`` when launching the container.
+
 Both approaches produce a self-contained environment ready to capture Wi‑Fi and GPS data with minimal setup on new hardware.
 
 Web UI Container

--- a/src/piwardrive/service.py
+++ b/src/piwardrive/service.py
@@ -816,7 +816,8 @@ async def main() -> None:
 
     import uvicorn
 
-    config = uvicorn.Config(app, host="127.0.0.1", port=8000)
+    port = int(os.getenv("PW_SERVICE_PORT", "8000"))
+    config = uvicorn.Config(app, host="127.0.0.1", port=port)
     server = uvicorn.Server(config)
     await server.serve()
     vehicle_sensors.close_obd()


### PR DESCRIPTION
## Summary
- allow overriding uvicorn port via `PW_SERVICE_PORT`
- document port override in deployment guide

## Testing
- `pre-commit run --files docs/deployment.rst src/piwardrive/service.py` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68617b624b4c8333a812f2018b75b60c