### PR TITLE
Add key docstrings across modules

### DIFF
--- a/src/piwardrive/config.py
+++ b/src/piwardrive/config.py
@@ -1,1 +1,8 @@
+"""Public configuration accessors for :mod:`piwardrive`.
+
+This module re-exports all names from :mod:`piwardrive.core.config` so that the
+rest of the code base can import configuration helpers without reaching into the
+``core`` package directly.
+"""
+
 from .core.config import *  # noqa: F401,F403

--- a/src/piwardrive/persistence.py
+++ b/src/piwardrive/persistence.py
@@ -1,3 +1,11 @@
+"""Public persistence helpers for :mod:`piwardrive`.
+
+This module re-exports the database utilities from
+:mod:`piwardrive.core.persistence`. Importing from this location keeps
+database-related helpers in a consistent namespace while allowing the core
+implementation to reside in the ``core`` package.
+"""
+
 from .core.persistence import *  # noqa: F401,F403
 from .core.persistence import _db_path, _get_conn
 

--- a/src/piwardrive/route_prefetch.py
+++ b/src/piwardrive/route_prefetch.py
@@ -67,6 +67,7 @@ class RoutePrefetcher:
         delta: float = 0.01,
         offline_tile_path: str | None = None,
     ) -> None:
+        """Create the prefetcher and register the polling task."""
         self._map_screen = map_screen
         self._lookahead = lookahead
         self._delta = delta

--- a/src/piwardrive/simpleui.py
+++ b/src/piwardrive/simpleui.py
@@ -1,9 +1,18 @@
+"""Minimal UI shim used within the test suite.
+
+This module provides very small stand-ins for a few Kivy widgets. They expose
+just enough behaviour for the unit tests without pulling in the heavy Kivy
+dependency.
+"""
+
 from __future__ import annotations
 
 from typing import Any, Callable, Iterable
 
 
 class Label:
+    """Simple stand-in for ``kivy.uix.label.Label``."""
+
     def __init__(
         self,
         text: str = "",
@@ -11,6 +20,7 @@ class Label:
         valign: str = "middle",
         **_kwargs: Any,
     ) -> None:
+        """Initialize the label with optional text and alignment."""
         self.text: str = text
         self.halign: str = halign
         self.valign: str = valign
@@ -19,10 +29,13 @@ class Label:
         self.height: int = 0
 
     def bind(self, **_kwargs: Callable[[Any, Any], None]) -> None:
+        """Bind callbacks to property changes (no-op in tests)."""
         pass
 
 
 class Card:
+    """Container widget that simply stores its children."""
+
     def __init__(
         self,
         orientation: str = "vertical",
@@ -30,29 +43,39 @@ class Card:
         radius: Iterable[int] | None = None,
         **_kwargs: Any,
     ) -> None:
+        """Create a new card layout container."""
         self.orientation: str = orientation
         self.padding: int | float = padding
         self.radius: list[int] = list(radius or [])
         self.children: list[Any] = []
 
     def add_widget(self, widget: Any) -> None:
+        """Append ``widget`` to the list of children."""
         self.children.append(widget)
 
 
 class BoxLayout:
+    """Simplified vertical/horizontal layout container."""
+
     def __init__(self, **_kwargs: Any) -> None:
+        """Create an empty layout."""
         self.children: list[Any] = []
 
     def add_widget(self, widget: Any) -> None:
+        """Add ``widget`` to the container."""
         self.children.append(widget)
 
     def bind(self, **kwargs: Callable[[Any, Any], None]) -> None:
+        """Immediately invoke provided callbacks (test helper)."""
         for cb in kwargs.values():
             cb(self, None)
 
 
 class ScrollView:
+    """Lightweight scroll view stub."""
+
     def __init__(self, **kwargs: Any) -> None:
+        """Initialise the view and store provided options."""
         self.width: int = 0
         self.children: list[Any] = []
         self.scroll_y: float = 0.0
@@ -60,35 +83,47 @@ class ScrollView:
             setattr(self, k, v)
 
     def add_widget(self, widget: Any) -> None:
+        """Append ``widget`` to the list of children."""
         self.children.append(widget)
 
     def bind(self, **kwargs: Callable[[Any, Any], None]) -> None:
+        """Immediately invoke callbacks (test helper)."""
         for cb in kwargs.values():
             cb(self, None)
 
 
 def dp(val: int | float) -> int | float:
+    """Return ``val`` unchanged to mimic :func:`kivy.metrics.dp`."""
     return val
 
 
 class Image:
+    """Minimal image widget used in tests."""
+
     def __init__(self, **_kwargs: Any) -> None:
+        """Initialise the image container."""
         self.source: str = ""
         self.size_hint_y: float | None = None
         self.height: int = 0
 
     def reload(self) -> None:
+        """Reload the current image source (no-op)."""
         pass
 
 
 class DropdownMenu:
+    """Very small dropdown menu placeholder."""
+
     def __init__(self, **kwargs: Any) -> None:
+        """Store provided ``kwargs`` for inspection by tests."""
         self.kwargs: dict[str, Any] = kwargs
         # Expose kwargs on the class for tests that inspect it
         type(self).kwargs = kwargs
 
     def open(self) -> None:
+        """Open the menu (no-op in tests)."""
         pass
 
     def dismiss(self) -> None:
+        """Close the menu (no-op in tests)."""
         pass

--- a/src/piwardrive/widgets/db_stats.py
+++ b/src/piwardrive/widgets/db_stats.py
@@ -17,6 +17,7 @@ try:  # pragma: no cover - optional dependency
 except Exception:  # pragma: no cover - fallbacks for tests without deps
 
     async def get_table_counts() -> dict[str, int]:
+        """Return an empty table-count mapping when persistence is missing."""
         return {}
 
     def _db_path() -> str:
@@ -34,6 +35,7 @@ except Exception:  # pragma: no cover - simple fallback
     def run_async_task(
         coro: Coroutine[Any, Any, T], callback: Callable[[T], None] | None = None
     ) -> Future[T]:
+        """Synchronously execute ``coro`` and invoke ``callback`` if given."""
         fut: Future[T] = Future()
 
         try:
@@ -52,6 +54,7 @@ class DBStatsWidget(DashboardWidget):
     update_interval = 10.0
 
     def __init__(self, **kwargs: Any) -> None:
+        """Create the widget and schedule the first update."""
         super().__init__(**kwargs)
         self.card = MDCard(orientation="vertical", padding=dp(8), radius=[8])
         self.label = MDLabel(text=f"{_('db')}: {_('not_available')}", halign="center")


### PR DESCRIPTION
## Summary
- add module docstrings for `config` and `persistence`
- expand documentation in `simpleui` placeholder widgets
- document `RoutePrefetcher.__init__`
- document fallback functions in DB stats widget

## Testing
- `pydocstyle --select=D100,D101,D102,D103,D104,D105,D107 src/piwardrive`
- `pytest -k "db_stats_widget" -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_686303d4c6508333aa99d65d18364cfd