### PR TITLE
Add cache cleanup helper

### DIFF
--- a/docs/tile_cache.rst
+++ b/docs/tile_cache.rst
@@ -49,6 +49,11 @@ Run maintenance without the GUI using the ``piwardrive-maintain-tiles`` command.
 
    piwardrive-maintain-tiles --purge --limit --vacuum --offline /path/offline.mbtiles
 
+``scripts/cleanup_cache.py`` offers a compact helper for deleting tiles
+older than a given age without enforcing the size limit::
+
+   python scripts/cleanup_cache.py --max-age-days 60
+
 Cache Maintenance
 -----------------
 

--- a/scripts/cleanup_cache.py
+++ b/scripts/cleanup_cache.py
@@ -1,0 +1,26 @@
+"""Delete tile cache entries older than a specified age."""
+
+import argparse
+
+from piwardrive.map import tile_maintenance as tm
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Remove tiles older than ``--max-age-days``."""
+    parser = argparse.ArgumentParser(description="Prune old map tiles")
+    parser.add_argument(
+        "--folder", default="/mnt/ssd/tiles", help="tile cache directory"
+    )
+    parser.add_argument(
+        "--max-age-days",
+        type=int,
+        default=30,
+        help="delete tiles older than this many days",
+    )
+    args = parser.parse_args(argv)
+
+    tm.purge_old_tiles(args.folder, args.max_age_days)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation
+    main()

--- a/src/piwardrive/scripts/cleanup_cache.py
+++ b/src/piwardrive/scripts/cleanup_cache.py
@@ -1,0 +1,26 @@
+"""Delete tile cache entries older than a specified age."""
+
+import argparse
+
+from piwardrive.map import tile_maintenance as tm
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Remove tiles older than ``--max-age-days``."""
+    parser = argparse.ArgumentParser(description="Prune old map tiles")
+    parser.add_argument(
+        "--folder", default="/mnt/ssd/tiles", help="tile cache directory"
+    )
+    parser.add_argument(
+        "--max-age-days",
+        type=int,
+        default=30,
+        help="delete tiles older than this many days",
+    )
+    args = parser.parse_args(argv)
+
+    tm.purge_old_tiles(args.folder, args.max_age_days)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation
+    main()


### PR DESCRIPTION
## Summary
- add cleanup_cache.py for removing old tile cache entries
- document script usage in tile_cache.rst

## Testing
- `pre-commit run --files scripts/cleanup_cache.py src/piwardrive/scripts/cleanup_cache.py docs/tile_cache.rst` *(fails: ModuleNotFoundError and npm errors)*
- `pytest -q` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686136c9ff708333b124d3e4200222a5