### PR TITLE
Add Dockerfile for aggregation service

### DIFF
--- a/Dockerfile.aggregation
+++ b/Dockerfile.aggregation
@@ -1,0 +1,16 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN pip install --no-cache-dir fastapi aiosqlite "uvicorn[standard]"
+
+COPY . .
+
+RUN pip install --no-cache-dir .
+
+EXPOSE 9100
+CMD ["python", "-m", "piwardrive.aggregation_service"]

--- a/docs/aggregation_service.rst
+++ b/docs/aggregation_service.rst
@@ -40,3 +40,16 @@ Endpoints
 
 ``/overlay``
     Returns heatmap points derived from all reported access point locations.
+
+Container Image
+---------------
+
+``Dockerfile.aggregation`` builds a lightweight image running
+``piwardrive.aggregation_service``.  Build it with::
+
+   docker build -f Dockerfile.aggregation -t piwardrive-aggregation .
+
+Run the container exposing port 9100 and mounting a data directory::
+
+   docker run --rm -p 9100:9100 -v ~/agg-data:/data \
+      -e PW_AGG_DIR=/data piwardrive-aggregation


### PR DESCRIPTION
## Summary
- add Dockerfile.aggregation for running `piwardrive.aggregation_service`
- document build and run steps in aggregation service docs

## Testing
- `pytest -q` *(fails: ImportError while importing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68617b5b3fb48333aadb9c384a8f69b5