### PR TITLE
Fix import order in utils

### DIFF
--- a/src/piwardrive/core/utils.py
+++ b/src/piwardrive/core/utils.py
@@ -42,7 +42,6 @@ try:  # pragma: no cover - optional dependency
 except Exception:
     KivyApp = None  # type: ignore[assignment]
 
-App = KivyApp
 from enum import IntEnum
 
 import psutil
@@ -55,6 +54,8 @@ except Exception:  # pragma: no cover - optional dependency
 import aiohttp
 
 from piwardrive import persistence
+
+App = KivyApp
 
 GPSD_CACHE_SECONDS = 2.0  # cache ttl in seconds
 


### PR DESCRIPTION
## Summary
- move optional imports to top of `utils.py`
- keep `App = KivyApp` after imports

## Testing
- `flake8 src/piwardrive/core/utils.py`
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_686193deb4608333853f19307e22af4c