### PR TITLE
Add webhook notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![Backend Coverage](https://codecov.io/gh/TRASHYTALK/piwardrive/branch/main/graph/badge.svg?flag=backend)](https://app.codecov.io/gh/TRASHYTALK/piwardrive?flags=backend)
 [![Frontend Coverage](https://codecov.io/gh/TRASHYTALK/piwardrive/branch/main/graph/badge.svg?flag=frontend)](https://app.codecov.io/gh/TRASHYTALK/piwardrive?flags=frontend)
 
-
 PiWardrive is a headless mapping and diagnostic suite for Raspberry Pi 5. It merges war-driving tools such as Kismet and BetterCAP with a lightweight command line SIGINT suite for scanning. The primary interface is a browser-based dashboard built with React. Launch it after building the frontend with:
 
 ```bash
@@ -59,6 +58,7 @@ graph LR
 - Status service with React web UI
 - Plugin widgets dynamically loaded in the web UI
 - Offline-capable PWA frontend
+- Webhook notifications for high CPU or disk usage
 
 ## Data Handling
 
@@ -200,11 +200,10 @@ source gui-env/bin/activate
 
 8. (Optional) copy `examples/piwardrive.service` into `/etc/systemd/system/` and enable it to run the API on boot:
 
-
-    ```bash
-    sudo cp examples/piwardrive-webui.service /etc/systemd/system/
-    sudo systemctl enable --now piwardrive-webui.service
-    ```
+   ```bash
+   sudo cp examples/piwardrive-webui.service /etc/systemd/system/
+   sudo systemctl enable --now piwardrive-webui.service
+   ```
 
 9. Start the application manually if the service is not enabled:
 
@@ -491,6 +490,7 @@ Password hashing guidelines are covered in [docs/security.rst](docs/security.rst
 
 Comprehensive guides and API references live in the `docs/` directory. Run `make html` there to build the Sphinx site. High level summaries are collected in [REFERENCE.md](REFERENCE.md).
 Detailed examples for each command line helper are available in [docs/cli_tools.rst](docs/cli_tools.rst).
+See [docs/notifications.rst](docs/notifications.rst) for enabling webhook alerts.
 
 ## Contributing
 

--- a/docs/config_schema.json
+++ b/docs/config_schema.json
@@ -2,12 +2,7 @@
   "$defs": {
     "Theme": {
       "description": "Available UI themes.",
-      "enum": [
-        "Dark",
-        "Light",
-        "Green",
-        "Red"
-      ],
+      "enum": ["Dark", "Light", "Green", "Red"],
       "title": "Theme",
       "type": "string"
     }
@@ -469,6 +464,25 @@
       "title": "Log Tail Cache Seconds",
       "type": "number"
     },
+    "notification_webhooks": {
+      "items": {
+        "type": "string"
+      },
+      "title": "Notification Webhooks",
+      "type": "array"
+    },
+    "notify_cpu_temp": {
+      "default": 80.0,
+      "minimum": 0,
+      "title": "Notify Cpu Temp",
+      "type": "number"
+    },
+    "notify_disk_percent": {
+      "default": 90.0,
+      "minimum": 0,
+      "title": "Notify Disk Percent",
+      "type": "number"
+    },
     "wigle_api_name": {
       "anyOf": [
         {
@@ -541,12 +555,35 @@
       ],
       "default": null,
       "title": "Cloud Profile"
+    },
+    "mysql_host": {
+      "default": "localhost",
+      "title": "Mysql Host",
+      "type": "string"
+    },
+    "mysql_port": {
+      "default": 3306,
+      "minimum": 1,
+      "title": "Mysql Port",
+      "type": "integer"
+    },
+    "mysql_user": {
+      "default": "piwardrive",
+      "title": "Mysql User",
+      "type": "string"
+    },
+    "mysql_password": {
+      "default": "",
+      "title": "Mysql Password",
+      "type": "string"
+    },
+    "mysql_db": {
+      "default": "piwardrive",
+      "title": "Mysql Db",
+      "type": "string"
     }
   },
-  "required": [
-    "theme",
-    "map_poll_gps"
-  ],
+  "required": ["theme", "map_poll_gps"],
   "title": "ConfigModel",
   "type": "object"
 }

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -49,6 +49,7 @@ Common issues are answered in the :doc:`faq`.
    drone_mapping
    r_integration
    grafana
-    web_ui
-    faq
-    legal
+   notifications
+   web_ui
+   faq
+   legal

--- a/docs/notifications.rst
+++ b/docs/notifications.rst
@@ -1,0 +1,43 @@
+Notifications
+=============
+
+PiWardrive can send HTTP POST requests to external services when certain
+thresholds are exceeded.  CPU temperature and disk usage are monitored
+by :class:`piwardrive.notifications.NotificationManager` which runs in the
+background.
+
+Configuration
+-------------
+
+Add webhook URLs to ``notification_webhooks`` inside ``config.json``.  The
+``notify_cpu_temp`` and ``notify_disk_percent`` fields control when alerts are
+triggered.  Example::
+
+   {
+       "notification_webhooks": ["http://localhost:9000/hook"],
+       "notify_cpu_temp": 75.0,
+       "notify_disk_percent": 85.0
+   }
+
+Webhooks receive a JSON body containing ``event`` and ``value`` keys.  Possible
+events are ``"cpu_temp"`` and ``"disk_percent"``.
+
+REST API
+--------
+
+The status service exposes ``/webhooks`` for managing the URL list::
+
+   curl http://localhost:8000/webhooks
+   curl -X POST -H 'Content-Type: application/json' \
+        -d '["http://localhost:9000/hook"]' http://localhost:8000/webhooks
+
+Testing
+-------
+
+Run a simple server that prints incoming requests::
+
+   python -m http.server 9000
+
+Then configure ``notification_webhooks`` to point at
+``http://localhost:9000``.  Trigger high CPU load or fill the disk to verify
+that a POST request is sent.

--- a/src/piwardrive/core/config.py
+++ b/src/piwardrive/core/config.py
@@ -39,6 +39,8 @@ ROUTE_PREFETCH_LOOKAHEAD = 5
 REMOTE_SYNC_INTERVAL = 60  # minutes
 HANDSHAKE_CACHE_SECONDS_DEFAULT = 10.0
 LOG_TAIL_CACHE_SECONDS_DEFAULT = 1.0
+NOTIFY_CPU_TEMP_DEFAULT = 80.0
+NOTIFY_DISK_PERCENT_DEFAULT = 90.0
 
 # Cloud upload defaults
 CLOUD_BUCKET = ""
@@ -120,6 +122,9 @@ class Config:
     remote_sync_interval: int = REMOTE_SYNC_INTERVAL  # noqa: V107
     handshake_cache_seconds: float = HANDSHAKE_CACHE_SECONDS_DEFAULT  # noqa: V107
     log_tail_cache_seconds: float = LOG_TAIL_CACHE_SECONDS_DEFAULT  # noqa: V107
+    notification_webhooks: List[str] = field(default_factory=list)  # noqa: V107
+    notify_cpu_temp: float = NOTIFY_CPU_TEMP_DEFAULT  # noqa: V107
+    notify_disk_percent: float = NOTIFY_DISK_PERCENT_DEFAULT  # noqa: V107
     wigle_api_name: str = ""  # noqa: V107
     wigle_api_key: str = ""  # noqa: V107
     gps_movement_threshold: float = 1.0  # noqa: V107
@@ -196,6 +201,9 @@ class FileConfigModel(BaseModel):
     remote_sync_interval: Optional[int] = Field(default=None, ge=1)
     handshake_cache_seconds: Optional[float] = Field(default=None, ge=0)
     log_tail_cache_seconds: Optional[float] = Field(default=None, ge=0)
+    notification_webhooks: List[str] = Field(default_factory=list)
+    notify_cpu_temp: Optional[float] = Field(default=None, ge=0)
+    notify_disk_percent: Optional[float] = Field(default=None, ge=0)
     wigle_api_name: Optional[str] = None
     wigle_api_key: Optional[str] = None
     gps_movement_threshold: Optional[float] = Field(default=None, gt=0)
@@ -231,6 +239,9 @@ class ConfigModel(FileConfigModel):
     log_tail_cache_seconds: float = Field(
         default=DEFAULTS["log_tail_cache_seconds"], ge=0
     )
+    notification_webhooks: List[str] = Field(default_factory=list)
+    notify_cpu_temp: float = Field(default=DEFAULTS["notify_cpu_temp"], ge=0)
+    notify_disk_percent: float = Field(default=DEFAULTS["notify_disk_percent"], ge=0)
     mysql_host: str = DEFAULTS["mysql_host"]
     mysql_port: int = Field(default=DEFAULTS["mysql_port"], ge=1)
     mysql_user: str = DEFAULTS["mysql_user"]
@@ -452,6 +463,9 @@ class AppConfig:
     remote_sync_interval: int = DEFAULTS["remote_sync_interval"]
     handshake_cache_seconds: float = DEFAULTS["handshake_cache_seconds"]
     log_tail_cache_seconds: float = DEFAULTS["log_tail_cache_seconds"]
+    notification_webhooks: List[str] = field(default_factory=list)
+    notify_cpu_temp: float = DEFAULTS["notify_cpu_temp"]
+    notify_disk_percent: float = DEFAULTS["notify_disk_percent"]
     wigle_api_name: str = DEFAULTS["wigle_api_name"]
     wigle_api_key: str = DEFAULTS["wigle_api_key"]
     gps_movement_threshold: float = DEFAULTS["gps_movement_threshold"]

--- a/src/piwardrive/main.py
+++ b/src/piwardrive/main.py
@@ -9,7 +9,7 @@ import time
 from dataclasses import asdict, fields
 from typing import Any, Callable
 
-from piwardrive import diagnostics, exception_handler, remote_sync, utils
+from piwardrive import diagnostics, exception_handler, notifications, remote_sync, utils
 from piwardrive.config import (
     CONFIG_PATH,
     Config,
@@ -82,6 +82,13 @@ class PiWardriveApp:
                 ),
                 self.config_data.remote_sync_interval * 60,
             )
+
+        self.notifications = notifications.NotificationManager(
+            self.scheduler,
+            webhooks=self.config_data.notification_webhooks,
+            cpu_temp_threshold=self.config_data.notify_cpu_temp,
+            disk_percent_threshold=self.config_data.notify_disk_percent,
+        )
         if os.getenv("PW_PROFILE"):
             diagnostics.start_profiling()
         self._config_stamp = config_mtime()

--- a/src/piwardrive/notifications.py
+++ b/src/piwardrive/notifications.py
@@ -1,0 +1,77 @@
+"""Webhook notification helpers."""
+
+from __future__ import annotations
+
+import logging
+from typing import Iterable, List
+
+import httpx
+
+from .core import config
+from .scheduler import PollScheduler
+from .utils import get_cpu_temp, get_disk_usage, run_async_task
+
+logger = logging.getLogger(__name__)
+
+
+class NotificationManager:
+    """Send webhook notifications when thresholds are exceeded."""
+
+    def __init__(
+        self,
+        scheduler: PollScheduler,
+        *,
+        interval: int = 60,
+        webhooks: Iterable[str] | None = None,
+        cpu_temp_threshold: float | None = None,
+        disk_percent_threshold: float | None = None,
+    ) -> None:
+        self._scheduler = scheduler
+        self.webhooks: List[str] = list(webhooks or [])
+        cfg = config.AppConfig.load()
+        self.cpu_temp_threshold = (
+            cpu_temp_threshold
+            if cpu_temp_threshold is not None
+            else cfg.notify_cpu_temp
+        )
+        self.disk_percent_threshold = (
+            disk_percent_threshold
+            if disk_percent_threshold is not None
+            else cfg.notify_disk_percent
+        )
+        self._event = "notification_check"
+        self._cpu_alert = False
+        self._disk_alert = False
+        scheduler.schedule(
+            self._event, lambda _dt: run_async_task(self._check()), interval
+        )
+
+    async def _post(self, payload: dict) -> None:
+        if not self.webhooks:
+            return
+        async with httpx.AsyncClient() as client:
+            for url in self.webhooks:
+                try:
+                    await client.post(url, json=payload, timeout=5)
+                except Exception as exc:  # pragma: no cover - network errors
+                    logger.warning("notification to %s failed: %s", url, exc)
+
+    async def _check(self) -> None:
+        cpu = get_cpu_temp()
+        disk = get_disk_usage("/")
+        if cpu is not None and self.cpu_temp_threshold > 0:
+            if cpu >= self.cpu_temp_threshold and not self._cpu_alert:
+                await self._post({"event": "cpu_temp", "value": cpu})
+                self._cpu_alert = True
+            elif cpu < self.cpu_temp_threshold - 5:
+                self._cpu_alert = False
+        if disk is not None and self.disk_percent_threshold > 0:
+            if disk >= self.disk_percent_threshold and not self._disk_alert:
+                await self._post({"event": "disk_percent", "value": disk})
+                self._disk_alert = True
+            elif disk < self.disk_percent_threshold - 5:
+                self._disk_alert = False
+
+    def update_webhooks(self, urls: Iterable[str]) -> None:
+        """Replace the configured webhook URL list."""
+        self.webhooks = list(urls)

--- a/src/piwardrive/service.py
+++ b/src/piwardrive/service.py
@@ -539,6 +539,24 @@ async def update_config_endpoint(
     return data
 
 
+@GET("/webhooks")
+async def get_webhooks_endpoint(_auth: None = AUTH_DEP) -> dict[str, list[str]]:
+    """Return configured notification webhook URLs."""
+    cfg = config.load_config()
+    return {"webhooks": list(cfg.notification_webhooks)}
+
+
+@POST("/webhooks")
+async def update_webhooks_endpoint(
+    urls: list[str] = BODY, _auth: None = AUTH_DEP
+) -> dict[str, list[str]]:
+    """Update notification webhook URL list."""
+    cfg = config.load_config()
+    cfg.notification_webhooks = list(urls)
+    config.save_config(cfg)
+    return {"webhooks": cfg.notification_webhooks}
+
+
 @GET("/dashboard-settings")
 async def get_dashboard_settings_endpoint(
     _auth: None = AUTH_DEP,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,9 +1,9 @@
 """Tests for the configuration module."""
 
+import builtins
 import json
 import os
 import sys
-import builtins
 from dataclasses import asdict
 from pathlib import Path
 from typing import Any
@@ -312,3 +312,13 @@ def test_export_config_missing_yaml(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setitem(sys.modules, "yaml", None)
     with pytest.raises(config.ConfigError, match="PyYAML required"):
         config.export_config(cfg, str(dest))
+
+
+def test_save_load_webhooks(tmp_path: Path) -> None:
+    cfg_file = setup_temp_config(tmp_path)
+    cfg = config.load_config()
+    cfg.notification_webhooks = ["http://x"]
+    config.save_config(cfg)
+    assert Path(cfg_file).is_file()
+    loaded = config.load_config()
+    assert loaded.notification_webhooks == ["http://x"]

--- a/tests/test_core_config_extra.py
+++ b/tests/test_core_config_extra.py
@@ -144,3 +144,9 @@ def test_export_config_missing_yaml(tmp_path, monkeypatch):
     monkeypatch.setitem(sys.modules, "yaml", None)
     with pytest.raises(config.ConfigError, match="PyYAML required"):
         config.export_config(cfg, str(dest))
+
+
+def test_env_override_webhooks(monkeypatch):
+    monkeypatch.setenv("PW_NOTIFICATION_WEBHOOKS", '["http://h"]')
+    cfg = config.AppConfig.load()
+    assert cfg.notification_webhooks == ["http://h"]


### PR DESCRIPTION
## Summary
- support webhook notifications
- allow managing webhooks via REST
- document how to enable the alerts
- test new config fields

## Testing
- `pre-commit run --files README.md docs/config_schema.json docs/index.rst docs/notifications.rst src/piwardrive/core/config.py src/piwardrive/main.py src/piwardrive/service.py src/piwardrive/notifications.py tests/test_config.py tests/test_core_config_extra.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862f3ca596c8333b2c395d19f033af3