### PR TITLE
Refactor cellular scanners

### DIFF
--- a/src/piwardrive/integrations/sigint_suite/cellular/imsi_catcher/scanner.py
+++ b/src/piwardrive/integrations/sigint_suite/cellular/imsi_catcher/scanner.py
@@ -3,17 +3,17 @@
 import asyncio
 import logging
 import os
-import shlex
 import subprocess
 from typing import Any, Callable, List, Optional, cast
 
 from piwardrive.core import config
 from piwardrive.scheduler import PollScheduler
-
 from piwardrive.sigint_suite.cellular.parsers import parse_imsi_output
 from piwardrive.sigint_suite.gps import get_position
 from piwardrive.sigint_suite.hooks import apply_post_processors
 from piwardrive.sigint_suite.models import ImsiRecord
+
+from ..utils import build_cmd_args
 
 logger = logging.getLogger(__name__)
 
@@ -33,10 +33,12 @@ def scan_imsis(
     """Scan for IMSI numbers using an external command."""
     if not _allowed():
         return []
-    cmd_str = str(cmd or os.getenv("IMSI_CATCH_CMD", "imsi-catcher"))
-    args = shlex.split(cmd_str)
-    timeout = (
-        timeout if timeout is not None else int(os.getenv("IMSI_SCAN_TIMEOUT", "10"))
+    args, timeout = build_cmd_args(
+        cmd,
+        "IMSI_CATCH_CMD",
+        "imsi-catcher",
+        timeout,
+        "IMSI_SCAN_TIMEOUT",
     )
     try:
         output = subprocess.check_output(
@@ -76,10 +78,12 @@ async def async_scan_imsis(
     """Asynchronously scan for IMSI numbers."""
     if not _allowed():
         return []
-    cmd_str = str(cmd or os.getenv("IMSI_CATCH_CMD", "imsi-catcher"))
-    args = shlex.split(cmd_str)
-    timeout = (
-        timeout if timeout is not None else int(os.getenv("IMSI_SCAN_TIMEOUT", "10"))
+    args, timeout = build_cmd_args(
+        cmd,
+        "IMSI_CATCH_CMD",
+        "imsi-catcher",
+        timeout,
+        "IMSI_SCAN_TIMEOUT",
     )
     logger.debug("Executing: %s", " ".join(args))
     try:

--- a/src/piwardrive/integrations/sigint_suite/cellular/tower_scanner/scanner.py
+++ b/src/piwardrive/integrations/sigint_suite/cellular/tower_scanner/scanner.py
@@ -1,19 +1,45 @@
 import asyncio
 import logging
-import os
-import shlex
 import subprocess
 from typing import List, Optional
 
 from piwardrive.core import config
 from piwardrive.scheduler import PollScheduler
-
 from piwardrive.sigint_suite.cellular.parsers import parse_tower_output
 from piwardrive.sigint_suite.gps import get_position
 from piwardrive.sigint_suite.hooks import apply_post_processors
 from piwardrive.sigint_suite.models import TowerRecord
 
+from ..utils import build_cmd_args
+
 logger = logging.getLogger(__name__)
+
+
+def _run_scan(args: list[str], timeout: int) -> str | None:
+    """Execute the tower scan command and return its output."""
+    try:
+        return subprocess.check_output(
+            args, text=True, stderr=subprocess.DEVNULL, timeout=timeout
+        )
+    except Exception as exc:
+        logger.exception("Tower scan failed: %s", exc)
+        return None
+
+
+async def _run_scan_async(args: list[str], timeout: int) -> str | None:
+    """Asynchronously execute the tower scan command."""
+    logger.debug("Executing: %s", " ".join(args))
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            *args,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+        stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+        return stdout.decode()
+    except Exception as exc:
+        logger.exception("Tower scan failed: %s", exc)
+        return None
 
 
 def _allowed() -> bool:
@@ -31,17 +57,15 @@ def scan_towers(
     """Scan for nearby cell towers and return a list of records."""
     if not _allowed():
         return []
-    cmd_str = str(cmd or os.getenv("TOWER_SCAN_CMD", "tower-scan"))
-    args = shlex.split(cmd_str)
-    timeout = (
-        timeout if timeout is not None else int(os.getenv("TOWER_SCAN_TIMEOUT", "10"))
+    args, timeout = build_cmd_args(
+        cmd,
+        "TOWER_SCAN_CMD",
+        "tower-scan",
+        timeout,
+        "TOWER_SCAN_TIMEOUT",
     )
-    try:
-        output = subprocess.check_output(
-            args, text=True, stderr=subprocess.DEVNULL, timeout=timeout
-        )
-    except Exception as exc:
-        logger.exception("Tower scan failed: %s", exc)
+    output = _run_scan(args, timeout)
+    if output is None:
         return []
 
     records = parse_tower_output(output)
@@ -66,22 +90,15 @@ async def async_scan_towers(
     """Asynchronously scan for cell towers."""
     if not _allowed():
         return []
-    cmd_str = str(cmd or os.getenv("TOWER_SCAN_CMD", "tower-scan"))
-    args = shlex.split(cmd_str)
-    timeout = (
-        timeout if timeout is not None else int(os.getenv("TOWER_SCAN_TIMEOUT", "10"))
+    args, timeout = build_cmd_args(
+        cmd,
+        "TOWER_SCAN_CMD",
+        "tower-scan",
+        timeout,
+        "TOWER_SCAN_TIMEOUT",
     )
-    logger.debug("Executing: %s", " ".join(args))
-    try:
-        proc = await asyncio.create_subprocess_exec(
-            *args,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.DEVNULL,
-        )
-        stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=timeout)
-        output = stdout.decode()
-    except Exception as exc:
-        logger.exception("Tower scan failed: %s", exc)
+    output = await _run_scan_async(args, timeout)
+    if output is None:
         return []
 
     records = parse_tower_output(output)

--- a/src/piwardrive/integrations/sigint_suite/cellular/utils.py
+++ b/src/piwardrive/integrations/sigint_suite/cellular/utils.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import os
+import shlex
+from typing import List, Optional, Tuple
+
+
+def build_cmd_args(
+    cmd: Optional[str],
+    env_cmd: str,
+    default_cmd: str,
+    timeout: Optional[int],
+    env_timeout: str,
+) -> tuple[list[str], int]:
+    """Return command args list and timeout for scanner helpers."""
+    cmd_str = str(cmd or os.getenv(env_cmd, default_cmd))
+    args = shlex.split(cmd_str)
+    timeout_val = timeout if timeout is not None else int(os.getenv(env_timeout, "10"))
+    return args, timeout_val


### PR DESCRIPTION
## Summary
- deduplicate command parsing with `build_cmd_args`
- factor out tower scanner subprocess helpers

## Testing
- `flake8 src/piwardrive/integrations/sigint_suite/cellular/utils.py src/piwardrive/integrations/sigint_suite/cellular/imsi_catcher/scanner.py src/piwardrive/integrations/sigint_suite/cellular/tower_scanner/scanner.py` *(fails: command not found)*
- `mypy` *(fails: missing stub packages)*
- `bandit -r src/piwardrive/integrations/sigint_suite/cellular/utils.py src/piwardrive/integrations/sigint_suite/cellular/imsi_catcher/scanner.py src/piwardrive/integrations/sigint_suite/cellular/tower_scanner/scanner.py` *(fails: command not found)*
- `pytest -q` *(fails: missing packages)*

------
https://chatgpt.com/codex/tasks/task_e_6863036f6ec0833395e7faa4610010cf