### PR TITLE
Improve orientation map reset logic

### DIFF
--- a/src/piwardrive/orientation_sensors.py
+++ b/src/piwardrive/orientation_sensors.py
@@ -26,6 +26,9 @@ except Exception:  # pragma: no cover - missing dependency
 
 logger = logging.getLogger(__name__)
 
+# Environment variable used by :func:`reset_orientation_map`.
+ORIENTATION_MAP_ENV = "PW_ORIENTATION_MAP_FILE"
+
 # Default mapping between orientation strings and rotation angles.  The mapping
 # is copied to ``_ORIENTATION_MAP`` so callers can freely modify the latter
 # without losing the canonical defaults.
@@ -71,22 +74,19 @@ def reset_orientation_map() -> None:
     """
 
     _ORIENTATION_MAP.clear()
-    path = os.getenv("PW_ORIENTATION_MAP_FILE")
+    path = os.getenv(ORIENTATION_MAP_ENV)
     if path:
-        if os.path.exists(path):
-            try:
-                with open(path, "r", encoding="utf-8") as fh:
-                    data = json.load(fh)
-                if isinstance(data, dict):
-                    _ORIENTATION_MAP.update(
-                        {k.lower(): float(v) for k, v in data.items()}
-                    )
-                    return
-                logger.error("Invalid orientation map in %s", path)
-            except Exception as exc:  # pragma: no cover - runtime errors
-                logger.error("Failed to load orientation map from %s: %s", path, exc)
-        else:
+        try:
+            with open(path, "r", encoding="utf-8") as fh:
+                data = json.load(fh)
+            if isinstance(data, dict):
+                _ORIENTATION_MAP.update({k.lower(): float(v) for k, v in data.items()})
+                return
+            logger.error("Invalid orientation map in %s", path)
+        except FileNotFoundError:
             logger.error("Orientation map file not found: %s", path)
+        except Exception as exc:  # pragma: no cover - runtime errors
+            logger.error("Failed to load orientation map from %s: %s", path, exc)
 
     _ORIENTATION_MAP.update(DEFAULT_ORIENTATION_MAP)
 


### PR DESCRIPTION
## Summary
- use constant for PW_ORIENTATION_MAP_FILE
- improve `reset_orientation_map` error handling

## Testing
- `pre-commit run --files src/piwardrive/orientation_sensors.py` *(fails: vitest not found, npm scripts missing)*
- `pytest -q` *(fails: missing optional test dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6861870c99988333bf3a09f1f6b36633