### PR TITLE
Add log rotation helper

### DIFF
--- a/docs/logging.rst
+++ b/docs/logging.rst
@@ -20,3 +20,11 @@ from ``log_paths``. Adjust ``log_rotate_interval`` and ``log_rotate_archives`` i
 
 Passing ``stdout=True`` to ``setup_logging`` duplicates output to the console,
 which is useful during development or when running inside Docker.
+
+Rotating Logs Manually
+~~~~~~~~~~~~~~~~~~~~~
+Use ``scripts/rotate_logs.py`` to rotate the default log files without running PiWardrive::
+
+    python scripts/rotate_logs.py
+
+Specify paths as arguments or ``--max-files`` to choose how many archives to keep.

--- a/scripts/rotate_logs.py
+++ b/scripts/rotate_logs.py
@@ -1,0 +1,41 @@
+"""Rotate log files listed in the default configuration."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+
+from piwardrive import config, diagnostics
+from piwardrive.logconfig import setup_logging
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Rotate configured log files."""
+    parser = argparse.ArgumentParser(description="Rotate log files")
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        help="files to rotate (defaults to config.DEFAULT_CONFIG.log_paths)",
+    )
+    parser.add_argument(
+        "--max-files",
+        "-n",
+        type=int,
+        default=config.DEFAULT_CONFIG.log_rotate_archives,
+        help="number of archives to keep",
+    )
+    args = parser.parse_args(argv)
+
+    setup_logging(stdout=True)
+
+    log_paths = args.paths or list(config.DEFAULT_CONFIG.log_paths)
+    for path in log_paths:
+        try:
+            diagnostics.rotate_log(path, max_files=args.max_files)
+            logging.info("Rotated %s", path)
+        except Exception:
+            logging.exception("Failed to rotate %s", path)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation
+    main()


### PR DESCRIPTION
## Summary
- add rotate_logs.py CLI
- document manual log rotation

## Testing
- `pre-commit run --files docs/logging.rst scripts/rotate_logs.py` *(fails: ModuleNotFoundError: No module named 'pydantic')*


------
https://chatgpt.com/codex/tasks/task_e_686136a9594c8333b1d11469d12d44d6