### PR TITLE
Add watch_service helper

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,4 +20,7 @@ Use the following convenience targets during development:
 - `make docs` — build the Sphinx documentation in `docs/_build/html`.
 - `make coverage` — generate combined Python and Node test coverage reports.
 
+During development you can automatically restart the backend service when files
+change by running `scripts/watch_service.py` (requires the `watchgod` package).
+
 Contributions should pass these checks before you submit a pull request.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,3 +11,5 @@ pre-commit==3.7.1
 black==25.1.0
 isort==6.0.1
 bandit==1.8.5
+
+watchgod==0.8.2

--- a/scripts/watch_service.py
+++ b/scripts/watch_service.py
@@ -1,0 +1,56 @@
+"""Restart a systemd unit whenever watched files change."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import os
+from typing import Iterable
+
+from watchgod import awatch
+
+from piwardrive.logconfig import setup_logging
+from piwardrive.utils import run_service_cmd
+
+
+async def _restart(service: str) -> None:
+    ok, _out, err = await asyncio.to_thread(run_service_cmd, service, "restart")
+    if ok:
+        logging.info("Restarted %s.service", service)
+    else:
+        logging.error("Failed to restart %s.service: %s", service, err.strip())
+
+
+async def _watch(paths: Iterable[str], service: str) -> None:
+    for p in paths:
+        logging.info("Watching %s", os.path.abspath(p))
+    async for _changes in awatch(*paths):
+        await _restart(service)
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(
+        description="Restart a systemd service whenever files change."
+    )
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        default=["src"],
+        help="Directories to watch (default: src)",
+    )
+    parser.add_argument(
+        "--service",
+        default="piwardrive",
+        help="Name of the systemd service to restart (default: piwardrive)",
+    )
+    args = parser.parse_args(argv)
+    setup_logging(stdout=True)
+    try:
+        asyncio.run(_watch(args.paths, args.service))
+    except KeyboardInterrupt:
+        pass
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation
+    main()


### PR DESCRIPTION
## Summary
- restart piwardrive.service on code changes via watchgod
- document the helper in `CONTRIBUTING.md`
- include watchgod in dev requirements

## Testing
- `make lint` *(fails: pre-commit not found)*
- `make test` *(fails: missing dependencies such as numpy, fastapi, watchdog)*

------
https://chatgpt.com/codex/tasks/task_e_686136b0b0608333a9138dad48ecf91b