### PR TITLE
Add compose file for aggregation

### DIFF
--- a/docker-compose.aggregation.yml
+++ b/docker-compose.aggregation.yml
@@ -1,0 +1,16 @@
+version: "3.9"
+services:
+  aggregation:
+    build: .
+    command: python -m piwardrive.aggregation_service
+    ports:
+      - "9100:9100"
+    volumes:
+      - ./aggregation-data:/root/piwardrive-aggregation
+  sync-receiver:
+    build: .
+    command: python sync_receiver.py
+    ports:
+      - "9000:9000"
+    volumes:
+      - ./sync-data:/root/piwardrive-sync

--- a/docs/aggregation_service.rst
+++ b/docs/aggregation_service.rst
@@ -12,6 +12,11 @@ Run the server with::
 
     python -m piwardrive.aggregation_service
 
+``docker-compose.aggregation.yml`` launches the aggregation service together
+with a simple sync receiver. Start both with::
+
+    docker compose -f docker-compose.aggregation.yml up
+
 By default data is stored under ``~/piwardrive-aggregation``.  Set the
 ``PW_AGG_DIR`` environment variable to change the location.
 

--- a/sync_receiver.py
+++ b/sync_receiver.py
@@ -1,0 +1,22 @@
+import os
+import shutil
+
+from fastapi import FastAPI, UploadFile
+
+app = FastAPI()
+STORAGE = os.path.expanduser("~/piwardrive-sync")
+os.makedirs(STORAGE, exist_ok=True)
+
+
+@app.post("/")
+async def receive(file: UploadFile):
+    dest = os.path.join(STORAGE, file.filename)
+    with open(dest, "wb") as fh:
+        shutil.copyfileobj(file.file, fh)
+    return {"saved": dest}
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=9000)


### PR DESCRIPTION
## Summary
- provide docker-compose.aggregation.yml to run aggregation service plus sync receiver
- document this compose file in `aggregation_service.rst`
- add example sync_receiver.py used by the compose file

## Testing
- `pre-commit run --files docs/aggregation_service.rst docker-compose.aggregation.yml sync_receiver.py` *(fails: no tests ran)*

------
https://chatgpt.com/codex/tasks/task_e_686136b8e1c88333ab3b7ebcacd6989c