### PR TITLE
Remove duplicate scan_rules declaration

### DIFF
--- a/src/piwardrive/core/config.py
+++ b/src/piwardrive/core/config.py
@@ -1,8 +1,8 @@
 """Application configuration helpers with env overrides and validation."""
 
+import dataclasses
 import json
 import os
-import dataclasses
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -10,7 +10,6 @@ from typing import Any, Dict, List, Optional
 from pydantic import BaseModel, Field, ValidationError
 
 from ..errors import ConfigError
-
 
 CONFIG_DIR = str(Path.home() / ".config" / "piwardrive")
 CONFIG_PATH = str(Path(CONFIG_DIR) / "config.json")
@@ -58,7 +57,6 @@ def config_mtime(profile: Optional[str] = None) -> Optional[float]:  # noqa: V10
 @dataclass
 class Config:
     """Persistent application configuration."""
-
 
     map_poll_aps: int = 60  # noqa: V107
     map_poll_bt: int = 60  # noqa: V107
@@ -259,7 +257,6 @@ class ConfigModel(FileConfigModel):
     mysql_db: str = DEFAULTS["mysql_db"]
     enable_graphql: bool = DEFAULTS["enable_graphql"]
     enable_mqtt: bool = DEFAULTS["enable_mqtt"]
-    scan_rules: Dict[str, Any] = Field(default_factory=dict)
     influx_url: str = DEFAULTS["influx_url"]
     influx_token: str = DEFAULTS["influx_token"]
     influx_org: str = DEFAULTS["influx_org"]
@@ -416,6 +413,7 @@ def import_config(path: str) -> Config:
 @dataclass
 class AppConfig:
     """Typed configuration container."""
+
     map_poll_aps: int = DEFAULTS["map_poll_aps"]
     map_poll_bt: int = DEFAULTS["map_poll_bt"]
     map_poll_wigle: int = DEFAULTS["map_poll_wigle"]


### PR DESCRIPTION
## Summary
- drop redundant scan_rules field from `ConfigModel`
- apply formatting via pre-commit hooks

## Testing
- `pre-commit run --files src/piwardrive/core/config.py` *(fails: ESLint config missing)*
- `pytest -q tests/test_config.py` *(fails: ModuleNotFoundError: pydantic)*

------
https://chatgpt.com/codex/tasks/task_e_686313543a748333ac64bc8c47c6bab8