### PR TITLE
Use boto3 for uploads

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,6 +22,7 @@ fastapi==0.115.12
 defusedxml==0.7.1
 uvicorn[standard]==0.34.3
 httpx==0.28.1
+boto3==1.39.0
 aiohttp==3.12.13
 aiosqlite==0.21.0
 aiomysql==0.2.0

--- a/src/piwardrive/cloud_export.py
+++ b/src/piwardrive/cloud_export.py
@@ -5,22 +5,29 @@ from __future__ import annotations
 import logging
 import os
 import subprocess
-from typing import Optional
+from typing import Any, Optional
+
+import boto3
 
 logger = logging.getLogger(__name__)
 
 
 def upload_to_s3(
-    file_path: str, bucket: str, key: str, profile: Optional[str] = None
+    file_path: str,
+    bucket: str,
+    key: str,
+    profile: Optional[str] = None,
+    extra_args: Optional[dict[str, Any]] = None,
 ) -> None:
-    """Upload ``file_path`` to the given S3 ``bucket`` using the AWS CLI."""
+    """Upload ``file_path`` to the given S3 ``bucket`` using :mod:`boto3`."""
     if not os.path.exists(file_path):
         raise FileNotFoundError(file_path)
-    cmd = ["aws", "s3", "cp", file_path, f"s3://{bucket}/{key}"]
-    if profile:
-        cmd.extend(["--profile", profile])
+
+    session = boto3.Session(profile_name=profile) if profile else boto3.Session()
+    s3 = session.client("s3")
+
     try:
-        subprocess.run(cmd, check=True)
+        s3.upload_file(file_path, bucket, key, ExtraArgs=extra_args or {})
         logger.info("Uploaded %s to s3://%s/%s", file_path, bucket, key)
     except Exception as exc:  # pragma: no cover - runtime errors
         logger.error("S3 upload failed: %s", exc)


### PR DESCRIPTION
## Summary
- use boto3 SDK for S3 uploads
- update test to stub boto3 session
- add boto3 as a requirement

## Testing
- `pytest -q tests/test_cloud_export.py tests/test_data_sink.py`

------
https://chatgpt.com/codex/tasks/task_e_68630a801074833399f44bac5c670160