### PR TITLE
Document PW_ORIENTATION_MAP_FILE usage

### DIFF
--- a/docs/orientation.rst
+++ b/docs/orientation.rst
@@ -164,3 +164,8 @@ when PiWardrive starts. The file should contain the mapping produced by
 invocation looks like::
 
    PW_ORIENTATION_MAP_FILE=/path/to/orientation_map.json python -m piwardrive.main
+
+You can also point the variable to the example mapping bundled with the
+repository::
+
+   PW_ORIENTATION_MAP_FILE=examples/orientation_map.json python -m piwardrive.main


### PR DESCRIPTION
## Summary
- expand docs about `PW_ORIENTATION_MAP_FILE` with an example referencing the bundled JSON mapping

## Testing
- `pre-commit run --files docs/orientation.rst` *(fails: could not install hooks)*
- `pytest -q` *(fails: missing dependencies)*
- `make docs` *(fails: sphinx-build missing)*

------
https://chatgpt.com/codex/tasks/task_e_68618340a690833393505269b9edc7be