### PR TITLE
Remove Kivy stubs

### DIFF
--- a/examples/plugins/weather_widget.py
+++ b/examples/plugins/weather_widget.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 import requests
-from piwardrive.simpleui import Card as MDCard
-from piwardrive.simpleui import Label as MDLabel
-from piwardrive.simpleui import dp
+from piwardrive.ui import Card
+from piwardrive.ui import Label
+from piwardrive.ui import dp
 
 from widgets.base import DashboardWidget
 
@@ -18,8 +18,8 @@ class WeatherWidget(DashboardWidget):
     def __init__(self, **kwargs: object) -> None:
         """Create widget layout and fetch initial data."""
         super().__init__(**kwargs)
-        self.card = MDCard(orientation="vertical", padding=dp(8), radius=[8])
-        self.label = MDLabel(text="Fetching weather...", halign="center")
+        self.card = Card(orientation="vertical", padding=dp(8), radius=[8])
+        self.label = Label(text="Fetching weather...", halign="center")
         self.card.add_widget(self.label)
         self.add_widget(self.card)
         self.update()

--- a/src/piwardrive/ui.py
+++ b/src/piwardrive/ui.py
@@ -1,8 +1,8 @@
 """Minimal UI shim used within the test suite.
 
-This module provides very small stand-ins for a few Kivy widgets. They expose
-just enough behaviour for the unit tests without pulling in the heavy Kivy
-dependency.
+This module provides lightweight stand-ins for a handful of UI widgets.  They
+expose just enough behaviour for the unit tests without relying on any external
+GUI frameworks.
 """
 
 from __future__ import annotations
@@ -11,7 +11,7 @@ from typing import Any, Callable, Iterable
 
 
 class Label:
-    """Simple stand-in for ``kivy.uix.label.Label``."""
+    """Very small text container used in the tests."""
 
     def __init__(
         self,
@@ -93,7 +93,7 @@ class ScrollView:
 
 
 def dp(val: int | float) -> int | float:
-    """Return ``val`` unchanged to mimic :func:`kivy.metrics.dp`."""
+    """Return ``val`` unchanged to aid readability in tests."""
     return val
 
 

--- a/src/piwardrive/widgets/base.py
+++ b/src/piwardrive/widgets/base.py
@@ -2,7 +2,7 @@
 
 from typing import Any
 
-from piwardrive.simpleui import BoxLayout
+from piwardrive.ui import BoxLayout
 
 
 class DashboardWidget(BoxLayout):

--- a/src/piwardrive/widgets/battery_status.py
+++ b/src/piwardrive/widgets/battery_status.py
@@ -6,9 +6,9 @@ from typing import Any
 import psutil
 
 from piwardrive.localization import _
-from piwardrive.simpleui import Card as MDCard
-from piwardrive.simpleui import Label as MDLabel
-from piwardrive.simpleui import dp
+from piwardrive.ui import Card
+from piwardrive.ui import Label
+from piwardrive.ui import dp
 
 from .base import DashboardWidget
 
@@ -24,8 +24,8 @@ class BatteryStatusWidget(DashboardWidget):
 
     def __init__(self, **kwargs: Any) -> None:
         super().__init__(**kwargs)
-        self.card = MDCard(orientation="vertical", padding=dp(8), radius=[8])
-        self.label = MDLabel(
+        self.card = Card(orientation="vertical", padding=dp(8), radius=[8])
+        self.label = Label(
             text=f"{_('battery')}: {_('not_available')}", halign="center"
         )
         self.card.add_widget(self.label)

--- a/src/piwardrive/widgets/db_stats.py
+++ b/src/piwardrive/widgets/db_stats.py
@@ -6,9 +6,9 @@ import os
 from typing import Any
 
 from piwardrive.localization import _
-from piwardrive.simpleui import Card as MDCard
-from piwardrive.simpleui import Label as MDLabel
-from piwardrive.simpleui import dp
+from piwardrive.ui import Card
+from piwardrive.ui import Label
+from piwardrive.ui import dp
 
 from .base import DashboardWidget
 
@@ -56,8 +56,8 @@ class DBStatsWidget(DashboardWidget):
     def __init__(self, **kwargs: Any) -> None:
         """Create the widget and schedule the first update."""
         super().__init__(**kwargs)
-        self.card = MDCard(orientation="vertical", padding=dp(8), radius=[8])
-        self.label = MDLabel(text=f"{_('db')}: {_('not_available')}", halign="center")
+        self.card = Card(orientation="vertical", padding=dp(8), radius=[8])
+        self.label = Label(text=f"{_('db')}: {_('not_available')}", halign="center")
         self.card.add_widget(self.label)
         self.add_widget(self.card)
         self.update()

--- a/src/piwardrive/widgets/gps_status.py
+++ b/src/piwardrive/widgets/gps_status.py
@@ -4,9 +4,9 @@ import logging
 from typing import Any
 
 from piwardrive.localization import _
-from piwardrive.simpleui import Card as MDCard
-from piwardrive.simpleui import Label as MDLabel
-from piwardrive.simpleui import dp
+from piwardrive.ui import Card
+from piwardrive.ui import Label
+from piwardrive.ui import dp
 from piwardrive.utils import get_gps_fix_quality
 
 from .base import DashboardWidget
@@ -23,8 +23,8 @@ class GPSStatusWidget(DashboardWidget):
 
     def __init__(self, **kwargs: Any) -> None:
         super().__init__(**kwargs)
-        self.card = MDCard(orientation="vertical", padding=dp(8), radius=[8])
-        self.label = MDLabel(text=f"{_('gps')}: {_('not_available')}", halign="center")
+        self.card = Card(orientation="vertical", padding=dp(8), radius=[8])
+        self.label = Label(text=f"{_('gps')}: {_('not_available')}", halign="center")
         self.card.add_widget(self.label)
         self.add_widget(self.card)
         self.update()

--- a/src/piwardrive/widgets/handshake_counter.py
+++ b/src/piwardrive/widgets/handshake_counter.py
@@ -4,9 +4,9 @@ import logging
 from typing import Any
 
 from piwardrive.localization import _
-from piwardrive.simpleui import Card as MDCard
-from piwardrive.simpleui import Label as MDLabel
-from piwardrive.simpleui import dp
+from piwardrive.ui import Card
+from piwardrive.ui import Label
+from piwardrive.ui import dp
 from piwardrive.utils import count_bettercap_handshakes
 
 from .base import DashboardWidget
@@ -23,8 +23,8 @@ class HandshakeCounterWidget(DashboardWidget):
 
     def __init__(self, **kwargs: Any) -> None:
         super().__init__(**kwargs)
-        self.card = MDCard(orientation="vertical", padding=dp(8), radius=[8])
-        self.label = MDLabel(text=f"{_('handshakes')}: 0", halign="center")
+        self.card = Card(orientation="vertical", padding=dp(8), radius=[8])
+        self.label = Label(text=f"{_('handshakes')}: 0", halign="center")
         self.card.add_widget(self.label)
         self.add_widget(self.card)
         self.update()

--- a/src/piwardrive/widgets/health_analysis.py
+++ b/src/piwardrive/widgets/health_analysis.py
@@ -7,10 +7,10 @@ from typing import Any
 from piwardrive.analysis import compute_health_stats, plot_cpu_temp
 from piwardrive.localization import _
 from piwardrive.persistence import load_recent_health
-from piwardrive.simpleui import Card as MDCard
-from piwardrive.simpleui import Image
-from piwardrive.simpleui import Label as MDLabel
-from piwardrive.simpleui import dp
+from piwardrive.ui import Card
+from piwardrive.ui import Image
+from piwardrive.ui import Label
+from piwardrive.ui import dp
 from piwardrive.utils import run_async_task
 
 from .base import DashboardWidget
@@ -28,8 +28,8 @@ class HealthAnalysisWidget(DashboardWidget):
     def __init__(self, max_records: int = 50, **kwargs: Any) -> None:
         super().__init__(**kwargs)
         self.max_records = max_records
-        self.card = MDCard(orientation="vertical", padding=dp(8), radius=[8])
-        self.label = MDLabel(
+        self.card = Card(orientation="vertical", padding=dp(8), radius=[8])
+        self.label = Label(
             text=f"{_('health_analysis')}: {_('not_available')}", halign="center"
         )
         self.image = Image(size_hint_y=None, height=dp(150))

--- a/src/piwardrive/widgets/health_status.py
+++ b/src/piwardrive/widgets/health_status.py
@@ -4,9 +4,9 @@ import logging
 from typing import Any
 
 from piwardrive.localization import _
-from piwardrive.simpleui import Card as MDCard
-from piwardrive.simpleui import Label as MDLabel
-from piwardrive.simpleui import dp
+from piwardrive.ui import Card
+from piwardrive.ui import Label
+from piwardrive.ui import dp
 
 from .base import DashboardWidget
 
@@ -22,8 +22,8 @@ class HealthStatusWidget(DashboardWidget):
 
     def __init__(self, **kwargs: Any) -> None:
         super().__init__(**kwargs)
-        self.card = MDCard(orientation="vertical", padding=dp(8), radius=[8])
-        self.label = MDLabel(
+        self.card = Card(orientation="vertical", padding=dp(8), radius=[8])
+        self.label = Label(
             text=f"{_('health')}: {_('not_available')}", halign="center"
         )
         self.card.add_widget(self.label)

--- a/src/piwardrive/widgets/heatmap.py
+++ b/src/piwardrive/widgets/heatmap.py
@@ -9,10 +9,10 @@ from typing import Any
 from piwardrive.heatmap import histogram, save_png
 from piwardrive.localization import _
 from piwardrive.persistence import load_ap_cache
-from piwardrive.simpleui import Card as MDCard
-from piwardrive.simpleui import Image
-from piwardrive.simpleui import Label as MDLabel
-from piwardrive.simpleui import dp
+from piwardrive.ui import Card
+from piwardrive.ui import Image
+from piwardrive.ui import Label
+from piwardrive.ui import dp
 from piwardrive.utils import run_async_task
 
 from .base import DashboardWidget
@@ -26,8 +26,8 @@ class HeatmapWidget(DashboardWidget):
     def __init__(self, bins: int = 40, **kwargs: Any) -> None:
         super().__init__(**kwargs)
         self.bins = bins
-        self.card = MDCard(orientation="vertical", padding=dp(8), radius=[8])
-        self.label = MDLabel(text=_("heatmap"), halign="center")
+        self.card = Card(orientation="vertical", padding=dp(8), radius=[8])
+        self.label = Label(text=_("heatmap"), halign="center")
         self.image = Image(size_hint_y=None, height=dp(150))
         self.card.add_widget(self.label)
         self.card.add_widget(self.image)

--- a/src/piwardrive/widgets/log_viewer.py
+++ b/src/piwardrive/widgets/log_viewer.py
@@ -4,11 +4,11 @@ import os
 import re
 from typing import Any, List
 
-from piwardrive.simpleui import DropdownMenu, Label, ScrollView
+from piwardrive.ui import DropdownMenu, Label, ScrollView
 from piwardrive.utils import tail_file
 
 try:  # pragma: no cover - optional dependency
-    from piwardrive.simpleui import App as SimpleApp
+    from piwardrive.ui import App as SimpleApp
 except Exception:  # pragma: no cover - fallback when missing
     SimpleApp = None  # type: ignore[assignment]
 
@@ -83,7 +83,7 @@ class LogViewer(ScrollView):
         """Display a dropdown menu to select ``log_path``."""
         app = App.get_running_app() if App is not None else None
         paths = getattr(app, "log_paths", self.log_paths)
-        MDDropdownMenu = DropdownMenu
+        DropdownMenu = DropdownMenu
         items = [
             {
                 "text": os.path.basename(p),
@@ -92,7 +92,7 @@ class LogViewer(ScrollView):
             }
             for p in paths
         ]
-        self._menu = MDDropdownMenu(caller=caller, items=items, width_mult=4)
+        self._menu = DropdownMenu(caller=caller, items=items, width_mult=4)
         self._menu.open()
 
     def _select_path(self, path: str) -> None:

--- a/src/piwardrive/widgets/lora_scan_widget.py
+++ b/src/piwardrive/widgets/lora_scan_widget.py
@@ -5,9 +5,9 @@ from typing import Any
 
 from piwardrive import lora_scanner
 from piwardrive.localization import _
-from piwardrive.simpleui import Card as MDCard
-from piwardrive.simpleui import Label as MDLabel
-from piwardrive.simpleui import dp
+from piwardrive.ui import Card
+from piwardrive.ui import Label
+from piwardrive.ui import dp
 
 from .base import DashboardWidget
 
@@ -23,8 +23,8 @@ class LoRaScanWidget(DashboardWidget):
 
     def __init__(self, **kwargs: Any) -> None:
         super().__init__(**kwargs)
-        self.card = MDCard(orientation="vertical", padding=dp(8), radius=[8])
-        self.label = MDLabel(text=f"{_('lora_devices')}: 0", halign="center")
+        self.card = Card(orientation="vertical", padding=dp(8), radius=[8])
+        self.label = Label(text=f"{_('lora_devices')}: 0", halign="center")
         self.card.add_widget(self.label)
         self.add_widget(self.card)
         self.update()

--- a/src/piwardrive/widgets/orientation_widget.py
+++ b/src/piwardrive/widgets/orientation_widget.py
@@ -5,9 +5,9 @@ from typing import Any
 
 from piwardrive import orientation_sensors
 from piwardrive.localization import _
-from piwardrive.simpleui import Card as MDCard
-from piwardrive.simpleui import Label as MDLabel
-from piwardrive.simpleui import dp
+from piwardrive.ui import Card
+from piwardrive.ui import Label
+from piwardrive.ui import dp
 
 from .base import DashboardWidget
 
@@ -23,8 +23,8 @@ class OrientationWidget(DashboardWidget):
 
     def __init__(self, **kwargs: Any) -> None:
         super().__init__(**kwargs)
-        self.card = MDCard(orientation="vertical", padding=dp(8), radius=[8])
-        self.label = MDLabel(
+        self.card = Card(orientation="vertical", padding=dp(8), radius=[8])
+        self.label = Label(
             text=f"{_('orientation')}: {_('not_available')}", halign="center"
         )
         self.card.add_widget(self.label)

--- a/src/piwardrive/widgets/service_status.py
+++ b/src/piwardrive/widgets/service_status.py
@@ -4,9 +4,9 @@ import logging
 from typing import Any
 
 from piwardrive.localization import _
-from piwardrive.simpleui import Card as MDCard
-from piwardrive.simpleui import Label as MDLabel
-from piwardrive.simpleui import dp
+from piwardrive.ui import Card
+from piwardrive.ui import Label
+from piwardrive.ui import dp
 from piwardrive.utils import service_status
 
 from .base import DashboardWidget
@@ -23,8 +23,8 @@ class ServiceStatusWidget(DashboardWidget):
 
     def __init__(self, **kwargs: Any) -> None:
         super().__init__(**kwargs)
-        self.card = MDCard(orientation="vertical", padding=dp(8), radius=[8])
-        self.label = MDLabel(
+        self.card = Card(orientation="vertical", padding=dp(8), radius=[8])
+        self.label = Label(
             text=f"{_('services')}: {_('not_available')}", halign="center"
         )
         self.card.add_widget(self.label)

--- a/src/piwardrive/widgets/signal_strength.py
+++ b/src/piwardrive/widgets/signal_strength.py
@@ -4,9 +4,9 @@ import logging
 from typing import Any
 
 from piwardrive.localization import _
-from piwardrive.simpleui import Card as MDCard
-from piwardrive.simpleui import Label as MDLabel
-from piwardrive.simpleui import dp
+from piwardrive.ui import Card
+from piwardrive.ui import Label
+from piwardrive.ui import dp
 from piwardrive.utils import fetch_kismet_devices_async, get_avg_rssi, run_async_task
 
 from .base import DashboardWidget
@@ -23,8 +23,8 @@ class SignalStrengthWidget(DashboardWidget):
 
     def __init__(self, **kwargs: Any) -> None:
         super().__init__(**kwargs)
-        self.card = MDCard(orientation="vertical", padding=dp(8), radius=[8])
-        self.label = MDLabel(text=f"{_('rssi')}: {_('not_available')}", halign="center")
+        self.card = Card(orientation="vertical", padding=dp(8), radius=[8])
+        self.label = Label(text=f"{_('rssi')}: {_('not_available')}", halign="center")
         self.card.add_widget(self.label)
         self.add_widget(self.card)
         self.update()

--- a/src/piwardrive/widgets/storage_usage.py
+++ b/src/piwardrive/widgets/storage_usage.py
@@ -4,9 +4,9 @@ import logging
 from typing import Any
 
 from piwardrive.localization import _
-from piwardrive.simpleui import Card as MDCard
-from piwardrive.simpleui import Label as MDLabel
-from piwardrive.simpleui import dp
+from piwardrive.ui import Card
+from piwardrive.ui import Label
+from piwardrive.ui import dp
 from piwardrive.utils import get_disk_usage
 
 from .base import DashboardWidget
@@ -23,8 +23,8 @@ class StorageUsageWidget(DashboardWidget):
 
     def __init__(self, **kwargs: Any) -> None:
         super().__init__(**kwargs)
-        self.card = MDCard(orientation="vertical", padding=dp(8), radius=[8])
-        self.label = MDLabel(text=f"{_('ssd')}: {_('not_available')}", halign="center")
+        self.card = Card(orientation="vertical", padding=dp(8), radius=[8])
+        self.label = Label(text=f"{_('ssd')}: {_('not_available')}", halign="center")
         self.card.add_widget(self.label)
         self.add_widget(self.card)
         self.update()

--- a/src/piwardrive/widgets/vehicle_speed.py
+++ b/src/piwardrive/widgets/vehicle_speed.py
@@ -5,9 +5,9 @@ from typing import Any
 
 from piwardrive import vehicle_sensors
 from piwardrive.localization import _
-from piwardrive.simpleui import Card as MDCard
-from piwardrive.simpleui import Label as MDLabel
-from piwardrive.simpleui import dp
+from piwardrive.ui import Card
+from piwardrive.ui import Label
+from piwardrive.ui import dp
 
 from .base import DashboardWidget
 
@@ -23,8 +23,8 @@ class VehicleSpeedWidget(DashboardWidget):
 
     def __init__(self, **kwargs: Any) -> None:
         super().__init__(**kwargs)
-        self.card = MDCard(orientation="vertical", padding=dp(8), radius=[8])
-        self.label = MDLabel(
+        self.card = Card(orientation="vertical", padding=dp(8), radius=[8])
+        self.label = Label(
             text=f"{_('vehicle_speed')}: {_('not_available')}", halign="center"
         )
         self.card.add_widget(self.label)

--- a/tests/test_battery_widget.py
+++ b/tests/test_battery_widget.py
@@ -17,7 +17,7 @@ def _load_widget():
 def test_widget_updates(monkeypatch: Any) -> None:
     bs = _load_widget()
     widget = object.__new__(bs.BatteryStatusWidget)
-    widget.label = bs.MDLabel()  # type: ignore[attr-defined]
+    widget.label = bs.Label()  # type: ignore[attr-defined]
     monkeypatch.setattr(bs.psutil, "sensors_battery", lambda: DummyBattery(50, False))
     bs.BatteryStatusWidget.update(widget)
     assert "50" in widget.label.text

--- a/tests/test_db_stats_widget.py
+++ b/tests/test_db_stats_widget.py
@@ -12,7 +12,7 @@ def _load_widget():
 def test_widget_update(monkeypatch: Any) -> None:
     ds = _load_widget()
     widget = object.__new__(ds.DBStatsWidget)
-    widget.label = ds.MDLabel()  # type: ignore[attr-defined]
+    widget.label = ds.Label()  # type: ignore[attr-defined]
 
     monkeypatch.setattr(ds, "_db_path", lambda: "x.db")
     monkeypatch.setattr(ds.os.path, "getsize", lambda p: 2048)

--- a/tests/test_extra_widgets.py
+++ b/tests/test_extra_widgets.py
@@ -12,7 +12,7 @@ def _load_widgets():
 def test_orientation_widget(monkeypatch: Any) -> None:
     ow, _vs, _lw = _load_widgets()
     widget = object.__new__(ow.OrientationWidget)
-    widget.label = ow.MDLabel()  # type: ignore[attr-defined]
+    widget.label = ow.Label()  # type: ignore[attr-defined]
     monkeypatch.setattr(
         ow.orientation_sensors, "get_orientation_dbus", lambda: "right-up"
     )
@@ -24,7 +24,7 @@ def test_orientation_widget(monkeypatch: Any) -> None:
 def test_vehicle_speed_widget(monkeypatch: Any) -> None:
     _ow, vs, _lw = _load_widgets()
     widget = object.__new__(vs.VehicleSpeedWidget)
-    widget.label = vs.MDLabel()  # type: ignore[attr-defined]
+    widget.label = vs.Label()  # type: ignore[attr-defined]
     monkeypatch.setattr(vs.vehicle_sensors, "read_speed_obd", lambda port=None: 42.5)
     vs.VehicleSpeedWidget.update(widget)
     assert "42.5" in widget.label.text
@@ -33,7 +33,7 @@ def test_vehicle_speed_widget(monkeypatch: Any) -> None:
 def test_lora_scan_widget(monkeypatch: Any) -> None:
     _ow, _vs, lw = _load_widgets()
     widget = object.__new__(lw.LoRaScanWidget)
-    widget.label = lw.MDLabel()  # type: ignore[attr-defined]
+    widget.label = lw.Label()  # type: ignore[attr-defined]
     monkeypatch.setattr(
         lw.lora_scanner, "scan_lora", lambda interface="lora0": ["a", "b", "c"]
     )

--- a/tests/test_new_widgets.py
+++ b/tests/test_new_widgets.py
@@ -14,7 +14,7 @@ def _load():
 def test_gps_status_widget(monkeypatch):
     gs, _ss, _sig, _stg, _hs = _load()
     widget = object.__new__(gs.GPSStatusWidget)
-    widget.label = gs.MDLabel()  # type: ignore[attr-defined]
+    widget.label = gs.Label()  # type: ignore[attr-defined]
     monkeypatch.setattr(gs, "get_gps_fix_quality", lambda: "3D")
     gs.GPSStatusWidget.update(widget)
     assert "3D" in widget.label.text
@@ -23,7 +23,7 @@ def test_gps_status_widget(monkeypatch):
 def test_service_status_widget(monkeypatch):
     _gs, ss, _sig, _stg, _hs = _load()
     widget = object.__new__(ss.ServiceStatusWidget)
-    widget.label = ss.MDLabel()  # type: ignore[attr-defined]
+    widget.label = ss.Label()  # type: ignore[attr-defined]
     monkeypatch.setattr(ss, "service_status", lambda name: name == "kismet")
     ss.ServiceStatusWidget.update(widget)
     assert "ok" in widget.label.text and "down" in widget.label.text
@@ -32,7 +32,7 @@ def test_service_status_widget(monkeypatch):
 def test_handshake_counter_widget(monkeypatch):
     _gs, _ss, _sig, _stg, hs = _load()
     widget = object.__new__(hs.HandshakeCounterWidget)
-    widget.label = hs.MDLabel()  # type: ignore[attr-defined]
+    widget.label = hs.Label()  # type: ignore[attr-defined]
     monkeypatch.setattr(hs, "count_bettercap_handshakes", lambda: 7)
     hs.HandshakeCounterWidget.update(widget)
     assert "7" in widget.label.text
@@ -41,7 +41,7 @@ def test_handshake_counter_widget(monkeypatch):
 def test_storage_usage_widget(monkeypatch):
     _gs, _ss, _sig, stg, _hs = _load()
     widget = object.__new__(stg.StorageUsageWidget)
-    widget.label = stg.MDLabel()  # type: ignore[attr-defined]
+    widget.label = stg.Label()  # type: ignore[attr-defined]
     monkeypatch.setattr(stg, "get_disk_usage", lambda p: 55.0)
     stg.StorageUsageWidget.update(widget)
     assert "55" in widget.label.text
@@ -50,7 +50,7 @@ def test_storage_usage_widget(monkeypatch):
 def test_signal_strength_widget(monkeypatch):
     _gs, _ss, sig, _stg, _hs = _load()
     widget = object.__new__(sig.SignalStrengthWidget)
-    widget.label = sig.MDLabel()  # type: ignore[attr-defined]
+    widget.label = sig.Label()  # type: ignore[attr-defined]
 
     async def fake_fetch():
         return ([{}], [])

--- a/tests/test_robust_request.py
+++ b/tests/test_robust_request.py
@@ -35,7 +35,7 @@ def test_orientation_widget_update(monkeypatch):
     from piwardrive.widgets import orientation_widget as ow
 
     widget = object.__new__(ow.OrientationWidget)
-    widget.label = ow.MDLabel()
+    widget.label = ow.Label()
 
     monkeypatch.setattr(
         ow.orientation_sensors, "get_orientation_dbus", lambda: "right-up"


### PR DESCRIPTION
## Summary
- drop `simpleui` module that referenced Kivy
- introduce lightweight `ui` module
- update widgets and tests to import from new `ui` module

## Testing
- `pre-commit run --all-files` *(fails: ESLint config missing)*
- `pytest -q` *(fails: missing optional dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68630ca755248333a8f21ef603ef6f4d