### PR TITLE
Read PW_AGG_PORT in main

### DIFF
--- a/docs/aggregation_service.rst
+++ b/docs/aggregation_service.rst
@@ -58,4 +58,4 @@ Container Image
 Run the container exposing port 9100 and mounting a data directory::
 
    docker run --rm -p 9100:9100 -v ~/agg-data:/data \
-      -e PW_AGG_DIR=/data piwardrive-aggregation
+      -e PW_AGG_DIR=/data -e PW_AGG_PORT=9100 piwardrive-aggregation

--- a/src/piwardrive/aggregation_service.py
+++ b/src/piwardrive/aggregation_service.py
@@ -18,7 +18,7 @@ from .persistence import HealthRecord
 DATA_DIR = os.path.expanduser(os.getenv("PW_AGG_DIR", "~/piwardrive-aggregation"))
 DB_PATH = os.path.join(DATA_DIR, "aggregation.db")
 UPLOAD_DIR = os.path.join(DATA_DIR, "uploads")
-PORT = int(os.getenv("PW_AGG_PORT", "9100"))
+DEFAULT_PORT = 9100
 
 os.makedirs(UPLOAD_DIR, exist_ok=True)
 
@@ -149,7 +149,8 @@ async def main() -> None:
     import uvicorn
 
     await _get_conn()
-    config = uvicorn.Config(app, host="0.0.0.0", port=PORT)  # nosec B104
+    port = int(os.getenv("PW_AGG_PORT", str(DEFAULT_PORT)))
+    config = uvicorn.Config(app, host="0.0.0.0", port=port)  # nosec B104
     server = uvicorn.Server(config)
     await server.serve()
 


### PR DESCRIPTION
## Summary
- read `PW_AGG_PORT` at runtime instead of import time
- show environment variable in Docker run example

## Testing
- `pre-commit run --files src/piwardrive/aggregation_service.py docs/aggregation_service.rst` *(fails: ModuleNotFoundError: No module named 'fastapi' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6861870c3f808333af2085dbe15fe20f