### PR TITLE
Add Grafana export script and dashboards

### DIFF
--- a/docker-compose.grafana.yml
+++ b/docker-compose.grafana.yml
@@ -1,0 +1,8 @@
+version: "3"
+services:
+  grafana:
+    image: grafana/grafana
+    ports:
+      - "3000:3000"
+    volumes:
+      - ./grafana:/var/lib/grafana

--- a/docs/grafana.rst
+++ b/docs/grafana.rst
@@ -1,0 +1,31 @@
+Grafana Integration
+-------------------
+
+This guide explains how to visualize PiWardrive data in Grafana.
+
+Export Data
+~~~~~~~~~~~
+
+Use the ``export-grafana`` command to generate a SQLite database with
+``health_metrics`` and ``wifi_observations`` tables::
+
+   export-grafana grafana.db --limit 5000
+
+Grafana can connect to this database using the `SQLite data source
+<https://grafana.com/grafana/plugins/fr-ser-sqlite-datasource/>`_.
+
+Dashboards
+~~~~~~~~~~
+
+Two example dashboards live under ``grafana/dashboards``. Import the JSON
+files through *Gear → Dashboards → Import*.
+
+Quick Start
+~~~~~~~~~~~
+
+Start Grafana with Docker Compose::
+
+   docker compose -f docker-compose.grafana.yml up
+
+Login on <http://localhost:3000> (default ``admin/admin``), add the SQLite
+data source pointing at ``grafana.db`` and import the dashboards.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -46,6 +46,7 @@ See :doc:`tile_prefetching` for a diagram of the automatic tile prefetch flow.
    cli_tools
    drone_mapping
    r_integration
+   grafana
     web_ui
     faq
     legal

--- a/grafana/dashboards/metrics.json
+++ b/grafana/dashboards/metrics.json
@@ -1,0 +1,29 @@
+{
+  "title": "PiWardrive Metrics",
+  "uid": "pw-metrics",
+  "schemaVersion": 37,
+  "version": 1,
+  "time": { "from": "now-6h", "to": "now" },
+  "panels": [
+    {
+      "type": "timeseries",
+      "title": "CPU Temp",
+      "targets": [
+        {
+          "rawSql": "SELECT datetime(timestamp) as time, cpu_temp as value FROM health_metrics ORDER BY timestamp",
+          "format": "table"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "CPU Usage",
+      "targets": [
+        {
+          "rawSql": "SELECT datetime(timestamp) as time, cpu_percent as value FROM health_metrics ORDER BY timestamp",
+          "format": "table"
+        }
+      ]
+    }
+  ]
+}

--- a/grafana/dashboards/wifi.json
+++ b/grafana/dashboards/wifi.json
@@ -1,0 +1,19 @@
+{
+  "title": "Wi-Fi Observations",
+  "uid": "pw-wifi",
+  "schemaVersion": 37,
+  "version": 1,
+  "time": { "from": "now-24h", "to": "now" },
+  "panels": [
+    {
+      "type": "table",
+      "title": "Access Points",
+      "targets": [
+        {
+          "rawSql": "SELECT datetime(last_time) as time, ssid, bssid, lat, lon FROM wifi_observations ORDER BY last_time",
+          "format": "table"
+        }
+      ]
+    }
+  ]
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ export-log-bundle = "piwardrive.scripts.export_log_bundle:main"
 piwardrive-maintain-tiles = "piwardrive.scripts.tile_maintenance_cli:main"
 export-gpx = "piwardrive.scripts.export_gpx:main"
 export-shp = "piwardrive.scripts.export_shp:main"
+export-grafana = "piwardrive.scripts.export_grafana:main"
 
 [project.optional-dependencies]
 c-extensions = [

--- a/scripts/export_grafana.py
+++ b/scripts/export_grafana.py
@@ -1,0 +1,78 @@
+import argparse
+import asyncio
+import sqlite3
+from typing import Any
+
+
+def _create_tables(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        """CREATE TABLE IF NOT EXISTS health_metrics (
+            timestamp TEXT,
+            cpu_temp REAL,
+            cpu_percent REAL,
+            memory_percent REAL,
+            disk_percent REAL
+        )"""
+    )
+    conn.execute(
+        """CREATE TABLE IF NOT EXISTS wifi_observations (
+            bssid TEXT,
+            ssid TEXT,
+            encryption TEXT,
+            lat REAL,
+            lon REAL,
+            last_time INTEGER
+        )"""
+    )
+
+
+def _insert_health(conn: sqlite3.Connection, records: list[Any]) -> None:
+    conn.executemany(
+        (
+            "INSERT INTO health_metrics VALUES "
+            "(:timestamp, :cpu_temp, :cpu_percent, :memory_percent, :disk_percent)"
+        ),
+        [r.__dict__ for r in records],
+    )
+
+
+def _insert_wifi(conn: sqlite3.Connection, records: list[dict[str, Any]]) -> None:
+    conn.executemany(
+        (
+            "INSERT INTO wifi_observations VALUES "
+            "(:bssid, :ssid, :encryption, :lat, :lon, :last_time)"
+        ),
+        records,
+    )
+
+
+async def _load_data(limit: int) -> tuple[list[Any], list[dict[str, Any]]]:
+    try:
+        from persistence import load_ap_cache, load_recent_health  # type: ignore
+    except Exception:  # pragma: no cover - fallback
+        from piwardrive.persistence import load_ap_cache, load_recent_health
+
+    health = await load_recent_health(limit)
+    wifi = await load_ap_cache()
+    return health, wifi
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Export PiWardrive data for Grafana")
+    parser.add_argument("output", help="destination SQLite file")
+    parser.add_argument(
+        "--limit", "-n", type=int, default=1000, help="health record limit"
+    )
+    args = parser.parse_args(argv)
+
+    health, wifi = asyncio.run(_load_data(args.limit))
+    conn = sqlite3.connect(args.output)
+    _create_tables(conn)
+    _insert_health(conn, health)
+    _insert_wifi(conn, wifi)
+    conn.commit()
+    conn.close()
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation
+    main()


### PR DESCRIPTION
## Summary
- add `export-grafana` helper script
- ship example dashboards and compose file
- document Grafana integration

## Testing
- `pre-commit run --files docker-compose.grafana.yml docs/grafana.rst grafana/dashboards/metrics.json grafana/dashboards/wifi.json pyproject.toml scripts/export_grafana.py docs/index.rst` *(with npm-test, npm-lint, pytest skipped)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'piwardrive')*


------
https://chatgpt.com/codex/tasks/task_e_686183637bf883339209074eb12aa8d9