### PR TITLE
Clean up type: ignore comments

### DIFF
--- a/scripts/export_grafana.py
+++ b/scripts/export_grafana.py
@@ -48,7 +48,7 @@ def _insert_wifi(conn: sqlite3.Connection, records: list[dict[str, Any]]) -> Non
 
 async def _load_data(limit: int) -> tuple[list[Any], list[dict[str, Any]]]:
     try:
-        from persistence import load_ap_cache, load_recent_health  # type: ignore
+        from persistence import load_ap_cache, load_recent_health
     except Exception:  # pragma: no cover - fallback
         from piwardrive.persistence import load_ap_cache, load_recent_health
 

--- a/scripts/export_log_bundle.py
+++ b/scripts/export_log_bundle.py
@@ -7,7 +7,7 @@ import logging
 from piwardrive.logconfig import setup_logging
 
 try:  # allow tests to substitute a lightweight main module
-    from main import PiWardriveApp  # type: ignore
+    from main import PiWardriveApp
 except Exception:  # pragma: no cover - fallback
     from piwardrive.main import PiWardriveApp
 

--- a/scripts/export_logs.py
+++ b/scripts/export_logs.py
@@ -7,7 +7,7 @@ import logging
 from piwardrive.logconfig import setup_logging
 
 try:  # allow tests to substitute a lightweight main module
-    from main import PiWardriveApp  # type: ignore
+    from main import PiWardriveApp
 except Exception:  # pragma: no cover - fallback
     from piwardrive.main import PiWardriveApp
 

--- a/scripts/export_mysql.py
+++ b/scripts/export_mysql.py
@@ -6,7 +6,7 @@ import os
 from typing import Any
 
 try:
-    from persistence import load_ap_cache, load_recent_health  # type: ignore
+    from persistence import load_ap_cache, load_recent_health
 except Exception:  # pragma: no cover - fallback
     from piwardrive.persistence import load_ap_cache, load_recent_health
 

--- a/scripts/export_shp.py
+++ b/scripts/export_shp.py
@@ -5,7 +5,7 @@ import logging
 from piwardrive.logconfig import setup_logging
 
 try:  # allow tests to substitute a lightweight persistence module
-    from persistence import load_ap_cache  # type: ignore
+    from persistence import load_ap_cache
 except Exception:  # pragma: no cover - fallback
     from piwardrive.persistence import load_ap_cache
 

--- a/scripts/health_export.py
+++ b/scripts/health_export.py
@@ -8,7 +8,7 @@ from dataclasses import asdict
 from typing import Iterable
 
 try:
-    from persistence import HealthRecord, load_recent_health  # type: ignore
+    from persistence import HealthRecord, load_recent_health
 except Exception:  # pragma: no cover - fall back if tests replaced module
     from piwardrive.persistence import HealthRecord, load_recent_health
 

--- a/scripts/health_import.py
+++ b/scripts/health_import.py
@@ -7,8 +7,7 @@ import json
 from typing import Iterable, cast
 
 try:
-    from persistence import HealthRecord  # type: ignore
-    from persistence import flush_health_records, save_health_record
+    from persistence import HealthRecord, flush_health_records, save_health_record
 except Exception:  # pragma: no cover - fall back if tests replaced module
     from piwardrive.persistence import (
         HealthRecord,

--- a/scripts/health_stats.py
+++ b/scripts/health_stats.py
@@ -6,7 +6,7 @@ import json
 import logging
 
 try:
-    from persistence import load_recent_health  # type: ignore
+    from persistence import load_recent_health
 except Exception:  # pragma: no cover - fall back if tests replaced module
     from piwardrive.persistence import load_recent_health
 

--- a/scripts/prune_db.py
+++ b/scripts/prune_db.py
@@ -4,7 +4,7 @@ import argparse
 import asyncio
 
 try:  # allow tests to provide a lightweight persistence module
-    import persistence  # type: ignore
+    import persistence
 except Exception:  # pragma: no cover - fallback
     from piwardrive import persistence
 

--- a/scripts/uav_record.py
+++ b/scripts/uav_record.py
@@ -16,7 +16,7 @@ from piwardrive.logconfig import setup_logging
 try:
     from dronekit import connect
 except Exception:  # pragma: no cover - optional dependency
-    connect = None  # type: ignore
+    connect = None
 
 
 def main(argv: list[str] | None = None) -> None:

--- a/scripts/vacuum_db.py
+++ b/scripts/vacuum_db.py
@@ -3,7 +3,7 @@
 import asyncio
 
 try:  # allow tests to provide a lightweight persistence module
-    import persistence  # type: ignore
+    import persistence
 except Exception:  # pragma: no cover - fallback
     from piwardrive import persistence
 

--- a/setup.py
+++ b/setup.py
@@ -5,9 +5,9 @@ from pathlib import Path
 from setuptools import Extension, find_packages, setup
 
 try:  # Python >=3.11
-    import tomllib  # type: ignore
+    import tomllib
 except ModuleNotFoundError:  # Python <=3.10
-    import tomli as tomllib  # type: ignore
+    import tomli as tomllib
 
 
 def load_project_config():

--- a/src/piwardrive/analysis.py
+++ b/src/piwardrive/analysis.py
@@ -8,7 +8,7 @@ from typing import Dict, List
 from piwardrive.persistence import HealthRecord
 
 try:  # optional dependency
-    import pandas as pd  # type: ignore
+    import pandas as pd
 except Exception:  # pragma: no cover - fallback when pandas missing
     pd = None
 

--- a/src/piwardrive/cli/config_cli.py
+++ b/src/piwardrive/cli/config_cli.py
@@ -14,7 +14,7 @@ from piwardrive.core.config import _parse_env_value
 try:
     import httpx
 except Exception:  # pragma: no cover - optional dependency
-    httpx = None  # type: ignore
+    httpx = None
 
 
 def _parse_value(raw: str, default: Any) -> Any:

--- a/src/piwardrive/diagnostics.py
+++ b/src/piwardrive/diagnostics.py
@@ -105,7 +105,7 @@ async def rotate_log_async(path: str, max_files: int = 3) -> None:
         return
 
     try:
-        import aiofiles  # type: ignore
+        import aiofiles
     except Exception:  # pragma: no cover - optional dependency
         await asyncio.to_thread(rotate_log, path, max_files)
         return

--- a/src/piwardrive/integrations/sigint_suite/exports/exporter.py
+++ b/src/piwardrive/integrations/sigint_suite/exports/exporter.py
@@ -55,7 +55,7 @@ def export_csv(records: Iterable[Mapping[str, str]], path: str) -> None:
 def export_yaml(records: Iterable[Any], path: str) -> None:
     """Export ``records`` to ``path`` in YAML format."""
     try:
-        import yaml  # type: ignore
+        import yaml
     except Exception as exc:  # pragma: no cover - optional dep
         raise RuntimeError("PyYAML required for YAML export") from exc
 

--- a/src/piwardrive/map/tile_maintenance.py
+++ b/src/piwardrive/map/tile_maintenance.py
@@ -7,16 +7,7 @@ import os
 import sqlite3
 import time
 from concurrent.futures import Future
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Callable,
-    Coroutine,
-    Optional,
-    TypeVar,
-    cast,
-)
-
+from typing import TYPE_CHECKING, Any, Callable, Coroutine, Optional, TypeVar, cast
 
 from piwardrive.scheduler import PollScheduler
 
@@ -51,9 +42,9 @@ else:
         from watchdog.events import FileSystemEventHandler as _FileSystemEventHandler
         from watchdog.observers import Observer as _Observer
     except Exception:  # pragma: no cover - watchdog optional for tests
-        from typing import Any as _Observer  # type: ignore
+        from typing import Any as _Observer
 
-        _FileSystemEventHandler = object  # type: ignore
+        _FileSystemEventHandler = object
 
     from typing import Any
 

--- a/src/piwardrive/service.py
+++ b/src/piwardrive/service.py
@@ -22,7 +22,6 @@ try:  # pragma: no cover - optional FastAPI dependency
     )
     from fastapi.middleware.cors import CORSMiddleware
     from fastapi.responses import Response, StreamingResponse  # noqa: E402
-    from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm
     from fastapi.security import (
         HTTPBasic,
         HTTPBasicCredentials,
@@ -30,7 +29,7 @@ try:  # pragma: no cover - optional FastAPI dependency
         OAuth2PasswordRequestForm,
     )
 except Exception:
-    FastAPI = type(  # type: ignore[misc, assignment]
+    FastAPI = type(
         "FastAPI",
         (),
         {
@@ -40,43 +39,43 @@ except Exception:
             "websocket": lambda *a, **k: (lambda f: f),
             "add_middleware": lambda *a, **k: None,
         },
-    )  # type: ignore[misc, assignment]
+    )
 
     def _noop(*_a: typing.Any, **_k: typing.Any) -> None:
         return None
 
-    Depends = _noop  # type: ignore[misc, assignment]
-    HTTPException = type(  # type: ignore[misc]
+    Depends = _noop
+    HTTPException = type(
         "HTTPException",
         (Exception,),
         {},
-    )  # type: ignore[misc, assignment]
-    WebSocket = object  # type: ignore[misc, assignment]
-    WebSocketDisconnect = Exception  # type: ignore[misc, assignment]
-    Body = _noop  # type: ignore[misc, assignment]
-    Request = object  # type: ignore[misc, assignment]
-    StreamingResponse = Response = object  # type: ignore[misc, assignment]
-    OAuth2PasswordBearer = type(  # type: ignore[misc]
+    )
+    WebSocket = object
+    WebSocketDisconnect = Exception
+    Body = _noop
+    Request = object
+    StreamingResponse = Response = object
+    OAuth2PasswordBearer = type(
         "OAuth2PasswordBearer",
         (),
         {"__init__": lambda self, tokenUrl="/token", **k: None},
-    )  # type: ignore[misc, assignment]
-    OAuth2PasswordRequestForm = type(  # type: ignore[misc]
+    )
+    OAuth2PasswordRequestForm = type(
         "OAuth2PasswordRequestForm",
         (),
         {"__init__": lambda self, **k: None, "username": "", "password": ""},
-    )  # type: ignore[misc, assignment]
-    OAuth2PasswordBearer = type(  # type: ignore[misc]
+    )
+    OAuth2PasswordBearer = type(
         "OAuth2PasswordBearer",
         (),
         {"__init__": lambda self, **k: None},
     )
-    OAuth2PasswordRequestForm = type(  # type: ignore[misc]
+    OAuth2PasswordRequestForm = type(
         "OAuth2PasswordRequestForm",
         (),
         {"__init__": lambda self, **k: None},
     )
-    CORSMiddleware = object  # type: ignore[misc, assignment]
+    CORSMiddleware = object
 
 if TYPE_CHECKING:  # pragma: no cover - type hints only
     from fastapi import (
@@ -99,12 +98,12 @@ if TYPE_CHECKING:  # pragma: no cover - type hints only
     from fastapi.middleware.cors import CORSMiddleware
 
 import asyncio
+import functools
 import importlib
 import json
 import secrets
 import tempfile
 import time
-import functools
 from collections.abc import Mapping, Sequence
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Tuple
@@ -112,22 +111,22 @@ from typing import TYPE_CHECKING, Any, Tuple
 from piwardrive.logconfig import DEFAULT_LOG_PATH
 
 try:  # allow tests to stub out ``persistence``
-    from persistence import load_ap_cache  # type: ignore
     from persistence import (
         DashboardSettings,
-        User,
         FingerprintInfo,
+        User,
         _db_path,
         create_user,
         get_table_counts,
         get_user,
         get_user_by_token,
+        load_ap_cache,
         load_dashboard_settings,
-        load_recent_health,
-        load_health_history,
         load_fingerprint_info,
-        save_fingerprint_info,
+        load_health_history,
+        load_recent_health,
         save_dashboard_settings,
+        save_fingerprint_info,
         save_user,
         update_user_token,
     )
@@ -178,9 +177,12 @@ except Exception:  # pragma: no cover - fall back to real module
     from piwardrive import lora_scanner as _lora_scanner
 
 try:  # allow tests to stub out analytics
-    from analytics.baseline import analyze_health_baseline, load_baseline_health  # type: ignore
+    from analytics.baseline import analyze_health_baseline, load_baseline_health
 except Exception:  # pragma: no cover - fall back to real module
-    from piwardrive.analytics.baseline import analyze_health_baseline, load_baseline_health
+    from piwardrive.analytics.baseline import (
+        analyze_health_baseline,
+        load_baseline_health,
+    )
 
 
 logger = logging.getLogger(__name__)

--- a/src/piwardrive/utils.py
+++ b/src/piwardrive/utils.py
@@ -5,15 +5,15 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
-import requests  # type: ignore
+import requests
 
 from .error_reporting import format_error, report_error
 
 __all__ = ["format_error", "report_error"]
 
 try:  # pragma: no cover - optional dependencies may be missing
-    from .core.utils import *  # type: ignore  # noqa: F401,F403
-    from .core.utils import __all__ as _core_all  # type: ignore
+    from .core.utils import *  # noqa: F401,F403
+    from .core.utils import __all__ as _core_all
 
     for _name in _core_all:
         if _name not in __all__:

--- a/src/piwardrive/widgets/log_viewer.py
+++ b/src/piwardrive/widgets/log_viewer.py
@@ -8,7 +8,7 @@ from piwardrive.simpleui import DropdownMenu, Label, ScrollView
 from piwardrive.utils import tail_file
 
 try:  # pragma: no cover - optional dependency
-    from piwardrive.simpleui import App as SimpleApp  # type: ignore
+    from piwardrive.simpleui import App as SimpleApp
 except Exception:  # pragma: no cover - fallback when missing
     SimpleApp = None  # type: ignore[assignment]
 

--- a/tests/test_data_sink.py
+++ b/tests/test_data_sink.py
@@ -70,7 +70,7 @@ def test_write_postgres(monkeypatch):
         return conn
 
     asyncpg = ModuleType("asyncpg")
-    asyncpg.connect = fake_connect  # type: ignore
+    asyncpg.connect = fake_connect  # type: ignore[attr-defined]
     monkeypatch.setitem(sys.modules, "asyncpg", asyncpg)
     asyncio.run(ds.write_postgres("dsn", "tbl", rows))
     assert conn.calls and conn.calls[0][0].startswith("INSERT INTO tbl")

--- a/tests/test_route_optimizer.py
+++ b/tests/test_route_optimizer.py
@@ -2,7 +2,7 @@ import math
 import os
 import sys
 
-from piwardrive import route_optimizer  # noqa: E402  # type: ignore
+from piwardrive import route_optimizer  # noqa: E402
 
 
 def test_suggest_route_empty_returns_empty() -> None:

--- a/tests/test_sigint_exports.py
+++ b/tests/test_sigint_exports.py
@@ -18,7 +18,7 @@ def test_export_yaml(tmp_path):
     records = [{"a": 1, "b": 2}]
     out = tmp_path / "data.yaml"
     export_yaml(records, str(out))
-    import yaml  # type: ignore
+    import yaml
 
     loaded = yaml.safe_load(open(out))
     assert loaded == records


### PR DESCRIPTION
## Summary
- remove unused `type: ignore` comments in `service.py` and `utils.py`
- drop unnecessary ignores across scripts and tests
- ensure remaining ignores specify error codes

## Testing
- `pre-commit run --files scripts/export_grafana.py scripts/export_log_bundle.py scripts/export_logs.py scripts/export_mysql.py scripts/export_shp.py scripts/health_export.py scripts/health_import.py scripts/health_stats.py scripts/prune_db.py scripts/uav_record.py scripts/vacuum_db.py setup.py src/piwardrive/analysis.py src/piwardrive/cli/config_cli.py src/piwardrive/diagnostics.py src/piwardrive/integrations/sigint_suite/exports/exporter.py src/piwardrive/map/tile_maintenance.py src/piwardrive/service.py src/piwardrive/utils.py src/piwardrive/widgets/log_viewer.py tests/test_data_sink.py tests/test_route_optimizer.py tests/test_sigint_exports.py service.py`
- `pytest -q` *(fails: 40 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6863041478608333accea3873ce464fe