### PR TITLE
Add PW_CORS_ORIGINS env var

### DIFF
--- a/docs/deployment.rst
+++ b/docs/deployment.rst
@@ -63,7 +63,7 @@ Run the container exposing port 8000::
 
     docker run --rm -p 8000:8000 piwardrive-webui
 
-Set ``PW_API_PASSWORD_HASH`` and ``PORT`` as needed when running ``docker run``.
+Set ``PW_API_PASSWORD_HASH``, ``PW_CORS_ORIGINS`` and ``PORT`` as needed when running ``docker run``.
 
 
 Editing service.py

--- a/src/piwardrive/service.py
+++ b/src/piwardrive/service.py
@@ -20,6 +20,7 @@ try:  # pragma: no cover - optional FastAPI dependency
         WebSocket,
         WebSocketDisconnect,
     )
+    from fastapi.middleware.cors import CORSMiddleware
     from fastapi.responses import Response, StreamingResponse  # noqa: E402
     from fastapi.security import HTTPBasic, HTTPBasicCredentials
 except Exception:
@@ -31,6 +32,7 @@ except Exception:
             "post": lambda *a, **k: (lambda f: f),
             "delete": lambda *a, **k: (lambda f: f),
             "websocket": lambda *a, **k: (lambda f: f),
+            "add_middleware": lambda *a, **k: None,
         },
     )  # type: ignore[misc, assignment]
 
@@ -58,6 +60,7 @@ except Exception:
         (),
         {},
     )  # type: ignore[misc, assignment]
+    CORSMiddleware = object  # type: ignore[misc, assignment]
 
 if TYPE_CHECKING:  # pragma: no cover - type hints only
     from fastapi import (
@@ -71,6 +74,7 @@ if TYPE_CHECKING:  # pragma: no cover - type hints only
     )
     from fastapi.responses import Response, StreamingResponse
     from fastapi.security import HTTPBasic, HTTPBasicCredentials
+    from fastapi.middleware.cors import CORSMiddleware
 
 import asyncio
 import importlib
@@ -199,6 +203,16 @@ security = HTTPBasic(auto_error=False)
 SECURITY_DEP = Depends(security)
 BODY = Body(...)
 app = FastAPI()
+cors_origins_env = os.getenv("PW_CORS_ORIGINS", "")
+cors_origins = [o.strip() for o in cors_origins_env.split(",") if o.strip()]
+if cors_origins:
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=cors_origins,
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
 
 F = typing.TypeVar("F", bound=typing.Callable[..., typing.Any])
 


### PR DESCRIPTION
## Summary
- support CORS origins via `PW_CORS_ORIGINS` in the API service
- document the new variable in deployment docs

## Testing
- `pre-commit run --files src/piwardrive/service.py docs/deployment.rst` *(fails: mypy missing stubs, pytest missing modules, npm lint/test JSON parse error)*

------
https://chatgpt.com/codex/tasks/task_e_686136b4d4788333848f9f3c6588fed3