### PR TITLE
Update README with node test instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -623,6 +623,8 @@ pip install -r requirements-dev.txt
 pip install .[tests]
 pre-commit run --all-files
 pytest
+node --test                # runs scripts/*.test.js
+cd webui && npm test       # runs frontend tests
 ```
 
 You can also run `scripts/setup_dev_env.sh` to install these dependencies
@@ -636,6 +638,9 @@ Docker helpers are provided:
 ```bash
 docker compose run --rm tests
 ```
+
+The Makefile's `coverage` target also runs `pytest` and `npm test` when
+generating coverage reports.
 
 ## Legal Notice
 


### PR DESCRIPTION
## Summary
- document how to run Node-based tests for scripts and frontend
- mention that `make coverage` runs both Python and Node tests

## Testing
- `pytest -q` *(fails: 41 errors during collection)*
- `node --test` *(fails: test suite failures)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68630a929f8483339fde616a6baed2be