### PR TITLE
Add fingerprint clustering and persistence

### DIFF
--- a/src/piwardrive/analytics/__init__.py
+++ b/src/piwardrive/analytics/__init__.py
@@ -1,0 +1,5 @@
+"""Analytics utilities."""
+
+from .clustering import cluster_positions
+
+__all__ = ["cluster_positions"]

--- a/src/piwardrive/analytics/clustering.py
+++ b/src/piwardrive/analytics/clustering.py
@@ -1,0 +1,44 @@
+"""Clustering helpers using DBSCAN."""
+
+from __future__ import annotations
+
+from typing import Iterable, Mapping, Tuple, List
+
+import numpy as np
+from sklearn.cluster import DBSCAN
+
+
+def cluster_positions(
+    records: Iterable[Mapping[str, float]],
+    eps: float = 0.0005,
+    min_samples: int = 5,
+) -> List[Tuple[float, float]]:
+    """Return cluster centroids for ``records``.
+
+    Each record should contain ``lat`` and ``lon`` keys. The coordinates
+    are clustered using DBSCAN and the mean latitude/longitude for each
+    cluster is returned.
+    """
+
+    coords = np.array(
+        [
+            (rec["lat"], rec["lon"])
+            for rec in records
+            if "lat" in rec and "lon" in rec
+        ],
+        dtype=float,
+    )
+    if coords.size == 0:
+        return []
+
+    labels = DBSCAN(eps=eps, min_samples=min_samples).fit_predict(coords)
+    centers: list[tuple[float, float]] = []
+    for label in set(labels):
+        if label == -1:
+            continue
+        pts = coords[labels == label]
+        centers.append((float(pts[:, 0].mean()), float(pts[:, 1].mean())))
+    return centers
+
+
+__all__ = ["cluster_positions"]

--- a/src/piwardrive/service.py
+++ b/src/piwardrive/service.py
@@ -91,10 +91,13 @@ try:  # allow tests to stub out ``persistence``
     from persistence import load_ap_cache  # type: ignore
     from persistence import (
         DashboardSettings,
+        FingerprintInfo,
         _db_path,
         get_table_counts,
         load_dashboard_settings,
         load_recent_health,
+        load_fingerprint_info,
+        save_fingerprint_info,
         save_dashboard_settings,
     )
 except Exception:  # pragma: no cover - fall back to real module
@@ -102,10 +105,13 @@ except Exception:  # pragma: no cover - fall back to real module
         load_recent_health,
         load_ap_cache,
         load_dashboard_settings,
+        load_fingerprint_info,
+        save_fingerprint_info,
         save_dashboard_settings,
         get_table_counts,
         _db_path,
         DashboardSettings,
+        FingerprintInfo,
     )
 
 from piwardrive.errors import GeofenceError
@@ -558,6 +564,27 @@ async def update_dashboard_settings_endpoint(
     widgets = data.get("widgets", [])
     await save_dashboard_settings(DashboardSettings(layout=layout, widgets=widgets))
     return {"layout": layout, "widgets": widgets}
+
+
+@GET("/fingerprints")
+async def list_fingerprints_endpoint(_auth: None = AUTH_DEP) -> dict[str, Any]:
+    """Return stored fingerprint metadata."""
+    items = await load_fingerprint_info()
+    return {"fingerprints": [asdict(i) for i in items]}
+
+
+@POST("/fingerprints")
+async def add_fingerprint_endpoint(
+    data: dict[str, Any] = BODY, _auth: None = AUTH_DEP
+) -> dict[str, Any]:
+    """Store fingerprint metadata in the database."""
+    info = FingerprintInfo(
+        environment=data.get("environment", ""),
+        source=data.get("source", ""),
+        record_count=int(data.get("record_count", 0)),
+    )
+    await save_fingerprint_info(info)
+    return asdict(info)
 
 
 @GET("/geofences")

--- a/tests/test_clustering.py
+++ b/tests/test_clustering.py
@@ -1,0 +1,15 @@
+from piwardrive.analytics.clustering import cluster_positions
+
+
+def test_cluster_positions_basic() -> None:
+    records = [
+        {"lat": 0.0, "lon": 0.0},
+        {"lat": 0.0001, "lon": 0.0},
+        {"lat": 1.0, "lon": 1.0},
+    ]
+    centers = cluster_positions(records, eps=0.001, min_samples=1)
+    assert len(centers) == 2
+
+
+def test_cluster_positions_empty() -> None:
+    assert cluster_positions([]) == []

--- a/tests/test_fingerprint_persistence.py
+++ b/tests/test_fingerprint_persistence.py
@@ -1,0 +1,22 @@
+import asyncio
+from datetime import datetime
+from pathlib import Path
+
+from piwardrive import persistence
+
+
+def setup_tmp(tmp_path: Path) -> None:
+    persistence.config.CONFIG_DIR = str(tmp_path)
+
+
+def test_save_and_load_fingerprint_info(tmp_path: Path) -> None:
+    setup_tmp(tmp_path)
+    info = persistence.FingerprintInfo(
+        environment="test",
+        source="file",
+        record_count=5,
+        created_at=datetime.now().isoformat(),
+    )
+    asyncio.run(persistence.save_fingerprint_info(info))
+    rows = asyncio.run(persistence.load_fingerprint_info())
+    assert rows and rows[0].environment == "test"

--- a/webui/src/components/DashboardLayout.jsx
+++ b/webui/src/components/DashboardLayout.jsx
@@ -11,11 +11,10 @@ import GPSStatus from './GPSStatus.jsx';
 import StorageUsage from './StorageUsage.jsx';
 import DiskUsageTrend from './DiskUsageTrend.jsx';
 import VehicleSpeed from './VehicleSpeed.jsx';
-import DBStats from './DBStats.jsx';
 import HealthStatus from './HealthStatus.jsx';
 import HealthAnalysis from './HealthAnalysis.jsx';
-import LoRaScan from './LoRaScan.jsx';
 import LogViewer from './LogViewer.jsx';
+import FingerprintSummary from './FingerprintSummary.jsx';
 
 const COMPONENTS = {
   BatteryStatusWidget: BatteryStatus,
@@ -25,15 +24,15 @@ const COMPONENTS = {
   NetworkThroughputWidget: NetworkThroughput,
   CPUTempGraphWidget: CPUTempGraph,
   LoRaScanWidget: LoRaScan,
-  DBStatsWidget: DBStats,
   GPSStatusWidget: GPSStatus,
   StorageUsageWidget: StorageUsage,
   DiskUsageTrendWidget: DiskUsageTrend,
   VehicleSpeedWidget: VehicleSpeed,
-  DBStatsWidget: DBStats,
   HealthStatusWidget: HealthStatus,
   HealthAnalysisWidget: HealthAnalysis,
   LogViewer: LogViewer,
+  DBStatsWidget: DBStats,
+  FingerprintSummaryWidget: FingerprintSummary,
 };
 
 export default function DashboardLayout({ metrics }) {

--- a/webui/src/components/FingerprintSummary.jsx
+++ b/webui/src/components/FingerprintSummary.jsx
@@ -1,0 +1,20 @@
+import { useEffect, useState } from 'react';
+
+export default function FingerprintSummary() {
+  const [items, setItems] = useState(null);
+
+  useEffect(() => {
+    const load = () => {
+      fetch('/fingerprints')
+        .then(r => r.json())
+        .then(d => setItems(d.fingerprints || []))
+        .catch(() => setItems(null));
+    };
+    load();
+    const id = setInterval(load, 10000);
+    return () => clearInterval(id);
+  }, []);
+
+  if (!items) return <div>Fingerprints: N/A</div>;
+  return <div>Fingerprints: {items.length}</div>;
+}


### PR DESCRIPTION
## Summary
- add DBSCAN clustering helper
- store fingerprint metadata in SQLite
- expose `/fingerprints` API endpoints
- display fingerprint summary in React dashboard
- test clustering and persistence logic

## Testing
- `pytest tests/test_clustering.py tests/test_fingerprint_persistence.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6862f3be1d9883338f8a7f9b37f6898b