### PR TITLE
Remove unused remote command endpoint

### DIFF
--- a/src/piwardrive/service.py
+++ b/src/piwardrive/service.py
@@ -798,26 +798,6 @@ async def lora_scan_endpoint(
     return {"count": len(lines), "lines": lines}
 
 
-@POST("/command")
-async def run_command(
-    data: dict[str, Any] = BODY, _auth: User | None = AUTH_DEP
-) -> CommandResponse:
-    """Execute a shell command and return its output."""
-    cmd = str(data.get("cmd", "")).strip()
-    if not cmd:
-        raise HTTPException(status_code=400, detail=error_json(400, "cmd required"))
-    proc = await asyncio.create_subprocess_shell(
-        cmd,
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.STDOUT,
-    )
-    try:
-        out, _ = await asyncio.wait_for(proc.communicate(), timeout=SUBPROCESS_TIMEOUT)
-    except asyncio.TimeoutError:
-        proc.kill()
-        return error_json(408, "timeout")
-    return {"output": out.decode()}
-
 
 @POST("/service/{name}/{action}")
 async def control_service_endpoint(


### PR DESCRIPTION
## Summary
- delete unused `/command` endpoint

## Testing
- `pytest -q` *(fails: 41 errors during collection)*
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68630a98cb00833389bd58ec021697b4