### PR TITLE
Refine exception handling

### DIFF
--- a/server/parse_widgets.py
+++ b/server/parse_widgets.py
@@ -19,7 +19,7 @@ for node in tree.body:
     if value is not None:
         try:
             widgets = ast.literal_eval(value)
-        except Exception:
+        except (ValueError, SyntaxError):
             widgets = []
         break
 if not isinstance(widgets, list):

--- a/src/piwardrive/core/utils.py
+++ b/src/piwardrive/core/utils.py
@@ -33,7 +33,7 @@ from . import fastjson
 
 try:  # pragma: no cover - optional dependency
     from piwardrive.sigint_suite.models import BluetoothDevice
-except Exception:  # pragma: no cover - fallback when sigint_suite is missing
+except ImportError:  # pragma: no cover - fallback when sigint_suite is missing
     BluetoothDevice = dict[str, Any]
 from concurrent.futures import Future
 
@@ -44,7 +44,7 @@ import requests
 
 try:
     import requests_cache
-except Exception:  # pragma: no cover - optional dependency
+except ImportError:  # pragma: no cover - optional dependency
     requests_cache = None
 import aiohttp
 
@@ -447,7 +447,7 @@ def get_cpu_temp() -> float | None:
         with open("/sys/class/thermal/thermal_zone0/temp", "r") as f:
             temp_str = f.read().strip()
         return float(temp_str) / 1000.0
-    except Exception:
+    except (OSError, ValueError):
         return None
 
 

--- a/src/piwardrive/security.py
+++ b/src/piwardrive/security.py
@@ -1,6 +1,7 @@
 """Security utilities for input validation and encryption."""
 
 import base64
+import binascii
 import hashlib
 import os
 import re
@@ -39,7 +40,7 @@ def verify_password(password: str, hashed: str) -> bool:
         salt, digest = data[:16], data[16:]
         check = hashlib.pbkdf2_hmac("sha256", password.encode(), salt, 100_000)
         return secrets.compare_digest(check, digest)
-    except Exception:
+    except (binascii.Error, ValueError):
         return False
 
 

--- a/src/service.py
+++ b/src/service.py
@@ -44,7 +44,7 @@ _p.load_recent_health = _proxy("load_recent_health")  # type: ignore[attr-define
 
 try:  # pragma: no cover - optional dependency loading
     _service: ModuleType | None = importlib.import_module("piwardrive.service")
-except Exception:  # pragma: no cover - allow import without extras
+except ImportError:  # pragma: no cover - allow import without extras
     _service = None
 
 if _service is not None:


### PR DESCRIPTION
## Summary
- narrow exceptions when parsing widget modules
- be explicit about which decoding errors mean bad passwords
- handle file read errors more specifically when checking CPU temp
- expect ImportError for optional module imports

## Testing
- `make test` *(fails: 39 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6862fb6cdc08833387c73c3b29a2490a