### PR TITLE
Add validation to heatmap bin and radius

### DIFF
--- a/src/piwardrive/heatmap.py
+++ b/src/piwardrive/heatmap.py
@@ -6,8 +6,20 @@ from typing import Iterable, List, Sequence, Tuple
 
 
 def _get_bins(bins: int | Tuple[int, int]) -> Tuple[int, int]:
-    """Return latitude/longitude bin counts."""
-    return (bins, bins) if isinstance(bins, int) else bins
+    """Return latitude/longitude bin counts.
+
+    ``bins`` may be specified as a single integer or a ``(lat, lon)`` tuple. All
+    values must be strictly positive, otherwise a ``ValueError`` is raised.
+    """
+    if isinstance(bins, int):
+        if bins <= 0:
+            raise ValueError("bin count must be positive")
+        return (bins, bins)
+
+    lat_bins, lon_bins = bins
+    if lat_bins <= 0 or lon_bins <= 0:
+        raise ValueError("bin count must be positive")
+    return lat_bins, lon_bins
 
 
 def _derive_bounds(pts: list[Coord]) -> Tuple[float, float, float, float]:
@@ -122,6 +134,8 @@ def _spread_density(hist: Sequence[Sequence[int]], radius: int) -> List[List[int
     bins_lat = len(hist)
     bins_lon = len(hist[0]) if hist else 0
     density = [[0 for _ in range(bins_lon)] for _ in range(bins_lat)]
+    if radius <= 0:
+        raise ValueError("radius must be positive")
     for i, row in enumerate(hist):
         for j, count in enumerate(row):
             if count <= 0:

--- a/tests/test_heatmap.py
+++ b/tests/test_heatmap.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import pytest
 
 from piwardrive import heatmap
 
@@ -40,3 +41,15 @@ def test_coverage_map_binary():
     flat = [c for row in cov for c in row]
     assert all(v in (0, 1) for v in flat)
     assert sum(flat) > 1
+
+
+def test_histogram_invalid_bins():
+    with pytest.raises(ValueError):
+        heatmap.histogram([], bins=0)
+    with pytest.raises(ValueError):
+        heatmap.histogram([], bins=(1, 0))
+
+
+def test_density_map_invalid_radius():
+    with pytest.raises(ValueError):
+        heatmap.density_map([], radius=0)


### PR DESCRIPTION
## Summary
- validate bin counts in `_get_bins`
- reject zero or negative radius in `_spread_density`
- add tests for new validation rules

## Testing
- `pytest tests/test_heatmap.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: 'numpy', 'fastapi', 'aiosqlite', 'requests', 'requests_cache')*

------
https://chatgpt.com/codex/tasks/task_e_6862fb20fcbc8333be7d7d8252188383