### PR TITLE
Replace magic numbers with named constants

### DIFF
--- a/src/piwardrive/integrations/sigint_suite/bluetooth/scanner.py
+++ b/src/piwardrive/integrations/sigint_suite/bluetooth/scanner.py
@@ -14,6 +14,8 @@ from piwardrive.sigint_suite.models import BluetoothDevice
 
 logger = logging.getLogger(__name__)
 
+PROC_WAIT_TIMEOUT = 2.0
+
 _proc: asyncio.subprocess.Process | None = None
 _reader_task: asyncio.Task[None] | None = None
 _devices: Dict[str, str] = {}
@@ -79,7 +81,7 @@ async def stop_scanner() -> None:
             await _reader_task
     with contextlib.suppress(Exception):
         _proc.terminate()
-        await asyncio.wait_for(_proc.wait(), timeout=2.0)
+        await asyncio.wait_for(_proc.wait(), timeout=PROC_WAIT_TIMEOUT)
     _proc = None
     _reader_task = None
     _devices = {}

--- a/src/piwardrive/integrations/sigint_suite/enrichment/oui.py
+++ b/src/piwardrive/integrations/sigint_suite/enrichment/oui.py
@@ -9,6 +9,10 @@ import time
 from functools import lru_cache
 from typing import TYPE_CHECKING, Any, Dict, NoReturn, Optional, cast
 
+REQUEST_TIMEOUT = 5
+REQUEST_RETRY_DELAY = 1
+REQUEST_RETRY_ATTEMPTS = 3
+
 try:
     import requests
 except Exception:  # pragma: no cover - missing dependency
@@ -25,12 +29,12 @@ except Exception:  # pragma: no cover - minimal fallback
 
         def robust_request(url: str) -> "Response":
             last_exc = None
-            for _ in range(3):
+            for _ in range(REQUEST_RETRY_ATTEMPTS):
                 try:
-                    return requests.get(url, timeout=5)
+                    return requests.get(url, timeout=REQUEST_TIMEOUT)
                 except Exception as exc:  # pragma: no cover - simple retry
                     last_exc = exc
-                    time.sleep(1)
+                    time.sleep(REQUEST_RETRY_DELAY)
             if last_exc is not None:
                 raise last_exc
             raise RuntimeError("Unreachable")

--- a/src/piwardrive/notifications.py
+++ b/src/piwardrive/notifications.py
@@ -13,6 +13,8 @@ from .utils import get_cpu_temp, get_disk_usage, run_async_task
 
 logger = logging.getLogger(__name__)
 
+WEBHOOK_TIMEOUT = 5
+
 
 class NotificationManager:
     """Send webhook notifications when thresholds are exceeded."""
@@ -52,7 +54,7 @@ class NotificationManager:
         async with httpx.AsyncClient() as client:
             for url in self.webhooks:
                 try:
-                    await client.post(url, json=payload, timeout=5)
+                    await client.post(url, json=payload, timeout=WEBHOOK_TIMEOUT)
                 except Exception as exc:  # pragma: no cover - network errors
                     logger.warning("notification to %s failed: %s", url, exc)
 

--- a/src/piwardrive/remote_sync.py
+++ b/src/piwardrive/remote_sync.py
@@ -6,6 +6,7 @@ import sqlite3
 from typing import Tuple
 
 import remote_sync as _impl
+from remote_sync import DEFAULT_RETRIES, DEFAULT_TIMEOUT
 
 # Re-export commonly used modules to keep older imports working.
 asyncio = _impl.asyncio
@@ -41,8 +42,8 @@ async def sync_database_to_server(
     db_path: str,
     url: str,
     *,
-    timeout: int = 30,
-    retries: int = 3,
+    timeout: int = DEFAULT_TIMEOUT,
+    retries: int = DEFAULT_RETRIES,
     row_range: Tuple[int, int] | None = None,
 ) -> None:
     """Delegate to :func:`remote_sync.sync_database_to_server`."""
@@ -60,8 +61,8 @@ async def sync_new_records(
     url: str,
     *,
     state_file: str | None = None,
-    timeout: int = 30,
-    retries: int = 3,
+    timeout: int = DEFAULT_TIMEOUT,
+    retries: int = DEFAULT_RETRIES,
 ) -> int:
     """Delegate to :func:`remote_sync.sync_new_records` using local wrapper."""
     if state_file is None:

--- a/src/piwardrive/sync.py
+++ b/src/piwardrive/sync.py
@@ -11,6 +11,8 @@ import aiohttp
 
 from piwardrive import config
 
+RETRY_SLEEP = 1
+
 
 async def upload_data(records: Sequence[dict[str, Any]]) -> bool:
     """Upload ``records`` to the configured ``remote_sync_url``."""
@@ -36,5 +38,5 @@ async def upload_data(records: Sequence[dict[str, Any]]) -> bool:
             if attempt >= cfg.remote_sync_retries:
                 logging.exception("upload_data failed: %s", exc)
                 return False
-            await asyncio.sleep(1)
+            await asyncio.sleep(RETRY_SLEEP)
     return False

--- a/src/piwardrive/utils.py
+++ b/src/piwardrive/utils.py
@@ -12,6 +12,10 @@ from .error_reporting import format_error, report_error
 
 __all__ = ["format_error", "report_error"]
 
+HTTP_TIMEOUT = 5
+RETRY_ATTEMPTS = 3
+RETRY_DELAY = 1
+
 try:  # pragma: no cover - optional dependencies may be missing
     from .core.utils import *  # noqa: F401,F403
     from .core.utils import __all__ as _core_all
@@ -86,12 +90,12 @@ def robust_request(url: str) -> requests.Response:
 
     def do_request() -> requests.Response:
         try:
-            return requests.get(url, timeout=5)
+            return requests.get(url, timeout=HTTP_TIMEOUT)
         except requests.RequestException as exc:
             logging.warning("Request failed: %s", exc)
             raise
 
-    return retry_call(do_request, attempts=3, delay=1)  # noqa: F405
+    return retry_call(do_request, attempts=RETRY_ATTEMPTS, delay=RETRY_DELAY)  # noqa: F405
 
 
 __all__.append("robust_request")

--- a/src/remote_sync/__init__.py
+++ b/src/remote_sync/__init__.py
@@ -14,6 +14,11 @@ import aiohttp
 
 logger = logging.getLogger(__name__)
 
+# Default behavior tuning
+DEFAULT_TIMEOUT = 30
+DEFAULT_RETRIES = 3
+INITIAL_RETRY_DELAY = 1.0
+
 # Treat these environment variable values as "metrics disabled"
 _DISABLED_METRIC_VALUES = {
     None,
@@ -114,8 +119,8 @@ async def sync_new_records(
     url: str,
     *,
     state_file: str | None = None,
-    timeout: int = 30,
-    retries: int = 3,
+    timeout: int = DEFAULT_TIMEOUT,
+    retries: int = DEFAULT_RETRIES,
 ) -> int:
     """Sync new ``health_records`` rows to ``url``.
 
@@ -149,8 +154,8 @@ async def sync_database_to_server(
     db_path: str,
     url: str,
     *,
-    timeout: int = 30,
-    retries: int = 3,
+    timeout: int = DEFAULT_TIMEOUT,
+    retries: int = DEFAULT_RETRIES,
     row_range: tuple[int, int] | None = None,
 ) -> None:
     """Upload the SQLite database at ``db_path`` to ``url`` via HTTP POST.
@@ -163,7 +168,7 @@ async def sync_database_to_server(
     if not os.path.exists(db_path):
         raise FileNotFoundError(db_path)
 
-    delay = 1.0
+    delay = INITIAL_RETRY_DELAY
     temp_path = None
     if row_range is not None:
         start, end = row_range


### PR DESCRIPTION
## Summary
- avoid raw numeric literals for timing and limits
- use named constants for timeouts and sleeps

## Testing
- `pytest -q` *(fails: 41 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6863077c42288333a6c3296c6c10dda0