### PR TITLE
Remove duplicate exception_handler module

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,4 +1,5 @@
 [mypy]
 ignore_missing_imports = True
 files = src
+exclude = ^exception_handler\.py$
 

--- a/src/exception_handler.py
+++ b/src/exception_handler.py
@@ -1,5 +1,0 @@
-"""Compatibility wrapper for :mod:`piwardrive.exception_handler`."""
-
-from piwardrive.exception_handler import install
-
-__all__ = ["install"]


### PR DESCRIPTION
## Summary
- drop unused `src/exception_handler.py`
- ignore the repository stub module in mypy config

## Testing
- `mypy src/piwardrive/exception_handler.py exception_handler.py`

------
https://chatgpt.com/codex/tasks/task_e_686186ddc9d8833393a200a4e37f4c4a