### PR TITLE
Fix _add_records signature length

### DIFF
--- a/src/piwardrive/export.py
+++ b/src/piwardrive/export.py
@@ -275,7 +275,13 @@ def export_map_kml(
         pt = ET.SubElement(pm, "Point")
         ET.SubElement(pt, "coordinates").text = f"{lon},{lat}"
 
-    def _add_records(records: Sequence[Mapping[str, Any]], key1: str, key2: str | None = None, *, compute: bool = False) -> None:
+    def _add_records(
+        records: Sequence[Mapping[str, Any]],
+        key1: str,
+        key2: str | None = None,
+        *,
+        compute: bool = False,
+    ) -> None:
         for rec in records:
             lat = rec.get("lat")
             lon = rec.get("lon")


### PR DESCRIPTION
## Summary
- refactor export helper `_add_records` to wrap arguments over multiple lines
- run `flake8` to ensure no `E501` line-length violation remains

## Testing
- `flake8 src/piwardrive/export.py`

------
https://chatgpt.com/codex/tasks/task_e_686193e0b20c8333a693dd03472f6cdc