### PR TITLE
Add time-based playback

### DIFF
--- a/docs/status_service.rst
+++ b/docs/status_service.rst
@@ -137,6 +137,12 @@ environments where WebSockets are unavailable::
 The stream sends events formatted as JSON with the same ``seq`` and
 ``timestamp`` metadata.
 
+``/sse/history`` streams saved health records for time-based playback. Use
+``limit`` and ``interval`` to control the number of records and delay between
+events::
+
+   curl "http://localhost:8000/sse/history?limit=20&interval=0.5"
+
 Set ``PW_API_PASSWORD_HASH`` to require HTTP basic auth for all routes.
 
 Benchmark

--- a/docs/web_ui.rst
+++ b/docs/web_ui.rst
@@ -63,6 +63,14 @@ When GPS data is available the web interface predicts future positions using the
 two most recent fixes. It then downloads tiles along the anticipated path based
 on the ``route_prefetch_interval`` and ``route_prefetch_lookahead`` settings.
 
+Playback
+--------
+
+Historical health records can be reviewed directly in the browser. The
+``HealthPlayback`` component connects to ``/sse/history`` and displays each
+record at a configurable interval. Add the widget to your dashboard layout to
+step through past metrics.
+
 Authentication
 --------------
 

--- a/src/piwardrive/core/persistence.py
+++ b/src/piwardrive/core/persistence.py
@@ -217,6 +217,39 @@ async def load_recent_health(limit: int = 10) -> List[HealthRecord]:
     return [HealthRecord(**dict(row)) for row in rows]
 
 
+async def iter_health_history(
+    start: str | None = None, end: str | None = None
+) -> AsyncIterator[HealthRecord]:
+    """Yield :class:`HealthRecord` rows between ``start`` and ``end``."""
+    await flush_health_records()
+    conn = await _get_conn()
+    query = (
+        "SELECT timestamp, cpu_temp, cpu_percent, memory_percent, disk_percent"
+        " FROM health_records"
+    )
+    params: list[str] = []
+    if start and end:
+        query += " WHERE timestamp >= ? AND timestamp <= ?"
+        params = [start, end]
+    elif start:
+        query += " WHERE timestamp >= ?"
+        params = [start]
+    elif end:
+        query += " WHERE timestamp <= ?"
+        params = [end]
+    query += " ORDER BY timestamp"
+    cur = await conn.execute(query, tuple(params))
+    async for row in cur:
+        yield HealthRecord(**dict(row))
+
+
+async def load_health_history(
+    start: str | None = None, end: str | None = None
+) -> List[HealthRecord]:
+    """Return a list of :class:`HealthRecord` rows between ``start`` and ``end``."""
+    return [rec async for rec in iter_health_history(start, end)]
+
+
 async def purge_old_health(days: int) -> None:
     """Delete ``health_records`` older than ``days`` days."""
     await flush_health_records()

--- a/webui/src/components/HealthPlayback.jsx
+++ b/webui/src/components/HealthPlayback.jsx
@@ -1,0 +1,33 @@
+import { useEffect, useState } from 'react';
+
+export default function HealthPlayback({ limit = 100, interval = 1.0 }) {
+  const [records, setRecords] = useState([]);
+
+  useEffect(() => {
+    const params = new URLSearchParams({ limit, interval });
+    const es = new EventSource(`/sse/history?${params}`);
+    es.onmessage = ev => {
+      try {
+        const data = JSON.parse(ev.data);
+        if (data.record) {
+          setRecords(prev => [...prev, data.record]);
+        }
+      } catch {
+        /* ignore */
+      }
+    };
+    return () => es.close();
+  }, [limit, interval]);
+
+  if (!records.length) return <div>No playback data</div>;
+
+  return (
+    <div>
+      <h3>Playback</h3>
+      <pre style={{ maxHeight: '200px', overflowY: 'auto' }}>
+        {JSON.stringify(records, null, 2)}
+      </pre>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add iter_health_history/load_health_history helpers
- support /sse/history endpoint
- implement HealthPlayback React component
- document playback usage

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `npm test` *(fails: tests/orientationSensors.test.js failed)*

------
https://chatgpt.com/codex/tasks/task_e_6862f3c368508333852c37d57c870d9e