### PR TITLE
Implement resize hook for widgets

### DIFF
--- a/src/piwardrive/widgets/base.py
+++ b/src/piwardrive/widgets/base.py
@@ -14,4 +14,21 @@ class DashboardWidget(BoxLayout):
         super().__init__(**kwargs)
 
     def on_size(self, *_args: Any) -> None:  # pragma: no cover - no GUI
-        pass
+        """Handle resize events by updating child layout hints."""
+
+        width = getattr(self, "width", 0)
+        height = getattr(self, "height", 0)
+        for child in self.children:
+            if hasattr(child, "text_size"):
+                child.text_size = (width, 0)
+            if (
+                hasattr(child, "size_hint_y")
+                and child.size_hint_y is None
+                and hasattr(child, "height")
+            ):
+                child.height = height
+            if hasattr(child, "on_size") and child is not self:
+                try:
+                    child.on_size(*_args)
+                except Exception:
+                    pass


### PR DESCRIPTION
## Summary
- update DashboardWidget.on_size to adjust child layouts when resized

## Testing
- `pytest tests/test_widget_cache.py::test_widget_plugin_cache -q`
- `pytest tests/test_widget_plugins.py::test_plugin_discovery -q`
- `pytest tests/test_service_plugins.py::test_plugins_endpoint -q` *(fails: ImportError)*

------
https://chatgpt.com/codex/tasks/task_e_68630a73be048333b873e59dcf927547