### PR TITLE
Fix indentation issues in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,14 @@
 .PHONY: lint test docs coverage
 
 lint:
-	pre-commit run --all-files
+    pre-commit run --all-files
 
 test:
-	pytest -q
+    pytest -q
 
 docs:
-	sphinx-build -W -b html docs docs/_build/html
+    sphinx-build -W -b html docs docs/_build/html
 
 coverage:
-	pytest --cov=src --cov-report=xml -q
-	cd webui && npm test
+    pytest --cov=src --cov-report=xml -q
+    cd webui && npm test


### PR DESCRIPTION
## Summary
- replace tab indentation with spaces in the Makefile

## Testing
- `flake8`


------
https://chatgpt.com/codex/tasks/task_e_686307738b38833395d37366c7994c39