### PR TITLE
Document orientation map env var

### DIFF
--- a/docs/environment.rst
+++ b/docs/environment.rst
@@ -45,6 +45,9 @@ General
 ``PW_MPU6050_ADDR``
     I\ :sup:`2`\ C address for :func:`orientation_sensors.read_mpu6050` (default ``0x68``).
 
+``PW_ORIENTATION_MAP_FILE``
+    Path to a JSON orientation map loaded at startup.
+
 ``PW_REMOTE_SYNC_URL``
     Upload endpoint for automatic database sync.
 


### PR DESCRIPTION
## Summary
- document `PW_ORIENTATION_MAP_FILE` in environment variables
- build the docs to make sure they succeed

## Testing
- `make docs`

------
https://chatgpt.com/codex/tasks/task_e_686307a292908333a9c43ea9c8a7b0dc