### PR TITLE
Add FAQ and reference docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ PiWardrive is a headless mapping and diagnostic suite for Raspberry Pi 5. It mer
 python -m piwardrive.webui_server
 ```
 
-For a full index of guides see [REFERENCE.md](REFERENCE.md) and the `docs/` directory.
+For a full index of guides see [REFERENCE.md](REFERENCE.md) and the `docs/` directory. A short [FAQ](docs/faq.rst) covers common issues.
 
 ## Architecture Overview
 

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -1,0 +1,29 @@
+Frequently Asked Questions
+==========================
+.. note::
+   Please read the legal notice in the project `README.md` before using PiWardrive.
+
+Build Problems
+--------------
+**Q: ``python -m build`` fails with ``fatal error: Python.h: No such file or directory``**
+
+Install the system headers and compiler::
+
+   sudo apt install -y build-essential python3-dev
+
+Then rerun ``pip install -r requirements.txt``.
+
+Missing Sensors
+---------------
+**Q: Orientation always shows ``None``**
+
+Install ``iio-sensor-proxy`` and ``python3-dbus`` for built-in sensors or attach an
+MPU‑6050 and ``pip install mpu6050``. The application runs without orientation
+data but cannot rotate Wi‑Fi samples.
+
+Node Build Errors
+-----------------
+**Q: The web UI build complains about the Node version**
+
+Ensure Node.js 18 or newer is installed. Check with ``node --version`` and
+upgrade via your package manager or the official installer.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -44,5 +44,6 @@ See :doc:`tile_prefetching` for a diagram of the automatic tile prefetch flow.
    cli_tools
    drone_mapping
    r_integration
-   web_ui
-   legal
+    web_ui
+    faq
+    legal


### PR DESCRIPTION
## Summary
- document common build errors and missing sensor tips in `docs/faq.rst`
- reference FAQ from `README.md`
- link the FAQ in `docs/index.rst`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for several optional dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686136c4390c8333847ac513196a37bf