### PR TITLE
Fix lookahead slicing logic

### DIFF
--- a/src/piwardrive/route_prefetch.py
+++ b/src/piwardrive/route_prefetch.py
@@ -93,9 +93,12 @@ class RoutePrefetcher:
 
     def _run(self) -> None:
         try:
-            points: list[tuple[float, float]] = list(
-                getattr(self._map_screen, "track_points", [])
-            )[-self._lookahead :]
+            track = list(getattr(self._map_screen, "track_points", []))
+            if self._lookahead > 0:
+                points: list[tuple[float, float]] = track[-self._lookahead :]
+            else:
+                points = []
+
             points += self._predict_points()
             if not points:
                 return


### PR DESCRIPTION
## Summary
- prevent lookahead<=0 from using entire track when prefetching
- add regression test for zero lookahead
- fix missing pytest import in tests

## Testing
- `pytest -q tests/test_route_prefetch.py -vv`

------
https://chatgpt.com/codex/tasks/task_e_6862fb136b6483338ef3c199a05b8a5a