### PR TITLE
Fix tail_file early return

### DIFF
--- a/src/piwardrive/core/utils.py
+++ b/src/piwardrive/core/utils.py
@@ -562,6 +562,8 @@ def find_latest_file(directory: str, pattern: str = "*") -> str | None:
 
 def tail_file(path: str, lines: int = 50) -> list[str]:
     """Return the last ``lines`` from ``path`` efficiently using ``mmap``."""
+    if lines <= 0:
+        return []
     now = time.time()
     try:
         mtime = os.path.getmtime(path)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -76,6 +76,17 @@ def test_tail_file_missing_returns_empty_list() -> None:
     assert result == []
 
 
+def test_tail_file_nonpositive_lines() -> None:
+    with tempfile.NamedTemporaryFile("w+", delete=False) as tmp:
+        tmp.write("line0\nline1\n")
+        tmp_path = tmp.name
+    try:
+        assert utils.tail_file(tmp_path, lines=0) == []
+        assert utils.tail_file(tmp_path, lines=-1) == []
+    finally:
+        os.unlink(tmp_path)
+
+
 def test_tail_file_handles_large_file(tmp_path: Any) -> None:
     path = tmp_path / "large.txt"
     with open(path, "w") as f:


### PR DESCRIPTION
## Summary
- handle non-positive `lines` in `tail_file`
- add regression test

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6862fb10132c8333af3e2698bd098dee