### PR TITLE
Update hardware setup documentation links

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,6 +10,8 @@ PiWardrive's primary interface is a React-based web dashboard served by
 
 See :doc:`tile_prefetching` for a diagram of the automatic tile prefetch flow.
 
+For wiring diagrams of external sensors see :doc:`hardware_setup`.
+
 
 .. toctree::
    :maxdepth: 1

--- a/docs/orientation.rst
+++ b/docs/orientation.rst
@@ -27,7 +27,7 @@ and install the helper library::
    sudo apt install python3-smbus
    pip install mpu6050
 
-Refer to :doc:`hardware_setup` for wiring diagrams of the sensor and a
+See :doc:`hardware_setup` for wiring diagrams of the MPU-6050 and a
 typical GPS module.
 
 Orientation Map


### PR DESCRIPTION
## Summary
- add pointer to hardware setup diagrams in the index
- clarify wording that references the hardware setup page

## Testing
- `make test` *(fails: 34 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6861870dda8883338d7ab4895a3e9763