### PR TITLE
Add orientation map env var docs

### DIFF
--- a/docs/orientation.rst
+++ b/docs/orientation.rst
@@ -159,8 +159,18 @@ PW_ORIENTATION_MAP_FILE
 ~~~~~~~~~~~~~~~~~~~~~~~
 Set ``PW_ORIENTATION_MAP_FILE`` to load rotation angles from a JSON file
 when PiWardrive starts. The file should contain the mapping produced by
-``calibrate_orientation.py`` or a hand-crafted variant.  See
-``examples/orientation_map.json`` for a typical layout.  A common
-invocation looks like::
+``calibrate_orientation.py`` or a hand-crafted variant. ``examples/orientation_map.json``
+shows a typical layout:
+
+.. code-block:: json
+
+   {
+       "normal": 0.0,
+       "bottom-up": 180.0,
+       "right-up": 90.0,
+       "left-up": 270.0
+   }
+
+Activate the map at runtime with::
 
    PW_ORIENTATION_MAP_FILE=/path/to/orientation_map.json python -m piwardrive.main


### PR DESCRIPTION
## Summary
- document `PW_ORIENTATION_MAP_FILE`
- show JSON snippet from `examples/orientation_map.json`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6861870d85948333a4c44a40ccebde77