### PR TITLE
Improve error handling

### DIFF
--- a/src/piwardrive/db_browser.py
+++ b/src/piwardrive/db_browser.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import http.server
 import json
+import logging
 import sqlite3
 from pathlib import Path
 
@@ -12,24 +13,36 @@ class _DBHandler(http.server.BaseHTTPRequestHandler):
     db_path: Path
 
     def do_GET(self):  # pragma: no cover - simple HTTP handler
-        conn = sqlite3.connect(self.db_path)
-        cur = conn.execute("SELECT name FROM sqlite_master WHERE type='table'")
-        tables = [r[0] for r in cur.fetchall()]
-        data = {
-            # The table names come from sqlite_master and are not user supplied
-            t: conn.execute(f"SELECT * FROM {t} LIMIT 100").fetchall()  # nosec B608
-            for t in tables
-        }
+        conn = None
+        try:
+            conn = sqlite3.connect(self.db_path)
+            cur = conn.execute("SELECT name FROM sqlite_master WHERE type='table'")
+            tables = [r[0] for r in cur.fetchall()]
+            data = {
+                # The table names come from sqlite_master and are not user supplied
+                t: conn.execute(f"SELECT * FROM {t} LIMIT 100").fetchall()  # nosec B608
+                for t in tables
+            }
+        except sqlite3.Error as exc:
+            logging.error("Database access failed: %s", exc)
+            self.send_error(500, f"Database error: {exc}")
+            return
+        finally:
+            if conn is not None:
+                conn.close()
 
         self.send_response(200)
         self.send_header("Content-Type", "application/json")
         self.end_headers()
         self.wfile.write(json.dumps(data, default=str).encode())
-        conn.close()
 
 
 def launch_browser(db_path: str, port: int = 8080, host: str = "127.0.0.1") -> None:
     """Start a simple HTTP server exposing the contents of ``db_path``."""
     handler = type("Handler", (_DBHandler,), {"db_path": Path(db_path)})
-    server = http.server.HTTPServer((host, port), handler)
+    try:
+        server = http.server.HTTPServer((host, port), handler)
+    except OSError as exc:
+        logging.error("Failed to start HTTP server: %s", exc)
+        return
     server.serve_forever()

--- a/src/piwardrive/setup_wizard.py
+++ b/src/piwardrive/setup_wizard.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from pathlib import Path
 from typing import Any
 
@@ -12,10 +13,18 @@ CONFIG_PATH = Path.home() / ".config" / "piwardrive" / "setup.json"
 def run_wizard() -> None:
     """Prompt for service configuration options and save them."""
     config: dict[str, Any] = {}
-    config["kismet_host"] = input("Kismet host [localhost]: ") or "localhost"
-    config["kismet_port"] = int(input("Kismet port [2501]: ") or "2501")
-    config["bettercap_iface"] = input("BetterCAP interface [wlan0]: ") or "wlan0"
-    config["gpsd_port"] = int(input("GPSD port [2947]: ") or "2947")
+    try:
+        config["kismet_host"] = input("Kismet host [localhost]: ") or "localhost"
+        config["kismet_port"] = int(input("Kismet port [2501]: ") or "2501")
+        config["bettercap_iface"] = input("BetterCAP interface [wlan0]: ") or "wlan0"
+        config["gpsd_port"] = int(input("GPSD port [2947]: ") or "2947")
+    except ValueError as exc:
+        logging.error("Invalid input: %s", exc)
+        return
     CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
-    CONFIG_PATH.write_text(json.dumps(config, indent=2))
+    try:
+        CONFIG_PATH.write_text(json.dumps(config, indent=2))
+    except OSError as exc:
+        logging.error("Failed to write config: %s", exc)
+        return
     print(f"Configuration saved to {CONFIG_PATH}")

--- a/src/piwardrive/utils.py
+++ b/src/piwardrive/utils.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING
 
 import requests  # type: ignore
@@ -76,7 +77,11 @@ def robust_request(url: str) -> requests.Response:
     """Return ``requests.get(url)`` with simple retries."""
 
     def do_request() -> requests.Response:
-        return requests.get(url, timeout=5)
+        try:
+            return requests.get(url, timeout=5)
+        except requests.RequestException as exc:
+            logging.warning("Request failed: %s", exc)
+            raise
 
     return retry_call(do_request, attempts=3, delay=1)  # noqa: F405
 

--- a/sync_receiver.py
+++ b/sync_receiver.py
@@ -11,8 +11,11 @@ os.makedirs(STORAGE, exist_ok=True)
 @app.post("/")
 async def receive(file: UploadFile):
     dest = os.path.join(STORAGE, file.filename)
-    with open(dest, "wb") as fh:
-        shutil.copyfileobj(file.file, fh)
+    try:
+        with open(dest, "wb") as fh:
+            shutil.copyfileobj(file.file, fh)
+    except OSError as exc:  # pragma: no cover - I/O failure
+        return {"error": str(exc)}
     return {"saved": dest}
 
 


### PR DESCRIPTION
## Summary
- wrap sync receiver file writes in try/except
- make setup wizard robust against bad input and write errors
- handle WiGLE network request failures
- guard SQLite operations and HTTP server startup
- log RequestException in robust_request

## Testing
- `pre-commit run --files src/piwardrive/db_browser.py src/piwardrive/integrations/wigle.py src/piwardrive/setup_wizard.py src/piwardrive/utils.py sync_receiver.py` *(fails: ESLint couldn't find config)*
- `pytest -q` *(fails: ModuleNotFoundError: fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_6862fb7279f48333af7a84d38372470d