### PR TITLE
Fix fallback App definition indentation

### DIFF
--- a/src/piwardrive/route_prefetch.py
+++ b/src/piwardrive/route_prefetch.py
@@ -14,19 +14,12 @@ except Exception:
 
 App = KivyApp
 
-
-    class App:  # type: ignore[no-redef]
-        @staticmethod
-        def get_running_app() -> None:
-            return None
-          
-
+if App is None:
     class App:  # type: ignore[no-redef]
         @staticmethod
         def get_running_app() -> None:
             return None
 
-          
 from piwardrive.scheduler import PollScheduler
 from piwardrive.utils import haversine_distance
 


### PR DESCRIPTION
## Summary
- clean up fallback `App` definitions in `route_prefetch`

## Testing
- `flake8 src/piwardrive/route_prefetch.py`
- `mypy src/piwardrive/route_prefetch.py --config-file mypy.ini` *(fails: Library stubs not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686193dd73348333adaa83c8f651381b