### PR TITLE
Fix allowed log paths set

### DIFF
--- a/src/piwardrive/service.py
+++ b/src/piwardrive/service.py
@@ -295,9 +295,9 @@ def WEBSOCKET(*args: typing.Any, **kwargs: typing.Any) -> typing.Callable[[F], F
 
 
 # Allowed log file paths for the /logs endpoint
-ALLOWED_LOG_PATHS = [
+ALLOWED_LOG_PATHS = {
     sanitize_path(p) for p in config.DEFAULT_CONFIG.log_paths + [DEFAULT_LOG_PATH]
-]
+}
 
 # In-memory token store mapping token string to username
 TOKENS: dict[str, str] = {}


### PR DESCRIPTION
## Summary
- make `ALLOWED_LOG_PATHS` a set instead of a list for faster membership tests

## Testing
- `pre-commit run --files src/piwardrive/service.py` *(fails: black, isort, flake8, mypy, pytest, npm)*
- `pytest` *(fails: ModuleNotFoundError for many packages)*

------
https://chatgpt.com/codex/tasks/task_e_6862fb5f022c8333819f8015f9069f63