### PR TITLE
Enable production source maps

### DIFF
--- a/webui/README.md
+++ b/webui/README.md
@@ -55,6 +55,8 @@ npm run build
 
 The compiled assets appear in `webui/dist`. They include a service worker so the interface works offline after the first visit.
 
+Vite also emits source map files alongside the compiled scripts. Open your browser's developer tools and enable source maps to debug the original React code when using a production build.
+
 ## 5. Start the API and Dashboard
 
 Return to the repository root and run the bundled server. It serves the API under `/api` and the static files generated above at the site root:

--- a/webui/vite.config.js
+++ b/webui/vite.config.js
@@ -40,6 +40,9 @@ export default defineConfig({
       }
     }
   },
+  build: {
+    sourcemap: true
+  },
   test: {
     environment: 'jsdom',
     globals: true,


### PR DESCRIPTION
## Summary
- configure `vite.config.js` to emit source maps
- document how to use them in the Web UI README

## Testing
- `pre-commit run --files webui/README.md webui/vite.config.js` *(fails: npm install errors)*
- `pytest -q` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686136c73c608333b4271e046ed06ce8