### PR TITLE
Sanitize orientation map path

### DIFF
--- a/src/piwardrive/orientation_sensors.py
+++ b/src/piwardrive/orientation_sensors.py
@@ -76,18 +76,20 @@ def reset_orientation_map() -> None:
     if path:
         try:
             safe = sanitize_path(path)
-            with open(safe, "r", encoding="utf-8") as fh:
-                data = json.load(fh)
-            if isinstance(data, dict):
-                _ORIENTATION_MAP.update({k.lower(): float(v) for k, v in data.items()})
-                return
-            logger.error("Invalid orientation map in %s", path)
         except ValueError:
             logger.error("Unsafe orientation map path: %s", path)
-        except FileNotFoundError:
-            logger.error("Orientation map file not found: %s", path)
-        except Exception as exc:  # pragma: no cover - runtime errors
-            logger.error("Failed to load orientation map from %s: %s", path, exc)
+        else:
+            try:
+                with open(safe, "r", encoding="utf-8") as fh:
+                    data = json.load(fh)
+                if isinstance(data, dict):
+                    _ORIENTATION_MAP.update({k.lower(): float(v) for k, v in data.items()})
+                    return
+                logger.error("Invalid orientation map in %s", path)
+            except FileNotFoundError:
+                logger.error("Orientation map file not found: %s", path)
+            except Exception as exc:  # pragma: no cover - runtime errors
+                logger.error("Failed to load orientation map from %s: %s", path, exc)
 
     _ORIENTATION_MAP.update(DEFAULT_ORIENTATION_MAP)
 

--- a/tests/test_orientation_sensors_pkg.py
+++ b/tests/test_orientation_sensors_pkg.py
@@ -93,3 +93,17 @@ def test_read_mpu6050_env_pkg(monkeypatch):
     data = osens.read_mpu6050()
     monkeypatch.delenv("PW_MPU6050_ADDR", raising=False)
     assert data == {"accelerometer": {"addr": 105}, "gyroscope": {"addr": 105}}
+
+
+def test_reset_orientation_map_unsafe_pkg(monkeypatch, caplog) -> None:
+    monkeypatch.setenv("PW_ORIENTATION_MAP_FILE", "../omap.json")
+    osens.update_orientation_map({"flip": 45.0})
+    caplog.set_level(logging.ERROR)
+    try:
+        osens.reset_orientation_map()
+        assert "Unsafe orientation map path" in caplog.text
+        assert osens.orientation_to_angle("flip") is None
+        assert osens.orientation_to_angle("normal") == 0.0
+    finally:
+        monkeypatch.delenv("PW_ORIENTATION_MAP_FILE", raising=False)
+        osens.reset_orientation_map()


### PR DESCRIPTION
## Summary
- validate the `PW_ORIENTATION_MAP_FILE` env var with `sanitize_path`
- log errors and fall back to defaults on invalid paths
- test orientation map file sanitization for the package entry point

## Testing
- `pre-commit run --files src/piwardrive/orientation_sensors.py tests/test_orientation_sensors_pkg.py` *(fails: command not found)*
- `pytest -k reset_orientation_map_unsafe -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68631352554483338a2aefc4c2bd5475