### PR TITLE
Add ARIMA CPU temp forecasting

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,12 @@ Schedulers expose basic metrics via `get_metrics()` including the next
 scheduled run time and duration of the last callback execution. These values
 aid troubleshooting periodic jobs during development.
 
+## Advanced Analytics
+
+Health metrics can be analyzed beyond simple averages. The `health_stats`
+script accepts a `--forecast N` option to predict CPU temperature for the next
+`N` intervals using an ARIMA or Prophet model.
+
 ## Quick Start
 
 ### Hardware

--- a/scripts/health_stats.py
+++ b/scripts/health_stats.py
@@ -11,6 +11,7 @@ except Exception:  # pragma: no cover - fall back if tests replaced module
     from piwardrive.persistence import load_recent_health
 
 from piwardrive.analysis import compute_health_stats
+from piwardrive.analytics import forecast_cpu_temp
 from piwardrive.logconfig import setup_logging
 
 
@@ -28,12 +29,22 @@ def main(argv: list[str] | None = None) -> None:
         default=10,
         help="number of records to analyze",
     )
+    parser.add_argument(
+        "--forecast",
+        type=int,
+        metavar="N",
+        help="forecast CPU temp N steps ahead",
+    )
     args = parser.parse_args(argv)
 
     setup_logging(stdout=True)
     records = asyncio.run(_load_records(args.limit))
     stats = compute_health_stats(records)
     logging.info(json.dumps(stats))
+
+    if args.forecast:
+        pred = forecast_cpu_temp(records, args.forecast)
+        logging.info(json.dumps({"forecast": pred}))
 
 
 if __name__ == "__main__":  # pragma: no cover - manual invocation

--- a/src/piwardrive/analytics/__init__.py
+++ b/src/piwardrive/analytics/__init__.py
@@ -1,6 +1,7 @@
 """Analytics utilities."""
 
 from .clustering import cluster_positions
+from .forecasting import forecast_cpu_temp
 
-__all__ = ["cluster_positions"]
+__all__ = ["cluster_positions", "forecast_cpu_temp"]
 

--- a/src/piwardrive/analytics/forecasting.py
+++ b/src/piwardrive/analytics/forecasting.py
@@ -1,0 +1,59 @@
+"""Forecast system health metrics using ARIMA or Prophet."""
+
+from __future__ import annotations
+
+from typing import Iterable, List
+
+import numpy as np
+
+from ..persistence import HealthRecord
+
+__all__ = ["forecast_cpu_temp"]
+
+
+def _arima_forecast(values: list[float], steps: int) -> list[float]:
+    from statsmodels.tsa.arima.model import ARIMA
+
+    arr = np.array(values, dtype=float)
+    model = ARIMA(arr, order=(1, 1, 1))
+    fitted = model.fit()
+    forecast = fitted.forecast(steps=steps)
+    return [float(x) for x in forecast]
+
+
+def _prophet_forecast(values: list[float], steps: int) -> list[float]:
+    from prophet import Prophet  # type: ignore
+    import pandas as pd
+
+    df = pd.DataFrame({"ds": range(len(values)), "y": values})
+    model = Prophet()
+    model.fit(df)
+    future = model.make_future_dataframe(periods=steps, freq="S")
+    forecast = model.predict(future)
+    return [float(x) for x in forecast["yhat"].tail(steps)]
+
+
+def forecast_cpu_temp(records: Iterable[HealthRecord], steps: int) -> List[float]:
+    """Predict CPU temperature for upcoming intervals.
+
+    Parameters
+    ----------
+    records:
+        Historical :class:`HealthRecord` samples.
+    steps:
+        Number of future time steps to forecast.
+
+    Returns
+    -------
+    list[float]
+        Predicted CPU temperatures for each step.
+    """
+
+    temps = [r.cpu_temp for r in records if r.cpu_temp is not None]
+    if not temps:
+        return [float("nan")] * steps
+
+    try:
+        return _prophet_forecast(temps, steps)
+    except Exception:  # pragma: no cover - optional dependency
+        return _arima_forecast(temps, steps)

--- a/tests/test_forecasting.py
+++ b/tests/test_forecasting.py
@@ -1,0 +1,16 @@
+import numpy as np
+
+from piwardrive.analytics.forecasting import forecast_cpu_temp
+from piwardrive.persistence import HealthRecord
+
+
+def test_forecast_cpu_temp_deterministic():
+    recs = [HealthRecord(str(i), 40.0 + i, 0.0, 0.0, 0.0) for i in range(10)]
+    np.random.seed(0)
+    a = forecast_cpu_temp(recs, 3)
+    np.random.seed(0)
+    b = forecast_cpu_temp(recs, 3)
+    assert isinstance(a, list)
+    assert len(a) == 3
+    assert a == b
+

--- a/tests/test_health_stats_script.py
+++ b/tests/test_health_stats_script.py
@@ -13,7 +13,9 @@ def test_health_stats_script_output(monkeypatch, capsys):
         return records
 
     monkeypatch.setattr(hs, "load_recent_health", fake_load)
-    hs.main(["--limit", "5"])
+    monkeypatch.setattr(hs, "forecast_cpu_temp", lambda r, s: [1.0] * s)
+    hs.main(["--limit", "5", "--forecast", "2"])
     out_lines = [json.loads(l) for l in capsys.readouterr().out.strip().splitlines() if l]
     expected = {"temp_avg": 50.0, "cpu_avg": 20.0, "mem_avg": 30.0, "disk_avg": 40.0}
-    assert out_lines[-1]["message"] == json.dumps(expected)
+    assert out_lines[0]["message"] == json.dumps(expected)
+    assert out_lines[1]["message"] == json.dumps({"forecast": [1.0, 1.0]})


### PR DESCRIPTION
## Summary
- add ARIMA/Prophet-based temperature forecasting
- expose `forecast_cpu_temp` from analytics
- allow `--forecast` in `health_stats` script
- document forecasting feature
- test forecasting utilities

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sklearn')*

------
https://chatgpt.com/codex/tasks/task_e_6863170327608333a8b2ddd3a844d301