### PR TITLE
Improve filename validation

### DIFF
--- a/src/piwardrive/aggregation_service.py
+++ b/src/piwardrive/aggregation_service.py
@@ -14,7 +14,7 @@ from fastapi import FastAPI, UploadFile, HTTPException
 
 from . import analysis, heatmap
 from .persistence import HealthRecord
-from .security import sanitize_filename
+from .security import validate_filename
 
 DATA_DIR = os.path.expanduser(os.getenv("PW_AGG_DIR", "~/piwardrive-aggregation"))
 DB_PATH = os.path.join(DATA_DIR, "aggregation.db")
@@ -99,8 +99,11 @@ async def _process_upload(path: str) -> None:
 async def upload(file: UploadFile) -> Dict[str, str]:  # noqa: V103 - FastAPI route
     """Save ``file`` and merge its contents into the aggregation database."""
     # Called by FastAPI as a route handler.
+    name = os.path.basename(file.filename)
+    if name != file.filename:
+        raise HTTPException(status_code=400, detail=f"Invalid filename: {file.filename}")
     try:
-        name = sanitize_filename(file.filename)
+        validate_filename(name)
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc))
     dest = os.path.join(UPLOAD_DIR, name)

--- a/sync_receiver.py
+++ b/sync_receiver.py
@@ -3,7 +3,7 @@ import shutil
 
 from fastapi import FastAPI, UploadFile, HTTPException
 
-from piwardrive.security import sanitize_filename
+from piwardrive.security import validate_filename
 
 app = FastAPI()
 STORAGE = os.path.expanduser("~/piwardrive-sync")
@@ -12,8 +12,11 @@ os.makedirs(STORAGE, exist_ok=True)
 
 @app.post("/")
 async def receive(file: UploadFile):
+    name = os.path.basename(file.filename)
+    if name != file.filename:
+        raise HTTPException(status_code=400, detail=f"Invalid filename: {file.filename}")
     try:
-        name = sanitize_filename(file.filename)
+        validate_filename(name)
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc))
     dest = os.path.join(STORAGE, name)

--- a/tests/test_aggregation_service.py
+++ b/tests/test_aggregation_service.py
@@ -98,3 +98,16 @@ def test_upload_rejects_nested_traversal(tmp_path):
     with open(db_path, "rb") as fh:
         resp = client.post("/upload", files={"file": ("../../etc/passwd", fh)})
     assert resp.status_code == 400
+
+
+def test_upload_rejects_evil_db(tmp_path):
+    os.environ["PW_AGG_DIR"] = str(tmp_path)
+    module = importlib.import_module("piwardrive.aggregation_service")
+    importlib.reload(module)
+    db_path = tmp_path / "upload.db"
+    _create_src_db(str(db_path))
+
+    client = TestClient(module.app)
+    with open(db_path, "rb") as fh:
+        resp = client.post("/upload", files={"file": ("../evil.db", fh)})
+    assert resp.status_code == 400

--- a/tests/test_sync_receiver.py
+++ b/tests/test_sync_receiver.py
@@ -30,3 +30,10 @@ def test_rejects_nested_traversal(tmp_path, monkeypatch):
     client = TestClient(receiver.app)
     resp = client.post("/", files={"file": ("../../etc/passwd", b"data")})
     assert resp.status_code == 400
+
+
+def test_rejects_evil_db(tmp_path, monkeypatch):
+    receiver = _load_receiver(tmp_path, monkeypatch)
+    client = TestClient(receiver.app)
+    resp = client.post("/", files={"file": ("../evil.db", b"data")})
+    assert resp.status_code == 400


### PR DESCRIPTION
## Summary
- validate filenames using `os.path.basename` and `validate_filename`
- apply safe naming in sync receiver and aggregation service
- test that attempts at uploading `../evil.db` are rejected

## Testing
- `pytest tests/test_sync_receiver.py tests/test_aggregation_service.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686313503c3083338e23d306c8c87c45