### PR TITLE
Add data sinks and ML hook support

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -103,3 +103,21 @@ Cache Tuning
 
 ``log_tail_cache_seconds``
     Duration to cache tailed log lines before checking for updates.
+
+Data Sink Integrations
+----------------------
+
+``influx_url``
+    Base URL for an InfluxDB server.
+
+``influx_token``
+    Access token used for writes.
+
+``influx_org``
+    Organisation name associated with ``influx_token``.
+
+``influx_bucket``
+    Bucket receiving uploaded points.
+
+``postgres_dsn``
+    Connection string for a Postgres database.

--- a/docs/environment.rst
+++ b/docs/environment.rst
@@ -232,6 +232,16 @@ All available overrides are summarised below.
      - ``wigle_api_key``
    * - ``PW_WIGLE_API_NAME``
      - ``wigle_api_name``
+   * - ``PW_INFLUX_URL``
+     - ``influx_url``
+   * - ``PW_INFLUX_TOKEN``
+     - ``influx_token``
+   * - ``PW_INFLUX_ORG``
+     - ``influx_org``
+   * - ``PW_INFLUX_BUCKET``
+     - ``influx_bucket``
+   * - ``PW_POSTGRES_DSN``
+     - ``postgres_dsn``
 
 Using a ``.env`` File
 ---------------------

--- a/src/piwardrive/analysis.py
+++ b/src/piwardrive/analysis.py
@@ -87,3 +87,35 @@ def plot_cpu_temp(
     plt.tight_layout()
     plt.savefig(path)
     plt.close()
+
+
+# ─────────────────────────────────────────────────────────────
+# External ML hooks
+
+from typing import Callable
+
+_ML_HOOKS: list[Callable[[HealthRecord], None]] = []
+
+
+def register_ml_hook(func: Callable[[HealthRecord], None]) -> None:
+    """Register ``func`` to be called with each new :class:`HealthRecord`."""
+    _ML_HOOKS.append(func)
+
+
+def process_new_record(record: HealthRecord) -> None:
+    """Invoke registered ML hooks with ``record``."""
+    for hook in list(_ML_HOOKS):
+        try:
+            hook(record)
+        except Exception:  # pragma: no cover - third-party hooks
+            import logging
+
+            logging.exception("ML hook %s failed", hook)
+
+
+__all__ = [
+    "compute_health_stats",
+    "plot_cpu_temp",
+    "register_ml_hook",
+    "process_new_record",
+]

--- a/src/piwardrive/core/config.py
+++ b/src/piwardrive/core/config.py
@@ -131,6 +131,11 @@ class Config:
     mysql_user: str = "piwardrive"  # noqa: V107
     mysql_password: str = ""  # noqa: V107
     mysql_db: str = "piwardrive"  # noqa: V107
+    influx_url: str = ""  # noqa: V107
+    influx_token: str = ""  # noqa: V107
+    influx_org: str = ""  # noqa: V107
+    influx_bucket: str = ""  # noqa: V107
+    postgres_dsn: str = ""  # noqa: V107
 
 
 DEFAULT_CONFIG = Config()
@@ -207,6 +212,11 @@ class FileConfigModel(BaseModel):
     mysql_user: Optional[str] = None
     mysql_password: Optional[str] = None
     mysql_db: Optional[str] = None
+    influx_url: Optional[str] = None
+    influx_token: Optional[str] = None
+    influx_org: Optional[str] = None
+    influx_bucket: Optional[str] = None
+    postgres_dsn: Optional[str] = None
 
 
 class ConfigModel(FileConfigModel):
@@ -236,6 +246,11 @@ class ConfigModel(FileConfigModel):
     mysql_user: str = DEFAULTS["mysql_user"]
     mysql_password: str = DEFAULTS["mysql_password"]
     mysql_db: str = DEFAULTS["mysql_db"]
+    influx_url: str = DEFAULTS["influx_url"]
+    influx_token: str = DEFAULTS["influx_token"]
+    influx_org: str = DEFAULTS["influx_org"]
+    influx_bucket: str = DEFAULTS["influx_bucket"]
+    postgres_dsn: str = DEFAULTS["postgres_dsn"]
 
     theme: Theme
 

--- a/src/piwardrive/data_sink.py
+++ b/src/piwardrive/data_sink.py
@@ -1,0 +1,67 @@
+"""Helpers for uploading data to various storage backends."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any, Iterable, Mapping
+
+from . import cloud_export
+
+logger = logging.getLogger(__name__)
+
+
+async def upload_to_s3(
+    path: str, bucket: str, key: str, profile: str | None = None
+) -> None:
+    """Upload ``path`` to an S3 ``bucket`` using :mod:`cloud_export`."""
+    await asyncio.to_thread(cloud_export.upload_to_s3, path, bucket, key, profile)
+
+
+async def write_influxdb(
+    url: str,
+    token: str,
+    org: str,
+    bucket: str,
+    records: Iterable[str],
+) -> None:
+    """POST line protocol ``records`` to InfluxDB."""
+    try:
+        from aiohttp import ClientSession
+    except Exception as exc:  # pragma: no cover - optional dep
+        raise RuntimeError("aiohttp required for InfluxDB uploads") from exc
+
+    endpoint = f"{url.rstrip('/')}/api/v2/write"
+    params = {"org": org, "bucket": bucket, "precision": "s"}
+    headers = {"Authorization": f"Token {token}"}
+    data = "\n".join(records).encode()
+    async with ClientSession() as session:
+        async with session.post(
+            endpoint, params=params, data=data, headers=headers
+        ) as resp:
+            resp.raise_for_status()
+
+
+async def write_postgres(
+    dsn: str, table: str, rows: Iterable[Mapping[str, Any]]
+) -> None:
+    """Insert ``rows`` into ``table`` on the Postgres server ``dsn``."""
+    try:
+        import asyncpg
+    except Exception as exc:  # pragma: no cover - optional dep
+        raise RuntimeError("asyncpg required for Postgres uploads") from exc
+
+    rows = list(rows)
+    if not rows:
+        return
+
+    columns = list(rows[0].keys())
+    values = [tuple(r[c] for c in columns) for r in rows]
+    placeholders = ", ".join(f"${i}" for i in range(1, len(columns) + 1))
+    query = f'INSERT INTO {table} ({", ".join(columns)}) VALUES ({placeholders})'
+
+    conn = await asyncpg.connect(dsn)
+    try:
+        await conn.executemany(query, values)
+    finally:
+        await conn.close()

--- a/src/piwardrive/diagnostics.py
+++ b/src/piwardrive/diagnostics.py
@@ -276,6 +276,12 @@ class HealthMonitor:
                 disk_percent=system.get("disk_percent", 0.0),
             )
             await save_health_record(rec)
+            try:
+                from piwardrive import analysis
+
+                analysis.process_new_record(rec)
+            except Exception:  # pragma: no cover - optional hooks
+                logging.exception("ML processing failed")
             await purge_old_health(30)
             await vacuum()
         except Exception as exc:  # pragma: no cover - diagnostics best-effort

--- a/tests/test_analysis_hooks.py
+++ b/tests/test_analysis_hooks.py
@@ -1,0 +1,30 @@
+import sys
+from types import ModuleType
+
+# Stub aiosqlite so importing persistence works without the dependency
+fake_aiosqlite = ModuleType("aiosqlite")
+fake_aiosqlite.Connection = object  # type: ignore[attr-defined]
+sys.modules.setdefault("aiosqlite", fake_aiosqlite)
+
+# Minimal pydantic stub for config import
+fake_pydantic = ModuleType("pydantic")
+fake_pydantic.BaseModel = object  # type: ignore[attr-defined]
+fake_pydantic.Field = lambda *a, **k: None  # type: ignore[attr-defined]
+fake_pydantic.ValidationError = type("VE", (), {})  # type: ignore[attr-defined]
+fake_pydantic.field_validator = lambda *a, **k: (lambda f: f)  # type: ignore[attr-defined]
+sys.modules.setdefault("pydantic", fake_pydantic)
+
+from piwardrive import analysis
+from piwardrive.persistence import HealthRecord
+
+
+def test_ml_hook_invoked():
+    called = []
+
+    def hook(rec: HealthRecord) -> None:
+        called.append(rec.timestamp)
+
+    analysis.register_ml_hook(hook)
+    rec = HealthRecord("t", 1.0, 2.0, 3.0, 4.0)
+    analysis.process_new_record(rec)
+    assert called == ["t"]

--- a/tests/test_data_sink.py
+++ b/tests/test_data_sink.py
@@ -1,0 +1,76 @@
+import asyncio
+import sys
+from types import ModuleType
+
+import piwardrive.data_sink as ds
+
+
+async def _run(coro):
+    return await coro
+
+
+def test_upload_to_s3(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        ds.cloud_export, "upload_to_s3", lambda *a, **k: calls.append(a)
+    )
+    asyncio.run(ds.upload_to_s3("f", "b", "k", "p"))
+    assert calls == [("f", "b", "k", "p")]
+
+
+def test_write_influxdb(monkeypatch):
+    calls = []
+
+    class Sess:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            pass
+
+        def post(self, url, params=None, data=None, headers=None):
+            calls.append((url, params, data, headers))
+
+            class Resp:
+                async def __aenter__(self):
+                    return self
+
+                async def __aexit__(self, exc_type, exc, tb):
+                    pass
+
+                def raise_for_status(self):
+                    pass
+
+            return Resp()
+
+    aiohttp = ModuleType("aiohttp")
+    aiohttp.ClientSession = lambda: Sess()
+    monkeypatch.setitem(sys.modules, "aiohttp", aiohttp)
+    asyncio.run(ds.write_influxdb("http://x", "tok", "org", "bucket", ["r1"]))
+    assert calls and calls[0][0].startswith("http://x")
+
+
+def test_write_postgres(monkeypatch):
+    rows = [{"a": 1}, {"a": 2}]
+
+    class Conn:
+        def __init__(self):
+            self.calls = []
+
+        async def executemany(self, q, vals):
+            self.calls.append((q, vals))
+
+        async def close(self):
+            self.calls.append("close")
+
+    conn = Conn()
+
+    async def fake_connect(dsn):
+        assert dsn == "dsn"
+        return conn
+
+    asyncpg = ModuleType("asyncpg")
+    asyncpg.connect = fake_connect  # type: ignore
+    monkeypatch.setitem(sys.modules, "asyncpg", asyncpg)
+    asyncio.run(ds.write_postgres("dsn", "tbl", rows))
+    assert conn.calls and conn.calls[0][0].startswith("INSERT INTO tbl")


### PR DESCRIPTION
## Summary
- add S3/InfluxDB/Postgres helpers in `data_sink`
- expose ML hooks in `analysis` and trigger them from `HealthMonitor`
- document new environment variables and configuration options
- support new config keys for external sinks
- test data sink utilities and ML hook invocation

## Testing
- `pre-commit run --files src/piwardrive/analysis.py tests/test_analysis_hooks.py tests/test_data_sink.py src/piwardrive/data_sink.py src/piwardrive/diagnostics.py src/piwardrive/core/config.py docs/environment.rst docs/configuration.rst` *(fails: ESLint couldn't find config)*
- `pytest -q tests/test_data_sink.py tests/test_analysis_hooks.py`

------
https://chatgpt.com/codex/tasks/task_e_6862f3ee3b8483339a86821909c696b8