### PR TITLE
Read PW_WEBUI_PORT at runtime

### DIFF
--- a/src/piwardrive/web/webui_server.py
+++ b/src/piwardrive/web/webui_server.py
@@ -33,7 +33,8 @@ def create_app() -> FastAPI:
 def main() -> None:
     import uvicorn
 
-    port = int(os.getenv("PW_WEBUI_PORT", 8000))
+    port_env = os.environ.get("PW_WEBUI_PORT")
+    port = int(port_env) if port_env else 8000
     uvicorn.run(create_app(), host="127.0.0.1", port=port)
 
 

--- a/webui/README.md
+++ b/webui/README.md
@@ -83,7 +83,7 @@ python -c "import security,sys;print(security.hash_password(sys.argv[1]))" mypas
 ```
 
 Assign the resulting value to the environment variable before launching `piwardrive.webui_server`.
-Set `PW_WEBUI_PORT` if you need the server to listen on a different port.
+Set `PW_WEBUI_PORT` if you need the Python server to listen on a different port (default `8000`).
 
 ## PW_API_PASSWORD_HASH and PORT
 


### PR DESCRIPTION
## Summary
- expose optional `PW_WEBUI_PORT` var when launching the Python web UI server
- document the env var in the frontend README

## Testing
- `ruff check src/piwardrive/web/webui_server.py`

------
https://chatgpt.com/codex/tasks/task_e_68618343160c8333bffe2127a9a2b014