### PR TITLE
Add usage snippets for setup_logging, suggest_route, and remote sync

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -28,6 +28,7 @@ Common issues are answered in the :doc:`faq`.
    gps_clients
    tile_cache
    tile_prefetching
+   route_optimizer
    vector_tile_customizer
    bluetooth
    hardware_setup

--- a/docs/logging.rst
+++ b/docs/logging.rst
@@ -8,6 +8,16 @@ The main log file is ``~/.config/piwardrive/app.log``. Set the ``PW_LOG_LEVEL``
 environment variable to control verbosity or pass ``level`` to ``setup_logging``.
 Common levels are ``DEBUG``, ``INFO``, ``WARNING`` and ``ERROR``.
 
+Example::
+
+    from piwardrive.logconfig import setup_logging
+    import logging
+
+    logger = setup_logging(
+        "/tmp/piwardrive.log", level=logging.DEBUG, stdout=True
+    )
+    logger.info("PiWardrive initialized")
+
 Logs from external tools are stored separately. ``kismet_logdir`` points to the
 capture directory for Kismet (``/mnt/ssd/kismet_logs`` by default) while
 BetterCAP writes to ``/var/log/bettercap.log``. Additional paths may be listed

--- a/docs/remote_sync.rst
+++ b/docs/remote_sync.rst
@@ -61,11 +61,18 @@ Use the ``/sync`` endpoint exposed by ``piwardrive.service`` or call
     curl -X POST http://localhost:8000/sync
 
     # or in Python
-    import asyncio, remote_sync
-    asyncio.run(remote_sync.sync_database_to_server(
-        '~/.config/piwardrive/health.db',
-        'http://10.0.0.2:9000/'
-    ))
+    import asyncio
+    from remote_sync import sync_database_to_server
+
+    async def upload():
+        await sync_database_to_server(
+            db_path="/home/pi/piwardrive.db",
+            url="https://example.com/upload",
+            timeout=60,
+            retries=5,
+        )
+
+    asyncio.run(upload())
 
 The database will be uploaded to the server where it can be processed or backed
 up as needed.
@@ -82,16 +89,17 @@ many attempts are made before giving up.  The function raises
 Example::
 
     import asyncio
-    from piwardrive import remote_sync
+    from remote_sync import sync_database_to_server
 
-    asyncio.run(
-        remote_sync.sync_database_to_server(
-            "~/piwardrive/health.db",
-            "http://10.0.0.2:9000/",
-            timeout=10,
+    async def upload():
+        await sync_database_to_server(
+            db_path="/home/pi/piwardrive.db",
+            url="https://example.com/upload",
+            timeout=60,
             retries=5,
         )
-    )
+
+    asyncio.run(upload())
 
 Command Line Helper
 -------------------

--- a/docs/route_optimizer.rst
+++ b/docs/route_optimizer.rst
@@ -1,0 +1,27 @@
+Route Optimizer
+===============
+
+.. note::
+   Please read the legal notice in the project `README.md` before using PiWardrive.
+
+``route_optimizer.suggest_route`` generates a set of GPS waypoints that guide the
+map tile prefetcher toward unvisited areas.  Pass previously sampled
+``(lat, lon)`` tuples in chronological order and the helper returns new points in
+that grid.
+
+Example::
+
+    from piwardrive.route_optimizer import suggest_route
+
+    trail = [
+        (51.5, -0.1),
+        (51.5005, -0.1003),
+        (51.501, -0.1009),
+    ]
+    waypoints = suggest_route(trail, cell_size=0.001, steps=3)
+    print(waypoints)
+
+Adjust ``cell_size`` to match the size of a grid cell in degrees and
+``steps`` to control how many waypoints the optimizer emits.  ``search_radius``
+limits how far around the current location the function looks for
+new cells.


### PR DESCRIPTION
## Summary
- document basic logging setup in `docs/logging.rst`
- expand remote sync example with async snippet
- document `suggest_route` in new `docs/route_optimizer.rst`
- include new doc in the index

## Testing
- `SKIP=npm-test,npm-lint pre-commit run --files docs/logging.rst docs/remote_sync.rst docs/route_optimizer.rst docs/index.rst`

------
https://chatgpt.com/codex/tasks/task_e_686303f6c9048333bcbde071c049145a