### PR TITLE
Ensure upload filenames are sanitized

### DIFF
--- a/src/piwardrive/aggregation_service.py
+++ b/src/piwardrive/aggregation_service.py
@@ -14,7 +14,7 @@ from fastapi import FastAPI, UploadFile, HTTPException
 
 from . import analysis, heatmap
 from .persistence import HealthRecord
-from .security import validate_filename
+from .security import sanitize_filename
 
 DATA_DIR = os.path.expanduser(os.getenv("PW_AGG_DIR", "~/piwardrive-aggregation"))
 DB_PATH = os.path.join(DATA_DIR, "aggregation.db")
@@ -99,11 +99,8 @@ async def _process_upload(path: str) -> None:
 async def upload(file: UploadFile) -> Dict[str, str]:  # noqa: V103 - FastAPI route
     """Save ``file`` and merge its contents into the aggregation database."""
     # Called by FastAPI as a route handler.
-    name = os.path.basename(file.filename)
-    if name != file.filename:
-        raise HTTPException(status_code=400, detail="invalid filename")
     try:
-        validate_filename(name)
+        name = sanitize_filename(file.filename)
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc))
     dest = os.path.join(UPLOAD_DIR, name)

--- a/src/piwardrive/security.py
+++ b/src/piwardrive/security.py
@@ -33,6 +33,15 @@ def validate_filename(name: str) -> None:
         raise ValueError(f"Invalid filename: {name}")
 
 
+def sanitize_filename(filename: str) -> str:
+    """Return ``filename`` sanitized for safe storage."""
+    name = os.path.basename(filename)
+    if name != filename:
+        raise ValueError(f"Invalid filename: {filename}")
+    validate_filename(name)
+    return name
+
+
 def hash_password(password: str) -> str:
     """Return a PBKDF2-HMAC-SHA256 hash of ``password``."""
     salt = os.urandom(16)

--- a/sync_receiver.py
+++ b/sync_receiver.py
@@ -3,7 +3,7 @@ import shutil
 
 from fastapi import FastAPI, UploadFile, HTTPException
 
-from piwardrive.security import validate_filename
+from piwardrive.security import sanitize_filename
 
 app = FastAPI()
 STORAGE = os.path.expanduser("~/piwardrive-sync")
@@ -12,11 +12,8 @@ os.makedirs(STORAGE, exist_ok=True)
 
 @app.post("/")
 async def receive(file: UploadFile):
-    name = os.path.basename(file.filename)
-    if name != file.filename:
-        raise HTTPException(status_code=400, detail="invalid filename")
     try:
-        validate_filename(name)
+        name = sanitize_filename(file.filename)
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc))
     dest = os.path.join(STORAGE, name)

--- a/tests/test_aggregation_service.py
+++ b/tests/test_aggregation_service.py
@@ -85,3 +85,16 @@ def test_upload_rejects_traversal(tmp_path):
     with open(db_path, "rb") as fh:
         resp = client.post("/upload", files={"file": ("../db", fh)})
     assert resp.status_code == 400
+
+
+def test_upload_rejects_nested_traversal(tmp_path):
+    os.environ["PW_AGG_DIR"] = str(tmp_path)
+    module = importlib.import_module("piwardrive.aggregation_service")
+    importlib.reload(module)
+    db_path = tmp_path / "upload.db"
+    _create_src_db(str(db_path))
+
+    client = TestClient(module.app)
+    with open(db_path, "rb") as fh:
+        resp = client.post("/upload", files={"file": ("../../etc/passwd", fh)})
+    assert resp.status_code == 400

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -32,3 +32,9 @@ def test_validate_filename() -> None:
     security.validate_filename("good.db")
     with pytest.raises(ValueError):
         security.validate_filename("../bad")
+
+
+def test_sanitize_filename() -> None:
+    assert security.sanitize_filename("db") == "db"
+    with pytest.raises(ValueError):
+        security.sanitize_filename("../../etc/passwd")

--- a/tests/test_sync_receiver.py
+++ b/tests/test_sync_receiver.py
@@ -23,3 +23,10 @@ def test_rejects_traversal(tmp_path, monkeypatch):
     client = TestClient(receiver.app)
     resp = client.post("/", files={"file": ("../x", b"data")})
     assert resp.status_code == 400
+
+
+def test_rejects_nested_traversal(tmp_path, monkeypatch):
+    receiver = _load_receiver(tmp_path, monkeypatch)
+    client = TestClient(receiver.app)
+    resp = client.post("/", files={"file": ("../../etc/passwd", b"data")})
+    assert resp.status_code == 400


### PR DESCRIPTION
## Summary
- add `sanitize_filename` helper
- validate uploaded filenames in the aggregation and sync receivers
- test that traversal attempts like `../../etc/passwd` are rejected

## Testing
- `pytest tests/test_security.py tests/test_sync_receiver.py tests/test_aggregation_service.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68630a98102c8333856d7d75ad986e75