### PR TITLE
Fix login password verification

### DIFF
--- a/src/piwardrive/service.py
+++ b/src/piwardrive/service.py
@@ -593,7 +593,7 @@ async def login(
 ) -> AuthLoginResponse:
     """Validate credentials and return a bearer token."""
     user = await get_user(form.username)
-    if user is None or not verify_password(form.password, user.password):
+    if user is None or not verify_password(form.password, user.password_hash):
         raise HTTPException(status_code=401, detail=error_json(401, "Unauthorized"))
     token = secrets.token_urlsafe(32)
     TOKENS[token] = user.username


### PR DESCRIPTION
## Summary
- fix `/auth/login` to check `password_hash`
- test login endpoint returns a token for valid credentials

## Testing
- `pytest -vv tests/test_service.py::test_auth_login_valid` *(fails: ImportError cannot import load_fingerprint_info)*

------
https://chatgpt.com/codex/tasks/task_e_68630a9676a083339a3b427490939b23