### PR TITLE
Remove unused code and config

### DIFF
--- a/examples/plugins/hello_plugin.py
+++ b/examples/plugins/hello_plugin.py
@@ -1,27 +1,2 @@
 """Example dashboard plugin that displays a greeting."""
 
-from datetime import datetime
-
-from piwardrive.simpleui import Card as MDCard
-from piwardrive.simpleui import Label as MDLabel
-from piwardrive.simpleui import dp
-
-from widgets.base import DashboardWidget
-
-
-class HelloPluginWidget(DashboardWidget):
-    """Simple example widget for plugin demonstration."""
-
-    update_interval = 5.0
-
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-        self.card = MDCard(orientation="vertical", padding=dp(8), radius=[8])
-        self.label = MDLabel(text="Hello from plugin!", halign="center")
-        self.card.add_widget(self.label)
-        self.add_widget(self.card)
-        self.update()
-
-    def update(self):
-        """Update the label with the current time."""
-        self.label.text = datetime.now().strftime("Hello %H:%M:%S")

--- a/src/piwardrive/mysql_export.py
+++ b/src/piwardrive/mysql_export.py
@@ -1,6 +1,4 @@
 from __future__ import annotations
-
-import asyncio
 from dataclasses import dataclass
 from typing import Any, Iterable, List, Sequence
 

--- a/src/piwardrive/service.py
+++ b/src/piwardrive/service.py
@@ -168,7 +168,7 @@ import psutil
 import vehicle_sensors
 from sync import upload_data
 
-from piwardrive import export, graphql_api, orientation_sensors
+from piwardrive import export, graphql_api
 from piwardrive.config import CONFIG_DIR
 from piwardrive.gpsd_client import client as gps_client
 
@@ -489,37 +489,7 @@ async def get_storage(
     return {"percent": get_disk_usage(path)}
 
 
-@GET("/orientation")
-async def get_orientation_endpoint(
-    _auth: User | None = AUTH_DEP,
-) -> dict[str, Any]:
-    """Return device orientation and raw sensor data."""
-    orient = await asyncio.to_thread(orientation_sensors.get_orientation_dbus)
-    angle = None
-    accel = gyro = None
-    if orient:
-        angle = orientation_sensors.orientation_to_angle(orient)
-    else:
-        data = await asyncio.to_thread(orientation_sensors.read_mpu6050)
-        if data:
-            accel = data.get("accelerometer")
-            gyro = data.get("gyroscope")
-    return {
-        "orientation": orient,
-        "angle": angle,
-        "accelerometer": accel,
-        "gyroscope": gyro,
-    }
 
-
-@GET("/vehicle")
-async def get_vehicle_endpoint(_auth: User | None = AUTH_DEP) -> dict[str, Any]:
-    """Return vehicle metrics from OBD-II sensors."""
-    return {
-        "speed": await asyncio.to_thread(vehicle_sensors.read_speed_obd),
-        "rpm": await asyncio.to_thread(vehicle_sensors.read_rpm_obd),
-        "engine_load": await asyncio.to_thread(vehicle_sensors.read_engine_load_obd),
-    }
 
 
 @GET("/gps")

--- a/tests/test_cli_tools.py
+++ b/tests/test_cli_tools.py
@@ -27,9 +27,9 @@ def _import_cli():
 
 def test_config_cli_get_local(monkeypatch, capsys):
     cli = _import_cli()
-    monkeypatch.setattr(cli.cfg, "load_config", lambda: cli.cfg.Config(theme="Blue"))
-    cli.main(["get", "theme"])
-    assert capsys.readouterr().out.strip() == json.dumps("Blue")
+    monkeypatch.setattr(cli.cfg, "load_config", lambda: cli.cfg.Config(mysql_host="db"))
+    cli.main(["get", "mysql_host"])
+    assert capsys.readouterr().out.strip() == json.dumps("db")
 
 
 def test_config_cli_set_local(monkeypatch, capsys):
@@ -52,11 +52,11 @@ def test_config_cli_get_api(monkeypatch, capsys):
 
     async def fake_get(url):
         assert url == "http://api"
-        return {"theme": "Dark"}
+        return {"mysql_host": "db"}
 
     monkeypatch.setattr(cli, "_api_get", fake_get)
-    cli.main(["--url", "http://api", "get", "theme"])
-    assert capsys.readouterr().out.strip() == json.dumps("Dark")
+    cli.main(["--url", "http://api", "get", "mysql_host"])
+    assert capsys.readouterr().out.strip() == json.dumps("db")
 
 
 def test_config_cli_set_api(monkeypatch, capsys):
@@ -64,17 +64,17 @@ def test_config_cli_set_api(monkeypatch, capsys):
 
     async def fake_get(url):
         assert url == "http://api"
-        return {"theme": "Dark"}
+        return {"mysql_host": "db"}
 
     async def fake_update(url, updates):
         assert url == "http://api"
-        assert updates == {"theme": "Light"}
-        return {"theme": "Light"}
+        assert updates == {"mysql_host": "new"}
+        return {"mysql_host": "new"}
 
     monkeypatch.setattr(cli, "_api_get", fake_get)
     monkeypatch.setattr(cli, "_api_update", fake_update)
-    cli.main(["--url", "http://api", "set", "theme", "Light"])
-    assert capsys.readouterr().out.strip() == json.dumps("Light")
+    cli.main(["--url", "http://api", "set", "mysql_host", "new"])
+    assert capsys.readouterr().out.strip() == json.dumps("new")
 
 
 def test_config_cli_get_unknown_local(monkeypatch):
@@ -96,11 +96,11 @@ def test_config_cli_get_unknown_api(monkeypatch):
 
     async def fake_get(url):
         assert url == "http://api"
-        return {"theme": "Dark"}
+        return {"mysql_host": "db"}
 
     monkeypatch.setattr(cli, "_api_get", fake_get)
     with pytest.raises(SystemExit):
-        cli.main(["--url", "http://api", "get", "does_not_exist"])
+    cli.main(["--url", "http://api", "get", "does_not_exist"])
 
 
 def test_config_cli_set_unknown_api(monkeypatch):
@@ -108,7 +108,7 @@ def test_config_cli_set_unknown_api(monkeypatch):
 
     async def fake_get(url):
         assert url == "http://api"
-        return {"theme": "Dark"}
+        return {"mysql_host": "db"}
 
     monkeypatch.setattr(cli, "_api_get", fake_get)
     with pytest.raises(SystemExit):

--- a/tests/test_config_runtime.py
+++ b/tests/test_config_runtime.py
@@ -13,10 +13,10 @@ def setup_tmp(tmp_path: Path) -> Path:
 
 def test_config_mtime_updates(tmp_path: Path) -> None:
     setup_tmp(tmp_path)
-    cfg = config.Config(theme="Dark")
+    cfg = config.Config(mysql_host="db1")
     config.save_config(cfg)
     first = config.config_mtime()
-    cfg.theme = "Green"
+    cfg.mysql_host = "db2"
     config.save_config(cfg)
     second = config.config_mtime()
     assert first is not None and second is not None  # nosec B101

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -15,14 +15,7 @@ def setup(tmp_path: Path) -> None:
 
 def test_invalid_env_value(monkeypatch, tmp_path: Path) -> None:
     setup(tmp_path)
-    monkeypatch.setenv("PW_MAP_POLL_GPS", "0")
+    monkeypatch.setenv("PW_HEALTH_POLL_INTERVAL", "0")
     monkeypatch.setenv("PW_GPS_MOVEMENT_THRESHOLD", "-1")
-    with pytest.raises(ValidationError):
-        config.AppConfig.load()
-
-
-def test_invalid_theme(monkeypatch, tmp_path: Path) -> None:
-    setup(tmp_path)
-    monkeypatch.setenv("PW_THEME", "Blue")
     with pytest.raises(ValidationError):
         config.AppConfig.load()

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -22,4 +22,4 @@ def test_load_hello_plugin(tmp_path, monkeypatch):
     sys.modules.pop("piwardrive.widgets", None)
     sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
     widgets = importlib.import_module("piwardrive.widgets")
-    assert "HelloPluginWidget" in widgets.list_plugins()
+    assert widgets.list_plugins() == []

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -405,25 +405,25 @@ def test_websocket_timeout_closes_connection() -> None:
 
 def test_get_config_endpoint() -> None:
     with mock.patch("service.config.load_config") as load:
-        load.return_value = service.config.Config(theme="Green")
+        load.return_value = service.config.Config(mysql_host="db")
         client = TestClient(service.app)
         resp = client.get("/config")
         assert resp.status_code == 200
-        assert resp.json()["theme"] == "Green"
+        assert resp.json()["mysql_host"] == "db"
 
 
 def test_update_config_endpoint_success() -> None:
-    cfg = service.config.Config(theme="Dark")
+    cfg = service.config.Config(mysql_host="old")
     with (
         mock.patch("service.config.load_config", return_value=cfg),
         mock.patch("service.config.save_config") as save,
     ):
         client = TestClient(service.app)
-        resp = client.post("/config", json={"theme": "Light"})
+        resp = client.post("/config", json={"mysql_host": "new"})
         assert resp.status_code == 200
-        assert resp.json()["theme"] == "Light"
+        assert resp.json()["mysql_host"] == "new"
         args = save.call_args[0][0]
-        assert args.theme == "Light"
+        assert args.mysql_host == "new"
 
 
 def test_update_config_endpoint_invalid_key() -> None:
@@ -588,94 +588,6 @@ def test_storage_endpoint() -> None:
         assert resp.json() == {"percent": 70.0}
 
 
-def test_orientation_endpoint_dbus(monkeypatch) -> None:
-    with (
-        mock.patch(
-            "service.orientation_sensors.get_orientation_dbus",
-            return_value="right-up",
-        ),
-        mock.patch(
-            "piwardrive.service.orientation_sensors.get_orientation_dbus",
-            return_value="right-up",
-        ),
-        mock.patch(
-            "service.orientation_sensors.orientation_to_angle",
-            return_value=90.0,
-        ),
-        mock.patch(
-            "piwardrive.service.orientation_sensors.orientation_to_angle",
-            return_value=90.0,
-        ),
-        mock.patch(
-            "service.orientation_sensors.read_mpu6050",
-            return_value=None,
-        ),
-        mock.patch(
-            "piwardrive.service.orientation_sensors.read_mpu6050",
-            return_value=None,
-        ),
-    ):
-        client = TestClient(service.app)
-        resp = client.get("/orientation")
-        assert resp.status_code == 200
-        data = resp.json()
-        assert data["orientation"] == "right-up"
-        assert data["angle"] == 90.0
-        assert data["accelerometer"] is None
-
-
-def test_orientation_endpoint_mpu(monkeypatch) -> None:
-    with (
-        mock.patch(
-            "service.orientation_sensors.get_orientation_dbus",
-            return_value=None,
-        ),
-        mock.patch(
-            "piwardrive.service.orientation_sensors.get_orientation_dbus",
-            return_value=None,
-        ),
-        mock.patch(
-            "service.orientation_sensors.read_mpu6050",
-            return_value={"accelerometer": {"x": 1}, "gyroscope": {"y": 2}},
-        ),
-        mock.patch(
-            "piwardrive.service.orientation_sensors.read_mpu6050",
-            return_value={"accelerometer": {"x": 1}, "gyroscope": {"y": 2}},
-        ),
-    ):
-        client = TestClient(service.app)
-        resp = client.get("/orientation")
-        assert resp.status_code == 200
-        data = resp.json()
-        assert data["orientation"] is None
-        assert data["accelerometer"] == {"x": 1}
-        assert data["gyroscope"] == {"y": 2}
-
-
-def test_vehicle_endpoint(monkeypatch) -> None:
-    with (
-        mock.patch("service.vehicle_sensors.read_speed_obd", return_value=55.0),
-        mock.patch(
-            "piwardrive.service.vehicle_sensors.read_speed_obd", return_value=55.0
-        ),
-        mock.patch("service.vehicle_sensors.read_rpm_obd", return_value=1800.0),
-        mock.patch(
-            "piwardrive.service.vehicle_sensors.read_rpm_obd", return_value=1800.0
-        ),
-        mock.patch("service.vehicle_sensors.read_engine_load_obd", return_value=40.0),
-        mock.patch(
-            "piwardrive.service.vehicle_sensors.read_engine_load_obd",
-            return_value=40.0,
-        ),
-    ):
-        client = TestClient(service.app)
-        resp = client.get("/vehicle")
-        assert resp.status_code == 200
-        assert resp.json() == {
-            "speed": 55.0,
-            "rpm": 1800.0,
-            "engine_load": 40.0,
-        }
 
 
 def test_gps_endpoint(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- drop `asyncio` import from MySQL exporter
- delete example `HelloPluginWidget`
- remove obsolete `theme` and `map_poll_gps` settings
- drop orientation/vehicle REST endpoints
- update tests for configuration and service changes

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6863036a7848833386755dce2aac03b5