### PR TITLE
Restrict sync_receiver host binding

### DIFF
--- a/sync_receiver.py
+++ b/sync_receiver.py
@@ -22,4 +22,4 @@ async def receive(file: UploadFile):
 if __name__ == "__main__":
     import uvicorn
 
-    uvicorn.run(app, host="0.0.0.0", port=9000)
+    uvicorn.run(app, host="127.0.0.1", port=9000)


### PR DESCRIPTION
## Summary
- bind sync_receiver FastAPI service to localhost rather than all interfaces

## Testing
- `pytest tests/test_fingerprint_persistence.py -q` *(fails: module 'piwardrive.persistence' has no attribute 'FingerprintInfo')*
- `pytest -k nonexistentpattern -q` *(fails to collect tests due to missing dependencies e.g. numpy, httpx)*

------
https://chatgpt.com/codex/tasks/task_e_686303b728248333ab2dca8aacdb9d17