### PR TITLE
Make continuous scanning async

### DIFF
--- a/src/piwardrive/integrations/sigint_suite/scripts/continuous_scan.py
+++ b/src/piwardrive/integrations/sigint_suite/scripts/continuous_scan.py
@@ -1,6 +1,7 @@
 """Module continuous_scan."""
 
 import argparse
+import asyncio
 import os
 
 from piwardrive.sigint_suite import continuous_scan, paths
@@ -42,10 +43,12 @@ def main(argv: list[str] | None = None) -> None:
 
     os.makedirs(args.export_dir, exist_ok=True)
 
-    continuous_scan.run_continuous_scan(
-        interval=args.interval,
-        iterations=args.iterations,
-        on_result=lambda res: _save_results(args.export_dir, res),
+    asyncio.run(
+        continuous_scan.run_continuous_scan(
+            interval=args.interval,
+            iterations=args.iterations,
+            on_result=lambda res: _save_results(args.export_dir, res),
+        )
     )
 
 


### PR DESCRIPTION
## Summary
- update continuous scanning to run wifi and bluetooth scans concurrently
- adjust CLI entry point
- update unit tests for async scan loop

## Testing
- `pre-commit run --files src/piwardrive/integrations/sigint_suite/continuous_scan.py src/piwardrive/integrations/sigint_suite/scripts/continuous_scan.py tests/test_continuous_scan.py` *(fails: ESLint couldn't find a configuration file)*
- `pytest -q` *(fails: ModuleNotFoundError: numpy, fastapi, requests, ...)*

------
https://chatgpt.com/codex/tasks/task_e_6862fb43b9708333863d9ceeb316fdc7