### PR TITLE
Remove insecure command route

### DIFF
--- a/docs/security.rst
+++ b/docs/security.rst
@@ -22,3 +22,9 @@ Alternatively export it via ``PW_ADMIN_PASSWORD_HASH`` or place it in
 
     export PW_ADMIN_PASSWORD_HASH="$pbkdf2-sha256$..."
     python -m piwardrive.main
+
+For HTTP clients, obtain a bearer token by POSTing valid credentials to
+``/token``. Include ``Authorization: Bearer <token>`` with requests to
+routes that modify configuration or control services. When
+``PW_API_PASSWORD_HASH`` is unset the API does not enforce authentication,
+but running without a password is strongly discouraged.

--- a/docs/web_ui.rst
+++ b/docs/web_ui.rst
@@ -81,6 +81,13 @@ variable ``PW_API_PASSWORD_HASH`` to a password hash created with::
 
 to require a password. When the variable is not set, the endpoints are public.
 
+Some routes performing privileged actions, such as
+``/service/{name}`` and ``/service/{name}/{action}``, require a bearer token.
+Post valid credentials to ``/token`` and supply the returned token in an
+``Authorization: Bearer`` header for subsequent requests.
+The console screen now only displays logs and no longer runs arbitrary
+commands.
+
 Launching in Kiosk Mode
 -----------------------
 

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -184,33 +184,6 @@ def test_logs_endpoint_rejects_unknown_path() -> None:
         assert not called
 
 
-def test_command_endpoint_runs_command() -> None:
-    class DummyProc:
-        async def communicate(self) -> tuple[bytes, bytes]:
-            return b"out", b""
-
-        def kill(self) -> None:
-            pass
-
-    async def fake_create(cmd: str, **_k: Any) -> DummyProc:
-        assert cmd == "echo hi"
-        return DummyProc()
-
-    with (
-        mock.patch("service.asyncio.create_subprocess_shell", fake_create),
-        mock.patch("piwardrive.service.asyncio.create_subprocess_shell", fake_create),
-    ):
-        client = TestClient(service.app)
-        resp = client.post("/command", json={"cmd": "echo hi"})
-        assert resp.status_code == 200
-        assert resp.json()["output"] == "out"
-
-
-def test_command_endpoint_requires_cmd() -> None:
-    client = TestClient(service.app)
-    resp = client.post("/command", json={})
-    assert resp.status_code == 400
-
 
 def test_websocket_status_stream() -> None:
     rec = persistence.HealthRecord(

--- a/webui/src/components/ConsoleView.jsx
+++ b/webui/src/components/ConsoleView.jsx
@@ -2,8 +2,6 @@ import { useEffect, useState } from 'react';
 
 export default function ConsoleView() {
   const [logs, setLogs] = useState('');
-  const [cmd, setCmd] = useState('');
-  const [output, setOutput] = useState('');
   const [path, setPath] = useState('/var/log/syslog');
   const [paths, setPaths] = useState([]);
 
@@ -31,36 +29,16 @@ export default function ConsoleView() {
     return () => clearInterval(id);
   }, [path]);
 
-  const runCommand = () => {
-    fetch('/command', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ cmd }),
-    })
-      .then(r => r.json())
-      .then(d => setOutput(d.output || ''))
-      .catch(e => setOutput(String(e)));
-  };
-
   return (
     <div>
       <h2>Console</h2>
       <pre style={{ maxHeight: '200px', overflowY: 'auto' }}>{logs}</pre>
-      <div>
-        <input
-          value={cmd}
-          onChange={e => setCmd(e.target.value)}
-          onKeyDown={e => {
-            if (e.key === 'Enter') runCommand();
-          }}
-        />
-        <button onClick={runCommand}>Run</button>
-      </div>
-      {output && (
-        <>
-          <h3>Command Output</h3>
-          <pre data-testid="command-output">{output}</pre>
-        </>
+      {paths.length > 1 && (
+        <select value={path} onChange={e => setPath(e.target.value)}>
+          {paths.map(p => (
+            <option key={p}>{p}</option>
+          ))}
+        </select>
       )}
     </div>
   );

--- a/webui/tests/console.test.jsx
+++ b/webui/tests/console.test.jsx
@@ -1,31 +1,24 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import ConsoleView from '../src/components/ConsoleView.jsx';
 
-describe('ConsoleView command runner', () => {
+describe('ConsoleView log viewer', () => {
   let origFetch;
 
   beforeEach(() => {
     origFetch = global.fetch;
-    global.fetch = vi.fn((url) => {
-      if (url.startsWith('/logs')) {
-        return Promise.resolve({ json: () => Promise.resolve({ lines: ['log'] }) });
-      }
-      return Promise.resolve({ json: () => Promise.resolve({ output: 'pong' }) });
-    });
+    global.fetch = vi.fn((url) =>
+      Promise.resolve({ json: () => Promise.resolve({ lines: ['log'] }) })
+    );
   });
 
   afterEach(() => {
     global.fetch = origFetch;
   });
 
-  it('sends command and shows output', async () => {
+  it('loads logs on mount', async () => {
     render(<ConsoleView />);
-    const input = screen.getByRole('textbox');
-    fireEvent.change(input, { target: { value: 'ping' } });
-    fireEvent.click(screen.getByText('Run'));
-    expect(await screen.findByText('Command Output')).toBeInTheDocument();
-    expect(screen.getByText('pong')).toBeInTheDocument();
+    expect(await screen.findByText('log')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- drop `/command` endpoint from service API
- simplify Console view to only display logs
- update docs with token auth guidance
- clarify console is log-only
- drop `/command` tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_686307965cb883339d21b493f54e507e