### PR TITLE
Add setup_dev_env script and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -491,17 +491,19 @@ Detailed examples for each command line helper are available in [docs/cli_tools.
 
 ## Contributing
 
-Install the development dependencies and run the tests:
+Install the development dependencies (including the optional test extras) and
+run the test suite:
 
 ```bash
 pip install -r requirements.txt
 pip install -r requirements-dev.txt
-# Some tests rely on additional scientific libraries such as `numpy`.
-# Install them with the optional `tests` extras if needed:
-# pip install .[tests]
+pip install .[tests]
 pre-commit run --all-files
 pytest
 ```
+
+You can also run `scripts/setup_dev_env.sh` to install these dependencies
+automatically before running the tests.
 
 `pre-commit` automatically installs packages listed in `requirements.txt`
 and `requirements-dev.txt`, so hooks and tests run consistently.

--- a/scripts/setup_dev_env.sh
+++ b/scripts/setup_dev_env.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Install development dependencies including tests extras.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${SCRIPT_DIR}/.."
+cd "$REPO_ROOT"
+
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "python3 is required" >&2
+    exit 1
+fi
+
+python3 -m pip install --upgrade pip
+python3 -m pip install -r requirements.txt
+python3 -m pip install -r requirements-dev.txt
+python3 -m pip install .[tests]
+
+echo "Development environment ready. Run 'pytest' to execute the tests."


### PR DESCRIPTION
## Summary
- mention using the `tests` extras when running the test suite
- add a helper script to set up the dev environment with those extras

## Testing
- `pre-commit run --files README.md scripts/setup_dev_env.sh` *(fails: vitest not found)*
- `pytest -q` *(fails: 34 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_686193ea2c148333aaa387e7ab70735a