### PR TITLE
Enhance simpleui components with tkinter

### DIFF
--- a/src/piwardrive/simpleui.py
+++ b/src/piwardrive/simpleui.py
@@ -9,6 +9,31 @@ from __future__ import annotations
 
 from typing import Any, Callable, Iterable
 
+# Attempt to import tkinter for basic GUI support.  When unavailable or a display
+# cannot be opened, ``tk`` will remain ``None`` and all widgets fall back to the
+# previous no-op behaviour used in the tests.
+try:  # pragma: no cover - optional dependency
+    import tkinter as tk
+except Exception:  # pragma: no cover - running headless or tkinter missing
+    tk = None  # type: ignore[assignment]
+
+_tk_root: Any | None = None
+
+
+def _get_root() -> Any | None:
+    """Return a hidden ``Tk`` instance or ``None`` when not available."""
+
+    global _tk_root
+    if tk is None:
+        return None
+    if _tk_root is None:
+        try:  # pragma: no cover - may fail on headless systems
+            _tk_root = tk.Tk()
+            _tk_root.withdraw()
+        except Exception:
+            _tk_root = None
+    return _tk_root
+
 
 class Label:
     """Simple stand-in for ``kivy.uix.label.Label``."""
@@ -21,6 +46,8 @@ class Label:
         **_kwargs: Any,
     ) -> None:
         """Initialize the label with optional text and alignment."""
+        self._callbacks: dict[str, list[Callable[[Any, Any], None]]] = {}
+        self._widget: Any | None = None
         self.text: str = text
         self.halign: str = halign
         self.valign: str = valign
@@ -28,9 +55,47 @@ class Label:
         self.texture_size: list[int] = [0, 0]
         self.height: int = 0
 
-    def bind(self, **_kwargs: Callable[[Any, Any], None]) -> None:
-        """Bind callbacks to property changes (no-op in tests)."""
-        pass
+        root = _get_root()
+        if root is not None:
+            try:  # pragma: no cover - UI update
+                justify = {
+                    "left": tk.LEFT,
+                    "center": tk.CENTER,
+                    "right": tk.RIGHT,
+                }.get(halign, tk.LEFT)
+                self._widget = tk.Label(root, text=text, justify=justify)
+                self._widget.pack()
+                self._widget.update_idletasks()
+                self.texture_size = [
+                    self._widget.winfo_reqwidth(),
+                    self._widget.winfo_reqheight(),
+                ]
+            except Exception:
+                self._widget = None
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        object.__setattr__(self, name, value)
+        if name == "text":  # update underlying widget
+            widget = getattr(self, "_widget", None)
+            if widget is not None:
+                try:  # pragma: no cover - GUI update
+                    widget.config(text=value)
+                    widget.update_idletasks()
+                    width = widget.winfo_reqwidth()
+                    height = widget.winfo_reqheight()
+                    object.__setattr__(self, "texture_size", [width, height])
+                    for cb in self._callbacks.get("texture_size", []):
+                        cb(self, self.texture_size)
+                except Exception:
+                    pass
+        if name in getattr(self, "_callbacks", {}):
+            for cb in self._callbacks[name]:
+                cb(self, value)
+
+    def bind(self, **kwargs: Callable[[Any, Any], None]) -> None:
+        """Attach callbacks to property changes."""
+        for prop, cb in kwargs.items():
+            self._callbacks.setdefault(prop, []).append(cb)
 
 
 class Card:
@@ -105,10 +170,37 @@ class Image:
         self.source: str = ""
         self.size_hint_y: float | None = None
         self.height: int = 0
+        self._widget: Any | None = None
 
     def reload(self) -> None:
-        """Reload the current image source (no-op)."""
-        pass
+        """Reload the current image source if ``tkinter`` is available."""
+        if tk is None:
+            return
+        root = _get_root()
+        if root is None or not self.source:
+            return
+        try:  # pragma: no cover - GUI update
+            img = tk.PhotoImage(file=self.source)
+        except Exception:
+            return
+        if self._widget is None:
+            try:
+                self._widget = tk.Label(root, image=img)
+                self._widget.image = img
+                self._widget.pack()
+            except Exception:
+                self._widget = None
+                return
+        else:
+            try:
+                self._widget.configure(image=img)
+                self._widget.image = img
+            except Exception:
+                return
+        try:
+            root.update_idletasks()
+        except Exception:
+            pass
 
 
 class DropdownMenu:
@@ -119,11 +211,31 @@ class DropdownMenu:
         self.kwargs: dict[str, Any] = kwargs
         # Expose kwargs on the class for tests that inspect it
         type(self).kwargs = kwargs
+        self._window: Any | None = None
 
     def open(self) -> None:
-        """Open the menu (no-op in tests)."""
-        pass
+        """Open the menu using ``tkinter`` if available."""
+        if tk is None:
+            return
+        root = _get_root()
+        if root is None:
+            return
+        try:  # pragma: no cover - GUI update
+            self._window = tk.Toplevel(root)
+            for item in self.kwargs.get("items", []):
+                text = item.get("text", "")
+                cmd = item.get("on_release")
+                tk.Button(self._window, text=text, command=cmd).pack(fill=tk.X)
+            self._window.update_idletasks()
+        except Exception:
+            self._window = None
 
     def dismiss(self) -> None:
-        """Close the menu (no-op in tests)."""
-        pass
+        """Close the menu if it was opened."""
+        if self._window is not None:
+            try:  # pragma: no cover - GUI update
+                self._window.destroy()
+            except Exception:
+                pass
+            finally:
+                self._window = None


### PR DESCRIPTION
## Summary
- use tkinter when available to show basic UI elements
- update Label, Image, and DropdownMenu to create real widgets
- safely fall back to previous no-op behaviour when tkinter isn't usable

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68630a6f76a48333aa69f1d90ac1ffff