### PR TITLE
Fix open/close patterns

### DIFF
--- a/src/piwardrive/advanced_localization.py
+++ b/src/piwardrive/advanced_localization.py
@@ -40,7 +40,6 @@ def load_config(path: str | Path) -> Config:
 
 def load_kismet_data(db_path: str | Path) -> pd.DataFrame:
     """Return observation rows from a Kismet SQLite log."""
-    conn = sqlite3.connect(str(db_path))
     query = """
     SELECT devices.macaddr, devices.ssid, packets.lat, packets.lon,
            packets.signal AS rssi, packets.gpstime
@@ -49,8 +48,8 @@ def load_kismet_data(db_path: str | Path) -> pd.DataFrame:
     WHERE devices.type = 'infrastructure'
       AND packets.lat != 0 AND packets.lon != 0;
     """
-    df = pd.read_sql_query(query, conn)
-    conn.close()
+    with sqlite3.connect(str(db_path)) as conn:
+        df = pd.read_sql_query(query, conn)
     return df
 
 

--- a/src/piwardrive/db_browser.py
+++ b/src/piwardrive/db_browser.py
@@ -13,23 +13,21 @@ class _DBHandler(http.server.BaseHTTPRequestHandler):
     db_path: Path
 
     def do_GET(self):  # pragma: no cover - simple HTTP handler
-        conn = None
         try:
-            conn = sqlite3.connect(self.db_path)
-            cur = conn.execute("SELECT name FROM sqlite_master WHERE type='table'")
-            tables = [r[0] for r in cur.fetchall()]
-            data = {
-                # The table names come from sqlite_master and are not user supplied
-                t: conn.execute(f"SELECT * FROM {t} LIMIT 100").fetchall()  # nosec B608
-                for t in tables
-            }
+            with sqlite3.connect(self.db_path) as conn:
+                cur = conn.execute(
+                    "SELECT name FROM sqlite_master WHERE type='table'"
+                )
+                tables = [r[0] for r in cur.fetchall()]
+                data = {
+                    # The table names come from sqlite_master and are not user supplied
+                    t: conn.execute(f"SELECT * FROM {t} LIMIT 100").fetchall()  # nosec B608
+                    for t in tables
+                }
         except sqlite3.Error as exc:
             logging.error("Database access failed: %s", exc)
             self.send_error(500, f"Database error: {exc}")
             return
-        finally:
-            if conn is not None:
-                conn.close()
 
         self.send_response(200)
         self.send_header("Content-Type", "application/json")

--- a/src/piwardrive/export.py
+++ b/src/piwardrive/export.py
@@ -72,7 +72,8 @@ def export_csv(
     try:
         first = next(it)
     except StopIteration:
-        open(path, "w", newline="", encoding="utf-8").close()
+        with open(path, "w", newline="", encoding="utf-8"):
+            pass
         return
 
     fieldnames = fields or list(first.keys())

--- a/src/piwardrive/integrations/sigint_suite/exports/exporter.py
+++ b/src/piwardrive/integrations/sigint_suite/exports/exporter.py
@@ -41,7 +41,8 @@ def export_csv(records: Iterable[Mapping[str, str]], path: str) -> None:
     try:
         first = next(it)
     except StopIteration:
-        open(path, "w", newline="", encoding="utf-8").close()
+        with open(path, "w", newline="", encoding="utf-8"):
+            pass
         return
 
     with open(path, "w", newline="", encoding="utf-8") as fh:

--- a/src/remote_sync/__init__.py
+++ b/src/remote_sync/__init__.py
@@ -48,9 +48,8 @@ def get_metrics() -> dict[str, float | int]:
 
 def _make_range_db(src: str, start: int, end: int) -> str:
     """Return path to a temporary DB with rows ``start``..``end`` from ``src``."""
-    tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".db")
-    tmp.close()
-    dest = tmp.name
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".db") as tmp:
+        dest = tmp.name
 
     with sqlite3.connect(src) as src_db, sqlite3.connect(dest) as dst_db:
         dst_db.execute(


### PR DESCRIPTION
## Summary
- use with statements in the SQLite DB browser
- use context managers when exporting empty CSV files
- fix temporary file creation to close automatically
- use with statement when reading Kismet data

## Testing
- `pytest -q` *(fails: No module named 'numpy', 'fastapi', 'aiosqlite', 'requests', ...)*

------
https://chatgpt.com/codex/tasks/task_e_6863032e43c08333a6346df1c8d953c3