### PR TITLE
Fix docstring formatting for pydocstyle

### DIFF
--- a/src/piwardrive/exception_handler.py
+++ b/src/piwardrive/exception_handler.py
@@ -46,7 +46,6 @@ def install(app: FastAPI | None = None) -> None:
     If ``app`` is provided and FastAPI is available, an exception handler is
     registered that logs the error and responds with ``HTTP 500``.
     """
-
     global _installed
     if _installed:
         return

--- a/src/piwardrive/integrations/sigint_suite/exports/exporter.py
+++ b/src/piwardrive/integrations/sigint_suite/exports/exporter.py
@@ -77,10 +77,7 @@ def export_records(
     fmt: str,
     fields: Sequence[str] | None = None,
 ) -> None:
-    """Export ``records`` using ``fmt`` similar to
-    :func:`piwardrive.export.export_records`.
-    """
-
+    """Export ``records`` in ``fmt`` similar to :func:`piwardrive.export.export_records`."""
     fmt = fmt.lower()
     if fmt not in EXPORT_FORMATS:
         raise ValueError(f"Unsupported format: {fmt}")

--- a/src/piwardrive/orientation_sensors.py
+++ b/src/piwardrive/orientation_sensors.py
@@ -66,7 +66,6 @@ def clone_orientation_map() -> Dict[str, float]:
 
 def reset_orientation_map() -> None:
     """Restore :data:`_ORIENTATION_MAP` from ``PW_ORIENTATION_MAP_FILE`` if set."""
-
     _ORIENTATION_MAP.clear()
     path = os.getenv("PW_ORIENTATION_MAP_FILE")
     if path:

--- a/src/piwardrive/remote_sync.py
+++ b/src/piwardrive/remote_sync.py
@@ -24,19 +24,16 @@ logger = _impl.logger
 
 def _make_range_db(src: str, start: int, end: int) -> str:
     """Return path to a temporary DB containing rows ``start``..``end``."""
-
     return _impl._make_range_db(src, start, end)
 
 
 def _load_sync_state(path: str) -> int:
     """Return the last synced row id recorded in ``path``."""
-
     return _impl._load_sync_state(path)
 
 
 def _save_sync_state(path: str, row_id: int) -> None:
     """Persist ``row_id`` to ``path``."""
-
     _impl._save_sync_state(path, row_id)
 
 
@@ -49,7 +46,6 @@ async def sync_database_to_server(
     row_range: Tuple[int, int] | None = None,
 ) -> None:
     """Delegate to :func:`remote_sync.sync_database_to_server`."""
-
     await _impl.sync_database_to_server(
         db_path,
         url,

--- a/src/piwardrive/route_prefetch.py
+++ b/src/piwardrive/route_prefetch.py
@@ -10,21 +10,14 @@ from typing import Any
 try:  # pragma: no cover - optional dependency
     from kivy.app import App as KivyApp
 except Exception:
-    KivyApp = None  # type: ignore[assignment]
+    class KivyApp:  # type: ignore[no-redef]
+        """Fallback ``App`` implementation when Kivy is unavailable."""
+
+        @staticmethod
+        def get_running_app() -> None:
+            return None
 
 App = KivyApp
-
-
-    class App:  # type: ignore[no-redef]
-        @staticmethod
-        def get_running_app() -> None:
-            return None
-          
-
-    class App:  # type: ignore[no-redef]
-        @staticmethod
-        def get_running_app() -> None:
-            return None
 
           
 from piwardrive.scheduler import PollScheduler


### PR DESCRIPTION
## Summary
- fix docstring spacing in `remote_sync` and `exception_handler`
- fix docstring spacing in `orientation_sensors` and exporter
- clean up `route_prefetch` fallback class

## Testing
- `pydocstyle`


------
https://chatgpt.com/codex/tasks/task_e_686186dcd3908333bc55f453944b09d7