### PR TITLE
Document more environment variables

### DIFF
--- a/docs/environment.rst
+++ b/docs/environment.rst
@@ -63,6 +63,27 @@ General
 ``PW_REMOTE_SYNC_INTERVAL``
     How often to upload the database in minutes. ``0`` disables scheduling.
 
+``PW_UPDATE_INTERVAL``
+    How often PiWardrive checks for updates in hours.
+
+``PW_AGG_DIR``
+    Directory used by ``aggregation_service`` to store data.
+
+``PW_AGG_PORT``
+    Listening port for ``aggregation_service`` (default ``9100``).
+
+``PW_SERVICE_PORT``
+    Port for the HTTP API when running ``service.py`` (default ``8000``).
+
+``PW_API_USER``
+    Username created with ``PW_API_PASSWORD_HASH`` (default ``admin``).
+
+``PW_CORS_ORIGINS``
+    Comma-separated origins allowed by CORS.
+
+``PW_DB_KEY``
+    Passphrase for optional SQLCipher database encryption.
+
 Remote Sync Variables
 ---------------------
 


### PR DESCRIPTION
## Summary
- expand General section of environment variables
- note PW_UPDATE_INTERVAL and several server env vars

## Testing
- `make docs` *(fails: missing separator)*
- `sphinx-build -W -b html docs docs/_build/html` *(fails with warnings treated as errors)*

------
https://chatgpt.com/codex/tasks/task_e_68630c52877c83338594858e06436f7d