### PR TITLE
Add Codecov coverage uploads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,9 +55,18 @@ jobs:
         run: |
           pytest --cov=src --cov-report=xml -q
 
-      - name: Upload coverage to Codecov
+      - name: Upload Python coverage to Codecov
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: coverage.xml,webui/coverage/lcov.info
+          files: coverage.xml
+          flags: backend
+          fail_ci_if_error: true
+
+      - name: Upload Node coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: webui/coverage/lcov.info
+          flags: frontend
           fail_ci_if_error: true

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -33,4 +33,5 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml
+          flags: backend
           fail_ci_if_error: true

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # PiWardrive
 
-[![codecov](https://codecov.io/gh/TRASHYTALK/piwardrive/branch/main/graph/badge.svg)](https://codecov.io/gh/TRASHYTALK/piwardrive)
+[![Backend Coverage](https://codecov.io/gh/TRASHYTALK/piwardrive/branch/main/graph/badge.svg?flag=backend)](https://app.codecov.io/gh/TRASHYTALK/piwardrive?flags=backend)
+[![Frontend Coverage](https://codecov.io/gh/TRASHYTALK/piwardrive/branch/main/graph/badge.svg?flag=frontend)](https://app.codecov.io/gh/TRASHYTALK/piwardrive?flags=frontend)
 
 PiWardrive is a headless mapping and diagnostic suite for Raspberry Pi 5. It merges war-driving tools such as Kismet and BetterCAP with a lightweight command line SIGINT suite for scanning. The primary interface is a browser-based dashboard built with React. Launch it after building the frontend with:
 

--- a/webui/README.md
+++ b/webui/README.md
@@ -1,6 +1,6 @@
 # PiWardrive Web UI Setup
 
-![Coverage](https://github.com/TRASHYTALK/piwardrive/raw/main/webui/badges/coverage.svg)
+[![Frontend Coverage](https://codecov.io/gh/TRASHYTALK/piwardrive/branch/main/graph/badge.svg?flag=frontend)](https://app.codecov.io/gh/TRASHYTALK/piwardrive?flags=frontend)
 
 > **Note**
 > Refer to the Legal Notice in [../README.md](../README.md) before running PiWardrive.


### PR DESCRIPTION
## Summary
- send Python and Node coverage to Codecov in CI
- flag Python coverage as `backend`
- show Codecov coverage badges

## Testing
- `make test` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `npm ci` *(fails: ERESOLVE could not resolve)*

------
https://chatgpt.com/codex/tasks/task_e_68618710ce688333b4d1b9f25fddb1aa