### PR TITLE
Update security docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,19 +29,19 @@ graph LR
 - Import from `piwardrive` directly when running tools or tests.
 
 ## Data Inputs
+
 - Kismet
 - Bettercap
 - GPSD
 - SDR
 - Orientation sensors (gyroscope, accelerometer, OBD‑II adapter)
-  - ``dbus`` + ``iio-sensor-proxy`` or an external MPU‑6050 are optional;
+  - `dbus` + `iio-sensor-proxy` or an external MPU‑6050 are optional;
     the app falls back gracefully when absent
   - Wi-Fi scans record the current antenna heading along with RSSI when
     orientation data is available
 
-
-
 ## U/I Features
+
 - Service controls for Kismet and BetterCAP
 - Interactive map with offline tile prefetch and rotation
 - Predictive route tile caching
@@ -56,15 +56,15 @@ graph LR
 - Plugin widgets dynamically loaded in the web UI
 - Offline-capable PWA frontend
 
-
 ## Data Handling
+
 - Multi-format exports (GPX/KML/CSV/JSON/GeoJSON/Shapefile)
 - Diagnostics and log rotation. See `docs/logging.rst` for log levels and file locations.
 - Remote database sync (`remote_sync.py`) with a central aggregation service
   for combined statistics and map overlays
 - Observations stored in SQLite for later analysis
 - CLI SIGINT tools under `src/piwardrive/sigint_suite/` (set `SIGINT_DEBUG=1` for debug logs)
-  
+
 The scheduler drives periodic tasks while diagnostics records system health. Screens host widgets that show metrics on the dashboard, while helper routines control external services like Kismet and BetterCAP.
 
 ### Scanning and Logging
@@ -108,19 +108,21 @@ sequenceDiagram
     Clock-->>Scheduler: event handle
 ```
 
-Schedulers expose basic metrics via ``get_metrics()`` including the next
+Schedulers expose basic metrics via `get_metrics()` including the next
 scheduled run time and duration of the last callback execution. These values
 aid troubleshooting periodic jobs during development.
 
 ## Quick Start
 
 ### Hardware
+
 - Raspberry Pi 5 with 7" touchscreen
 - SSD mounted at `/mnt/ssd`
 - GPS dongle on `/dev/ttyACM0`
 - External Wi-Fi adapter (monitor mode)
 
 ### Software
+
 - Raspberry Pi OS Bookworm or Bullseye
 - Python 3.10+
 - System packages: `kismet`, `gpsd`, `bettercap`, `evtest`, `git`, `build-essential`, `cmake`
@@ -138,7 +140,6 @@ sudo apt update
 sudo apt install -y r-base r-base-dev
 
 ```
-
 
 #### Quickstart Script
 
@@ -159,39 +160,45 @@ source gui-env/bin/activate
    sudo apt update && sudo apt install -y \
        git build-essential cmake kismet bettercap gpsd evtest python3-venv
    ```
+
 3. Clone the repository and switch into the project directory:
 
    ```bash
    git clone git@github.com:Trashytalk/piwardrive.git
    cd piwardrive
    ```
+
 4. Create and activate the virtual environment:
 
    ```bash
    python3 -m venv gui-env
    source gui-env/bin/activate
    ```
+
 5. Install Python dependencies and the project itself:
 
    ```bash
    pip install -r requirements.txt
    pip install .
    ```
+
 6. (Optional) mount an external SSD by editing `/etc/fstab`::
 
-   /dev/sda1  /mnt/ssd  ext4  defaults,nofail  0  2
+   /dev/sda1 /mnt/ssd ext4 defaults,nofail 0 2
 
 7. Enable `kismet`, `bettercap` and `gpsd` to start on boot:
 
    ```bash
    sudo systemctl enable kismet bettercap gpsd
    ```
+
 8. (Optional) copy `examples/piwardrive.service` into `/etc/systemd/system/` and enable it to run the API on boot:
 
    ```bash
    sudo cp examples/piwardrive.service /etc/systemd/system/
    sudo systemctl enable --now piwardrive.service
    ```
+
 9. Start the application manually if the service is not enabled:
 
    ```bash
@@ -215,6 +222,7 @@ Activate the virtual environment and run `pip install <package>` for any that ap
 Follow these steps to configure the Python and React development environment.
 
 1. **Enter your project directory**
+
    ```bash
    cd ~/piwardrive
    ```
@@ -232,24 +240,28 @@ Follow these steps to configure the Python and React development environment.
 
 > PiWardrive's frontend and tests rely on **Node.js 18+**. Verify the tools
 > are installed and meet the version requirement:
+>
 > ```bash
 > node --version
 > npm --version
 > ```
 
 3. **Create and activate a Python venv**
+
    ```bash
    python3 -m venv venv
    source venv/bin/activate
    ```
 
 4. **Upgrade pip/setuptools and install Python deps**
+
    ```bash
    pip install --upgrade pip setuptools wheel meson ninja
    pip install -r requirements.txt
    ```
 
 5. **Build the React frontend**
+
    ```bash
    cd webui
    npm install         # only on first run or when package.json changes
@@ -258,16 +270,19 @@ Follow these steps to configure the Python and React development environment.
    ```
 
 6. **Install the package in editable mode**
+
    ```bash
    pip install --editable .
    ```
 
 7. **Start the ASGI server**
+
    ```bash
    uvicorn piwardrive.webui_server:app --reload
    ```
 
 8. **Verify**
+
    ```bash
    # Visit the React UI
    http://127.0.0.1:8000/
@@ -291,8 +306,8 @@ npm start  # starts the Node server
 # or use the Python version
 # python -m piwardrive.webui_server
 ```
-To autostart the dashboard on boot copy `examples/piwardrive-webui.service` into `/etc/systemd/system/` and enable it with `sudo systemctl enable --now piwardrive-webui.service`.
 
+To autostart the dashboard on boot copy `examples/piwardrive-webui.service` into `/etc/systemd/system/` and enable it with `sudo systemctl enable --now piwardrive-webui.service`.
 
 Alternatively serve `webui/dist` with any webserver while running
 `piwardrive-service` for the API. During development you can run
@@ -305,12 +320,13 @@ Launch Chromium in kiosk mode with the helper command:
 ```bash
 piwardrive-kiosk
 ```
+
 The command runs `piwardrive-webui` in the background and opens Chromium with
 `--kiosk` pointing to the dashboard. Chromium must run inside a graphical
-environment. Ensure an X server is available and ``$DISPLAY`` is set.
-Headless setups can use ``Xvfb``.
+environment. Ensure an X server is available and `$DISPLAY` is set.
+Headless setups can use `Xvfb`.
 
-Combine the web UI service with the example ``kiosk.service`` unit to
+Combine the web UI service with the example `kiosk.service` unit to
 launch the browser automatically on boot. This setup fully replaces the
 on-device Kivy GUI so the Pi's touch screen displays the React dashboard
 in full‑screen mode.
@@ -351,25 +367,24 @@ configuration and compiled assets persist between container restarts.
 
 #### Automated Aspects
 
-* **Health Monitoring & Log Rotation** – `HealthMonitor` polls `diagnostics.self_test()` on a schedule while `rotate_logs` trims old log files automatically.
-* **Tile Cache Maintenance** – stale tiles are purged and MBTiles databases vacuumed at intervals defined by `tile_maintenance_interval`.
-* **Configuration Reloads** – a filesystem watcher detects updates to `config.json` and applies them along with any `PW_` overrides without restarting.
-* **Plugin Discovery** – new widgets placed under `~/.config/piwardrive/plugins` are loaded automatically on startup. The `/plugins` API route lists any discovered classes so you can verify custom widgets were detected.
+- **Health Monitoring & Log Rotation** – `HealthMonitor` polls `diagnostics.self_test()` on a schedule while `rotate_logs` trims old log files automatically.
+- **Tile Cache Maintenance** – stale tiles are purged and MBTiles databases vacuumed at intervals defined by `tile_maintenance_interval`.
+- **Configuration Reloads** – a filesystem watcher detects updates to `config.json` and applies them along with any `PW_` overrides without restarting.
+- **Plugin Discovery** – new widgets placed under `~/.config/piwardrive/plugins` are loaded automatically on startup. The `/plugins` API route lists any discovered classes so you can verify custom widgets were detected.
 
 #### Manual Steps
 
-* **Installation** – run `scripts/quickstart.sh` or follow the manual steps to clone the repo, create a virtualenv and install dependencies.
-* **Launching the App** – activate the environment and start PiWardrive with `python -m piwardrive.main`.
-* **Systemd Service Setup** – copy `examples/piwardrive.service` to `/etc/systemd/system/` and enable it with `sudo systemctl enable --now piwardrive.service` to launch the backend on boot.
-* **Running the Status API** – start the FastAPI service manually with `piwardrive-service` to expose remote metrics.
-* **Browser Kiosk Mode** – build the React frontend (see above) and launch it with `piwardrive-kiosk` to start the server and open Chromium automatically.
-* **Map Tile Prefetch** – use `piwardrive-prefetch` to download map tiles without launching the dashboard.
-* **Syncing Data** – set `remote_sync_url` (and optionally `remote_sync_interval`)
+- **Installation** – run `scripts/quickstart.sh` or follow the manual steps to clone the repo, create a virtualenv and install dependencies.
+- **Launching the App** – activate the environment and start PiWardrive with `python -m piwardrive.main`.
+- **Systemd Service Setup** – copy `examples/piwardrive.service` to `/etc/systemd/system/` and enable it with `sudo systemctl enable --now piwardrive.service` to launch the backend on boot.
+- **Running the Status API** – start the FastAPI service manually with `piwardrive-service` to expose remote metrics.
+- **Browser Kiosk Mode** – build the React frontend (see above) and launch it with `piwardrive-kiosk` to start the server and open Chromium automatically.
+- **Map Tile Prefetch** – use `piwardrive-prefetch` to download map tiles without launching the dashboard.
+- **Syncing Data** – set `remote_sync_url` (and optionally `remote_sync_interval`)
   in `~/.config/piwardrive/config.json` and trigger uploads via `/sync` or call
   `remote_sync.sync_database_to_server` directly.
-* **Offline Vector Tile Customizer** – `piwardrive-mbtiles` builds and styles offline tile sets.
-* **Configuration Wizard** – run `python -m piwardrive.setup_wizard` to interactively create profiles or edit `~/.config/piwardrive/config.json` by hand.
-
+- **Offline Vector Tile Customizer** – `piwardrive-mbtiles` builds and styles offline tile sets.
+- **Configuration Wizard** – run `python -m piwardrive.setup_wizard` to interactively create profiles or edit `~/.config/piwardrive/config.json` by hand.
 
 ### Example systemd unit
 
@@ -392,12 +407,14 @@ WantedBy=multi-user.target
 ## Kiosk Setup on Pi OS Lite
 
 1. **Install prerequisites**
+
    ```bash
    sudo apt update
    sudo apt install -y xserver-xorg xinit matchbox-window-manager chromium-browser
    ```
 
 2. **Create `~/kiosk.sh`**
+
    ```bash
    #!/bin/sh
    xset -dpms
@@ -407,6 +424,7 @@ WantedBy=multi-user.target
    ```
 
 3. **Create `~/.xsession`**
+
    ```bash
    exec sh /home/pi/kiosk.sh
    ```
@@ -417,6 +435,7 @@ WantedBy=multi-user.target
    `~/.xsession` and in turn launches Chromium in kiosk mode.
 
 5. **(Optional) `piwardrive.service`**
+
    ```ini
    [Unit]
    Description=PiWardrive Backend
@@ -434,6 +453,7 @@ WantedBy=multi-user.target
    ```
 
 6. **Enable services and reboot**
+
    ```bash
    sudo systemctl enable kiosk.service
    sudo systemctl enable piwardrive.service  # optional
@@ -458,6 +478,7 @@ prefixed with `PW_` override any option. See `docs/configuration.rst` and the
 [Configuration Overrides](docs/environment.rst#configuration-overrides) section
 for a full list. A JSON schema describing all fields is provided at
 `docs/config_schema.json`.
+Password hashing guidelines are covered in [docs/security.rst](docs/security.rst).
 
 ## Additional Documentation
 

--- a/docs/security.rst
+++ b/docs/security.rst
@@ -10,3 +10,15 @@ To generate a hash run::
     python -c "import security,sys; print(security.hash_password(sys.argv[1]))" mypass
 
 Keep the resulting string in a protected location such as ``~/.config/piwardrive/config.json`` or a secrets manager. The verification helper is tolerant of bad input and simply returns ``False`` on failure.
+
+Store the digest in ``config.json`` using the ``admin_password_hash`` key::
+
+    {
+        "admin_password_hash": "$pbkdf2-sha256$..."
+    }
+
+Alternatively export it via ``PW_ADMIN_PASSWORD_HASH`` or place it in
+``~/.config/piwardrive/.env``::
+
+    export PW_ADMIN_PASSWORD_HASH="$pbkdf2-sha256$..."
+    python -m piwardrive.main


### PR DESCRIPTION
## Summary
- document storing hashed passwords in `docs/security.rst`
- link security guidance from README

## Testing
- `SKIP=prettier,npm-test,npm-lint pre-commit run --files README.md docs/security.rst`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_686136b2e6648333a5e75344c51db0e0