### PR TITLE
Validate network throughput interval

### DIFF
--- a/src/piwardrive/widgets/net_throughput.py
+++ b/src/piwardrive/widgets/net_throughput.py
@@ -17,6 +17,8 @@ class NetworkThroughputWidget(DashboardWidget):
     ) -> None:
         """Set up throughput graphs and schedule polling."""
         super().__init__(**kwargs)
+        if update_interval <= 0:
+            raise ValueError(_("update_interval must be positive"))
         self.update_interval = update_interval
         self.max_points = max_points
         self.index: int = 0


### PR DESCRIPTION
## Summary
- guard against invalid update interval for the NetworkThroughputWidget

## Testing
- `python -m py_compile src/piwardrive/widgets/net_throughput.py`
- `pytest -k net_throughput -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6862fb17d8a48333800e6a9ca0c208fd