### PR TITLE
Add missing return annotations

### DIFF
--- a/scripts/service_status.py
+++ b/scripts/service_status.py
@@ -8,7 +8,9 @@ from types import SimpleNamespace
 from piwardrive.logconfig import setup_logging
 
 
-def _get_service_statuses(services=None):
+def _get_service_statuses(
+    services: tuple[str, ...] | list[str] | None = None
+) -> dict[str, bool]:
     """Import :mod:`piwardrive.diagnostics` lazily and get statuses."""
     from piwardrive import diagnostics as _diag
 

--- a/src/piwardrive/core/utils.py
+++ b/src/piwardrive/core/utils.py
@@ -181,7 +181,9 @@ def _expire_safe_request_cache() -> None:
         _SAFE_REQUEST_CACHE.expire()
 
 
-def async_ttl_cache(ttl_getter: float | Callable[[], float]):
+def async_ttl_cache(
+    ttl_getter: float | Callable[[], float]
+) -> Callable[[Callable[..., Awaitable[T]]], Callable[..., Awaitable[T]]]:
     """Return decorator caching async function results for ``ttl`` seconds."""
 
     def decorator(func: Callable[..., Awaitable[T]]) -> Callable[..., Awaitable[T]]:

--- a/src/piwardrive/db_browser.py
+++ b/src/piwardrive/db_browser.py
@@ -12,7 +12,7 @@ from pathlib import Path
 class _DBHandler(http.server.BaseHTTPRequestHandler):
     db_path: Path
 
-    def do_GET(self):  # pragma: no cover - simple HTTP handler
+    def do_GET(self) -> None:  # pragma: no cover - simple HTTP handler
         conn = None
         try:
             conn = sqlite3.connect(self.db_path)

--- a/src/piwardrive/exception_handler.py
+++ b/src/piwardrive/exception_handler.py
@@ -63,7 +63,7 @@ def install(app: FastAPI | None = None) -> None:
     if app is not None and FastAPI is not None:
 
         @app.exception_handler(Exception)  # type: ignore[arg-type]
-        async def _fastapi_handler(request: Request, exc: Exception):
+        async def _fastapi_handler(request: Request, exc: Exception) -> JSONResponse:
             logging.exception("Unhandled FastAPI exception", exc_info=exc)
             return JSONResponse(
                 status_code=500,

--- a/src/piwardrive/scripts/service_status.py
+++ b/src/piwardrive/scripts/service_status.py
@@ -8,7 +8,9 @@ from types import SimpleNamespace
 from piwardrive.logconfig import setup_logging
 
 
-def _get_service_statuses(services=None):
+def _get_service_statuses(
+    services: tuple[str, ...] | list[str] | None = None
+) -> dict[str, bool]:
     """Import :mod:`piwardrive.diagnostics` lazily and get statuses."""
     from piwardrive import diagnostics as _diag
 


### PR DESCRIPTION
## Summary
- add return type to `_DBHandler.do_GET`
- type `_fastapi_handler`
- type `async_ttl_cache` decorator
- type `_get_service_statuses` helper

## Testing
- `mypy --strict`

------
https://chatgpt.com/codex/tasks/task_e_686303fff4588333821925a81207b8b1