### PR TITLE
Fix docstring mismatches

### DIFF
--- a/src/piwardrive/logconfig.py
+++ b/src/piwardrive/logconfig.py
@@ -35,24 +35,28 @@ def setup_logging(
     handlers: Optional[Iterable[logging.Handler]] = None,
     stdout: bool = False,
 ) -> Logger:
-    """
-    Configure root logger with JSON output.
+    """Configure the root logger for JSON output.
 
     ``PW_LOG_LEVEL`` may override ``level`` with a name like ``DEBUG`` or a
     numeric value. Invalid values are ignored.
 
     Parameters
     ----------
-    log_file:
+    log_file : str
         Destination file for :class:`logging.FileHandler`.
-    level:
+    level : int
         Logging level for the root logger.
-    handlers:
-        Extra handlers to attach in addition to the file handler.
-        If a handler has no formatter, :class:`JsonFormatter` is used.
-    stdout:
+    handlers : Optional[Iterable[logging.Handler]]
+        Extra handlers to attach in addition to the file handler. If a handler
+        has no formatter, :class:`JsonFormatter` is used.
+    stdout : bool
         When ``True`` also attach a :class:`logging.StreamHandler` writing to
         ``sys.stdout``.
+
+    Returns
+    -------
+    Logger
+        The configured root logger.
     """
     env_level = os.getenv("PW_LOG_LEVEL")
     if env_level:

--- a/src/piwardrive/route_optimizer.py
+++ b/src/piwardrive/route_optimizer.py
@@ -17,17 +17,17 @@ def suggest_route(
 ) -> List[Coord]:
     """Return waypoints that maximize coverage based on ``points``.
 
-    Parameters
-    ----------
-    points:
-        Sequence of ``(lat, lon)`` coordinates in chronological order.
-    cell_size:
-        Grid resolution in degrees used to mark visited areas.
-    steps:
-        Number of waypoints to return.
-    search_radius:
-        How far to search for new cells around the current location, in grid
-        cells.
+    Args:
+        points (Iterable[Coord]): Sequence of ``(lat, lon)`` coordinates in
+            chronological order.
+        cell_size (float): Grid resolution in degrees used to mark visited
+            areas.
+        steps (int): Number of waypoints to return.
+        search_radius (int): How far to search for new cells around the current
+            location, in grid cells.
+
+    Returns:
+        List[Coord]: Waypoints to visit in order.
     """
     pts = [(float(lat), float(lon)) for lat, lon in points]
     if not pts:

--- a/src/piwardrive/widgets/battery_status.py
+++ b/src/piwardrive/widgets/battery_status.py
@@ -14,12 +14,15 @@ from .base import DashboardWidget
 
 
 class BatteryStatusWidget(DashboardWidget):
-    """Show battery percentage and charging state."""
+    """Show battery percentage and charging state.
+
+    A label widget is created on initialization and the first reading is
+    displayed immediately.
+    """
 
     update_interval = 30.0
 
     def __init__(self, **kwargs: Any) -> None:
-        """Create label widget and display initial reading."""
         super().__init__(**kwargs)
         self.card = MDCard(orientation="vertical", padding=dp(8), radius=[8])
         self.label = MDLabel(

--- a/src/piwardrive/widgets/cpu_temp_graph.py
+++ b/src/piwardrive/widgets/cpu_temp_graph.py
@@ -9,12 +9,15 @@ from .base import DashboardWidget
 
 
 class CPUTempGraphWidget(DashboardWidget):
-    """Display CPU temperature history using a line graph."""
+    """Display CPU temperature history using a line graph.
+
+    Graph components are initialized on creation and updates are scheduled
+    automatically.
+    """
 
     def __init__(
         self, update_interval: int = 5, max_points: int = 60, **kwargs: Any
     ) -> None:
-        """Initialize graph components and schedule updates."""
         super().__init__(**kwargs)
         self.update_interval = update_interval
         self.max_points = max_points

--- a/src/piwardrive/widgets/disk_trend.py
+++ b/src/piwardrive/widgets/disk_trend.py
@@ -9,12 +9,15 @@ from .base import DashboardWidget
 
 
 class DiskUsageTrendWidget(DashboardWidget):
-    """Plot SSD disk usage percentage over time."""
+    """Plot SSD disk usage percentage over time.
+
+    The graph widget is initialized during construction and periodic updates are
+    scheduled automatically.
+    """
 
     def __init__(
         self, update_interval: int = 5, max_points: int = 60, **kwargs: Any
     ) -> None:
-        """Create disk usage graph and schedule periodic updates."""
         super().__init__(**kwargs)
         self.update_interval = update_interval
         self.max_points = max_points

--- a/src/piwardrive/widgets/gps_status.py
+++ b/src/piwardrive/widgets/gps_status.py
@@ -13,12 +13,15 @@ from .base import DashboardWidget
 
 
 class GPSStatusWidget(DashboardWidget):
-    """Show quality of the current GPS fix."""
+    """Show quality of the current GPS fix.
+
+    A label widget is created on startup and the first update is requested
+    immediately.
+    """
 
     update_interval = 5.0
 
     def __init__(self, **kwargs: Any) -> None:
-        """Create label widget and request the first update."""
         super().__init__(**kwargs)
         self.card = MDCard(orientation="vertical", padding=dp(8), radius=[8])
         self.label = MDLabel(text=f"{_('gps')}: {_('not_available')}", halign="center")

--- a/src/piwardrive/widgets/handshake_counter.py
+++ b/src/piwardrive/widgets/handshake_counter.py
@@ -13,12 +13,15 @@ from .base import DashboardWidget
 
 
 class HandshakeCounterWidget(DashboardWidget):
-    """Track the number of WPA handshakes captured."""
+    """Track the number of WPA handshakes captured.
+
+    A label widget is created during initialization and the first count is
+    performed immediately.
+    """
 
     update_interval = 5.0
 
     def __init__(self, **kwargs: Any) -> None:
-        """Initialize label widget and trigger first count."""
         super().__init__(**kwargs)
         self.card = MDCard(orientation="vertical", padding=dp(8), radius=[8])
         self.label = MDLabel(text=f"{_('handshakes')}: 0", halign="center")

--- a/src/piwardrive/widgets/health_analysis.py
+++ b/src/piwardrive/widgets/health_analysis.py
@@ -17,12 +17,15 @@ from .base import DashboardWidget
 
 
 class HealthAnalysisWidget(DashboardWidget):
-    """Visualize averaged system metrics and a temperature plot."""
+    """Visualize averaged system metrics and a temperature plot.
+
+    Widgets are prepared during initialization and analysis updates are
+    scheduled automatically.
+    """
 
     update_interval = 30.0
 
     def __init__(self, max_records: int = 50, **kwargs: Any) -> None:
-        """Prepare widgets and schedule periodic analysis updates."""
         super().__init__(**kwargs)
         self.max_records = max_records
         self.card = MDCard(orientation="vertical", padding=dp(8), radius=[8])

--- a/src/piwardrive/widgets/health_status.py
+++ b/src/piwardrive/widgets/health_status.py
@@ -12,12 +12,15 @@ from .base import DashboardWidget
 
 
 class HealthStatusWidget(DashboardWidget):
-    """Display results from the global health monitor."""
+    """Display results from the global health monitor.
+
+    A label widget is prepared on initialization and the first update is
+    triggered immediately.
+    """
 
     update_interval = 10.0
 
     def __init__(self, **kwargs: Any) -> None:
-        """Create widget label and trigger the first update."""
         super().__init__(**kwargs)
         self.card = MDCard(orientation="vertical", padding=dp(8), radius=[8])
         self.label = MDLabel(

--- a/src/piwardrive/widgets/log_viewer.py
+++ b/src/piwardrive/widgets/log_viewer.py
@@ -17,7 +17,11 @@ from piwardrive.utils import tail_file
 
 
 class LogViewer(ScrollView):
-    """Display the last N lines of a log file and update periodically."""
+    """Display the last N lines of a log file and update periodically.
+
+    The label widget is created on initialization and log polling is scheduled
+    automatically.
+    """
 
     log_path: str = "/var/log/syslog"
     max_lines: int = 200
@@ -27,7 +31,6 @@ class LogViewer(ScrollView):
     log_paths: List[str] = []
 
     def __init__(self, **kwargs: Any) -> None:
-        """Set up label widget and schedule periodic log refresh."""
         super().__init__(**kwargs)
         self.label = Label(size_hint_y=None, halign="left", valign="top")
         self.label.bind(texture_size=self._update_height)

--- a/src/piwardrive/widgets/lora_scan_widget.py
+++ b/src/piwardrive/widgets/lora_scan_widget.py
@@ -13,12 +13,15 @@ from .base import DashboardWidget
 
 
 class LoRaScanWidget(DashboardWidget):
-    """Display LoRa scan count."""
+    """Display LoRa scan count.
+
+    A label widget is created on initialization and populated with the initial
+    scan count.
+    """
 
     update_interval = 30.0
 
     def __init__(self, **kwargs: Any) -> None:
-        """Create label widget and show initial count."""
         super().__init__(**kwargs)
         self.card = MDCard(orientation="vertical", padding=dp(8), radius=[8])
         self.label = MDLabel(text=f"{_('lora_devices')}: 0", halign="center")

--- a/src/piwardrive/widgets/net_throughput.py
+++ b/src/piwardrive/widgets/net_throughput.py
@@ -10,12 +10,15 @@ from .base import DashboardWidget
 
 
 class NetworkThroughputWidget(DashboardWidget):
-    """Graph of bytes received and sent per second."""
+    """Graph of bytes received and sent per second.
+
+    Throughput graphs are initialized during construction and polling begins
+    immediately.
+    """
 
     def __init__(
         self, update_interval: int = 1, max_points: int = 60, **kwargs: Any
     ) -> None:
-        """Set up throughput graphs and schedule polling."""
         super().__init__(**kwargs)
         if update_interval <= 0:
             raise ValueError(_("update_interval must be positive"))

--- a/src/piwardrive/widgets/orientation_widget.py
+++ b/src/piwardrive/widgets/orientation_widget.py
@@ -13,12 +13,15 @@ from .base import DashboardWidget
 
 
 class OrientationWidget(DashboardWidget):
-    """Show the current device orientation."""
+    """Show the current device orientation.
+
+    A label widget is created during initialization and the first orientation
+    reading is displayed immediately.
+    """
 
     update_interval = 5.0
 
     def __init__(self, **kwargs: Any) -> None:
-        """Create label widget and display initial reading."""
         super().__init__(**kwargs)
         self.card = MDCard(orientation="vertical", padding=dp(8), radius=[8])
         self.label = MDLabel(

--- a/src/piwardrive/widgets/service_status.py
+++ b/src/piwardrive/widgets/service_status.py
@@ -13,12 +13,15 @@ from .base import DashboardWidget
 
 
 class ServiceStatusWidget(DashboardWidget):
-    """Report whether key capture services are running."""
+    """Report whether key capture services are running.
+
+    A label widget is created on initialization and the first status check is
+    performed immediately.
+    """
 
     update_interval = 5.0
 
     def __init__(self, **kwargs: Any) -> None:
-        """Set up label widget and kick off the first refresh."""
         super().__init__(**kwargs)
         self.card = MDCard(orientation="vertical", padding=dp(8), radius=[8])
         self.label = MDLabel(

--- a/src/piwardrive/widgets/signal_strength.py
+++ b/src/piwardrive/widgets/signal_strength.py
@@ -13,12 +13,15 @@ from .base import DashboardWidget
 
 
 class SignalStrengthWidget(DashboardWidget):
-    """Display average RSSI from Kismet devices."""
+    """Display average RSSI from Kismet devices.
+
+    The label widget is initialized when the widget is created and the first
+    RSSI poll is queued immediately.
+    """
 
     update_interval = 5.0
 
     def __init__(self, **kwargs: Any) -> None:
-        """Initialize label widget and queue the first RSSI poll."""
         super().__init__(**kwargs)
         self.card = MDCard(orientation="vertical", padding=dp(8), radius=[8])
         self.label = MDLabel(text=f"{_('rssi')}: {_('not_available')}", halign="center")

--- a/src/piwardrive/widgets/storage_usage.py
+++ b/src/piwardrive/widgets/storage_usage.py
@@ -13,12 +13,15 @@ from .base import DashboardWidget
 
 
 class StorageUsageWidget(DashboardWidget):
-    """Indicate SSD usage percentage."""
+    """Indicate SSD usage percentage.
+
+    A label widget is created on initialization and an initial update is
+    performed.
+    """
 
     update_interval = 5.0
 
     def __init__(self, **kwargs: Any) -> None:
-        """Set up label widget and trigger initial update."""
         super().__init__(**kwargs)
         self.card = MDCard(orientation="vertical", padding=dp(8), radius=[8])
         self.label = MDLabel(text=f"{_('ssd')}: {_('not_available')}", halign="center")

--- a/src/piwardrive/widgets/vehicle_speed.py
+++ b/src/piwardrive/widgets/vehicle_speed.py
@@ -13,12 +13,15 @@ from .base import DashboardWidget
 
 
 class VehicleSpeedWidget(DashboardWidget):
-    """Display vehicle speed in km/h."""
+    """Display vehicle speed in km/h.
+
+    A label widget is created on initialization and the first reading is
+    displayed immediately.
+    """
 
     update_interval = 5.0
 
     def __init__(self, **kwargs: Any) -> None:
-        """Create label widget and display initial reading."""
         super().__init__(**kwargs)
         self.card = MDCard(orientation="vertical", padding=dp(8), radius=[8])
         self.label = MDLabel(


### PR DESCRIPTION
## Summary
- add missing details to `setup_logging` docstring
- expand and move docstring for `suggest_route`
- shift widget docstrings to the class level

## Testing
- `pydoclint src/piwardrive`
- `pre-commit run --files src/piwardrive/logconfig.py src/piwardrive/route_optimizer.py src/piwardrive/widgets/battery_status.py src/piwardrive/widgets/cpu_temp_graph.py src/piwardrive/widgets/disk_trend.py src/piwardrive/widgets/gps_status.py src/piwardrive/widgets/handshake_counter.py src/piwardrive/widgets/health_analysis.py src/piwardrive/widgets/health_status.py src/piwardrive/widgets/log_viewer.py src/piwardrive/widgets/lora_scan_widget.py src/piwardrive/widgets/net_throughput.py src/piwardrive/widgets/orientation_widget.py src/piwardrive/widgets/service_status.py src/piwardrive/widgets/signal_strength.py src/piwardrive/widgets/storage_usage.py src/piwardrive/widgets/vehicle_speed.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686303db1c88833395c581856cf77781