### PR TITLE
Add db summary CLI

### DIFF
--- a/docs/persistence.rst
+++ b/docs/persistence.rst
@@ -41,3 +41,14 @@ use the ``piwardrive-migrate`` command::
 
 Deleting ``app.db`` will recreate it with the latest schema, but the migration
 command is useful when upgrading an existing installation.
+
+Database Summary
+----------------
+
+Health monitor databases copied from remote devices can grow quickly. The
+``db-summary`` command prints row counts for important tables so you can gauge
+their size::
+
+   db-summary ~/piwardrive/health.db
+
+Pass ``--json`` to emit machine-readable output.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ export-orientation-map = "piwardrive.scripts.export_orientation_map:main"
 check-orientation-sensors = "piwardrive.scripts.check_orientation_sensors:main"
 piwardrive-kiosk = "piwardrive.cli.kiosk:main"
 export-log-bundle = "piwardrive.scripts.export_log_bundle:main"
+db-summary = "piwardrive.scripts.db_summary:main"
 piwardrive-maintain-tiles = "piwardrive.scripts.tile_maintenance_cli:main"
 
 [project.optional-dependencies]

--- a/scripts/db_summary.py
+++ b/scripts/db_summary.py
@@ -1,0 +1,48 @@
+"""Summarize rows in health monitor databases."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sqlite3
+from typing import Dict
+
+KEY_TABLES = ("health_records", "ap_cache")
+
+
+def summarize(path: str) -> Dict[str, int]:
+    """Return row counts for ``KEY_TABLES`` in ``path``."""
+    if not os.path.exists(path):
+        raise FileNotFoundError(path)
+    counts: Dict[str, int] = {}
+    with sqlite3.connect(path) as db:
+        for table in KEY_TABLES:
+            try:
+                row = db.execute(f"SELECT COUNT(*) FROM {table}").fetchone()
+            except sqlite3.DatabaseError:
+                counts[table] = 0
+            else:
+                counts[table] = int(row[0]) if row else 0
+    return counts
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Print row counts for tables in a health.db file."""
+    parser = argparse.ArgumentParser(
+        description="Show row counts for health monitor tables"
+    )
+    parser.add_argument("db", help="path to health.db")
+    parser.add_argument("--json", action="store_true", help="output JSON")
+    args = parser.parse_args(argv)
+
+    counts = summarize(args.db)
+    if args.json:
+        print(json.dumps(counts))
+    else:
+        for name, count in counts.items():
+            print(f"{name}: {count}")
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation
+    main()

--- a/tests/test_db_summary_script.py
+++ b/tests/test_db_summary_script.py
@@ -1,0 +1,22 @@
+import json
+import sqlite3
+import sys
+
+
+def test_db_summary_script(tmp_path, capsys):
+    db_path = tmp_path / "health.db"
+    with sqlite3.connect(db_path) as db:
+        db.execute("CREATE TABLE health_records (timestamp TEXT)")
+        db.execute("CREATE TABLE ap_cache (bssid TEXT)")
+        db.execute("INSERT INTO health_records VALUES ('t1')")
+        db.execute("INSERT INTO ap_cache VALUES ('b1')")
+        db.commit()
+
+    if "piwardrive.scripts.db_summary" in sys.modules:
+        del sys.modules["piwardrive.scripts.db_summary"]
+    import piwardrive.scripts.db_summary as ds
+
+    ds.main([str(db_path), "--json"])
+    out = json.loads(capsys.readouterr().out)
+    assert out["health_records"] == 1
+    assert out["ap_cache"] == 1


### PR DESCRIPTION
## Summary
- add `db_summary.py` utility to count rows in `health.db`
- expose new command with `db-summary` entry point
- document usage in persistence docs
- add basic test for the CLI

## Testing
- `pytest -q tests/test_db_summary_script.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_686136a67b848333a5cb2a2ff0d7e585

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new command-line tool, `db-summary`, to display row counts for key tables in health monitor databases, with optional JSON output.
* **Documentation**
  * Added a "Database Summary" section explaining the new `db-summary` command and its usage.
* **Tests**
  * Added tests to ensure the `db-summary` script accurately reports table row counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->