### PR TITLE
Add gettext translation update script

### DIFF
--- a/docs/localization.rst
+++ b/docs/localization.rst
@@ -15,10 +15,12 @@ Adding a Language
    language code. Translate the values while keeping all keys intact.
 2. Update existing locale files whenever new strings are added. ``en.json``
    should always contain the complete set of keys.
-3. Run ``python scripts/check_locales_sync.py`` to verify that all locale
+3. Run ``scripts/update_translations.sh`` to generate
+   ``locales/piwardrive.pot`` using gettext.
+4. Run ``python scripts/check_locales_sync.py`` to verify that all locale
    files share the same keys. The script exits with a non-zero status if any
    differences are found.
-4. Set ``PW_LANG`` or call ``localization.set_locale()`` to switch languages.
+5. Set ``PW_LANG`` or call ``localization.set_locale()`` to switch languages.
 
 These steps keep the translations synchronized and avoid missing strings in the
 UI.

--- a/scripts/update_translations.sh
+++ b/scripts/update_translations.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Generate gettext POT template for PiWardrive
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${SCRIPT_DIR}/.."
+POT_DIR="${REPO_ROOT}/locales"
+
+cd "$REPO_ROOT"
+mkdir -p "$POT_DIR"
+
+xgettext --from-code=UTF-8 --language=Python --keyword=_ \
+    -o "$POT_DIR/piwardrive.pot" \
+    $(git ls-files '*.py')
+
+echo "POT file written to $POT_DIR/piwardrive.pot"


### PR DESCRIPTION
## Summary
- add `update_translations.sh` to generate POT files
- document translation generation in `localization.rst`

## Testing
- `pre-commit run --files docs/localization.rst scripts/update_translations.sh` *(fails: vitest not found)*
- `pytest -q` *(fails: 34 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68618715a4d48333a7a193380cc390f7