### PR TITLE
Fix kiosk webui path and handle missing

### DIFF
--- a/src/piwardrive/cli/kiosk.py
+++ b/src/piwardrive/cli/kiosk.py
@@ -22,7 +22,10 @@ def main(argv: Sequence[str] | None = None) -> None:
     )
     args = parser.parse_args(list(argv) if argv is not None else None)
 
-    proc = subprocess.Popen(["piwardrive-webui"])
+    webui = shutil.which("piwardrive-webui")
+    if webui is None:
+        raise FileNotFoundError("piwardrive-webui executable not found")
+    proc = subprocess.Popen([webui])
     try:
         time.sleep(args.delay)
         browser = shutil.which("chromium-browser") or shutil.which("chromium")


### PR DESCRIPTION
## Summary
- use `shutil.which` to locate `piwardrive-webui`
- raise a `FileNotFoundError` when the executable is missing

## Testing
- `pytest tests/test_kiosk_cli.py tests/test_start_kiosk_script.py -q`
- `bandit -r src/piwardrive/cli/kiosk.py -n 5`

------
https://chatgpt.com/codex/tasks/task_e_686193e996bc8333adbfb4841beee171