### PR TITLE
Fix flake8 W391 in parse_widgets

### DIFF
--- a/server/parse_widgets.py
+++ b/server/parse_widgets.py
@@ -26,4 +26,3 @@ if not isinstance(widgets, list):
     widgets = []
 widgets = [str(x) for x in widgets]
 print(json.dumps(widgets))
-


### PR DESCRIPTION
## Summary
- remove a stray newline from `server/parse_widgets.py`

## Testing
- `flake8 server/parse_widgets.py`

------
https://chatgpt.com/codex/tasks/task_e_686193e89c44833398a4473cd3972eb8