### PR TITLE
Fix duplicate dataclass field

### DIFF
--- a/src/piwardrive/core/config.py
+++ b/src/piwardrive/core/config.py
@@ -258,7 +258,6 @@ class ConfigModel(FileConfigModel):
     mysql_db: str = DEFAULTS["mysql_db"]
     enable_graphql: bool = DEFAULTS["enable_graphql"]
     enable_mqtt: bool = DEFAULTS["enable_mqtt"]
-    scan_rules: Dict[str, Any] = field(default_factory=dict)
     scan_rules: Dict[str, Any] = Field(default_factory=dict)
     influx_url: str = DEFAULTS["influx_url"]
     influx_token: str = DEFAULTS["influx_token"]


### PR DESCRIPTION
## Summary
- remove duplicate field definition in `ConfigModel`

## Testing
- `pre-commit run flake8 --files src/piwardrive/core/config.py`
- `pytest -q` *(fails: ModuleNotFoundError for numpy and other packages)*

------
https://chatgpt.com/codex/tasks/task_e_6863079e1d50833386878ef6c491c2f2