### PR TITLE
Validate playback interval

### DIFF
--- a/src/piwardrive/gps_track_playback.py
+++ b/src/piwardrive/gps_track_playback.py
@@ -12,6 +12,9 @@ async def playback_track(
     interval: float = 1.0,
 ) -> None:
     """Replay ``points`` by invoking ``callback`` for each coordinate."""
+    if interval <= 0:
+        raise ValueError(f"interval must be > 0, got {interval}")
+
     for lat, lon in points:
         await callback(lat, lon)
         await asyncio.sleep(interval)


### PR DESCRIPTION
## Summary
- raise `ValueError` when a non-positive interval is passed to `playback_track`

## Testing
- `pytest -q` *(fails: 39 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6862fb266648833382e483af5621628f