### PR TITLE
Add custom Swagger docs and Wi-Fi API

### DIFF
--- a/docs/examples/api_responses.json
+++ b/docs/examples/api_responses.json
@@ -1,0 +1,16 @@
+{
+  "scanResponse": {
+    "access_points": [
+      {
+        "ssid": "ExampleNet",
+        "bssid": "AA:BB:CC:DD:EE:FF",
+        "frequency": "2.437",
+        "channel": "6",
+        "quality": "70/100",
+        "encryption": "WPA2",
+        "vendor": "RaspberryPi",
+        "heading": 180.0
+      }
+    ]
+  }
+}

--- a/docs/examples/curl_examples.sh
+++ b/docs/examples/curl_examples.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Basic cURL examples for PiWardrive API
+
+# Unauthenticated Wi-Fi scan
+curl -X GET "http://127.0.0.1:8000/wifi/scan?interface=wlan0" -H "Accept: application/json"
+
+# Wi-Fi scan with POST and bearer token
+TOKEN="<your token>"
+curl -X POST "http://127.0.0.1:8000/wifi/scan" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"interface": "wlan0"}'

--- a/docs/examples/javascript_examples.js
+++ b/docs/examples/javascript_examples.js
@@ -1,0 +1,11 @@
+// Example JavaScript (browser/React) client for the PiWardrive API
+import axios from "axios";
+
+export async function scanWifi(token) {
+  const headers = token ? { Authorization: `Bearer ${token}` } : {};
+  const res = await axios.get("/wifi/scan", {
+    params: { interface: "wlan0" },
+    headers,
+  });
+  return res.data.access_points;
+}

--- a/docs/examples/python_examples.py
+++ b/docs/examples/python_examples.py
@@ -1,0 +1,26 @@
+"""Example Python client for the PiWardrive API."""
+
+from __future__ import annotations
+
+import requests
+
+BASE_URL = "http://127.0.0.1:8000"
+
+
+def scan_wifi(token: str | None = None) -> None:
+    """Run a Wi-Fi scan and print access points."""
+    headers = {"Authorization": f"Bearer {token}"} if token else {}
+    resp = requests.post(
+        f"{BASE_URL}/wifi/scan",
+        json={"interface": "wlan0"},
+        headers=headers,
+        timeout=15,
+    )
+    resp.raise_for_status()
+    data = resp.json()
+    for ap in data.get("access_points", []):
+        print(ap.get("ssid"), ap.get("bssid"))
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    scan_wifi()

--- a/src/piwardrive/models/__init__.py
+++ b/src/piwardrive/models/__init__.py
@@ -1,0 +1,17 @@
+"""API request and response models used by route handlers."""
+
+from .api_models import (
+    AccessPoint,
+    ErrorResponse,
+    SystemStats,
+    WiFiScanRequest,
+    WiFiScanResponse,
+)
+
+__all__ = [
+    "AccessPoint",
+    "ErrorResponse",
+    "SystemStats",
+    "WiFiScanRequest",
+    "WiFiScanResponse",
+]

--- a/src/piwardrive/models/api_models.py
+++ b/src/piwardrive/models/api_models.py
@@ -1,0 +1,107 @@
+"""Pydantic models for PiWardrive API."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class WiFiScanRequest(BaseModel):
+    """Parameters for initiating a Wi-Fi scan."""
+
+    interface: str = Field(
+        "wlan0",
+        description="Wireless interface used for scanning",
+        examples=["wlan0"],
+    )
+    timeout: int | None = Field(
+        None,
+        description="Optional timeout in seconds for the scan process",
+        examples=[10],
+    )
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class AccessPoint(BaseModel):
+    """Information about a discovered Wi-Fi access point."""
+
+    ssid: str | None = Field(None, description="Network SSID")
+    bssid: str | None = Field(None, description="Access point MAC address")
+    frequency: str | None = Field(None, description="Frequency in GHz")
+    channel: str | None = Field(None, description="Wi-Fi channel")
+    quality: str | None = Field(None, description="Signal quality")
+    encryption: str | None = Field(None, description="Encryption protocol")
+    vendor: str | None = Field(None, description="Vendor based on BSSID prefix")
+    heading: float | None = Field(None, description="Heading in degrees at scan time")
+
+    model_config = ConfigDict(
+        from_attributes=True,
+        json_schema_extra={
+            "example": {
+                "ssid": "ExampleNet",
+                "bssid": "AA:BB:CC:DD:EE:FF",
+                "frequency": "2.437",
+                "channel": "6",
+                "quality": "70/100",
+                "encryption": "WPA2",
+                "vendor": "RaspberryPi",
+                "heading": 180.0,
+            }
+        },
+    )
+
+
+class WiFiScanResponse(BaseModel):
+    """Wi-Fi scan result."""
+
+    access_points: list[AccessPoint] = Field(
+        default_factory=list,
+        description="List of discovered access points",
+    )
+
+    model_config = ConfigDict(
+        from_attributes=True,
+        json_schema_extra={
+            "example": {
+                "access_points": [
+                    AccessPoint.model_config["json_schema_extra"]["example"]
+                ]
+            }
+        },
+    )
+
+
+class SystemStats(BaseModel):
+    """System resource utilization metrics."""
+
+    cpu_percent: float = Field(..., description="CPU usage percentage")
+    memory_percent: float = Field(..., description="Memory usage percentage")
+    disk_percent: float = Field(..., description="Disk usage percentage")
+    temp_celsius: float | None = Field(
+        None,
+        description="Current CPU temperature in Celsius",
+    )
+
+    model_config = ConfigDict(
+        from_attributes=True,
+        json_schema_extra={
+            "example": {
+                "cpu_percent": 12.5,
+                "memory_percent": 45.2,
+                "disk_percent": 70.1,
+                "temp_celsius": 52.3,
+            }
+        },
+    )
+
+
+class ErrorResponse(BaseModel):
+    """Standard error response model."""
+
+    code: str = Field(..., description="Error code as string", examples=["404"])
+    message: str = Field(..., description="Human readable error message")
+
+    model_config = ConfigDict(
+        from_attributes=True,
+        json_schema_extra={"example": {"code": "404", "message": "Not found"}},
+    )

--- a/src/piwardrive/routes/wifi.py
+++ b/src/piwardrive/routes/wifi.py
@@ -1,0 +1,47 @@
+"""Wi-Fi scanning API routes."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+
+from piwardrive import service
+from piwardrive.models import (
+    AccessPoint,
+    ErrorResponse,
+    WiFiScanRequest,
+    WiFiScanResponse,
+)
+from piwardrive.sigint_suite.wifi.scanner import async_scan_wifi
+
+router = APIRouter(prefix="/wifi", tags=["wifi"])
+
+
+@router.get(
+    "/scan",
+    response_model=WiFiScanResponse,
+    responses={401: {"model": ErrorResponse}},
+)
+async def scan_wifi_get(
+    interface: str = "wlan0",
+    timeout: int | None = None,
+    _auth: None = Depends(service._check_auth),
+) -> WiFiScanResponse:
+    """Perform a Wi-Fi scan and return discovered access points."""
+    nets = await async_scan_wifi(interface=interface, timeout=timeout)
+    aps = [AccessPoint.model_validate(n.model_dump()) for n in nets]
+    return WiFiScanResponse(access_points=aps)
+
+
+@router.post(
+    "/scan",
+    response_model=WiFiScanResponse,
+    responses={401: {"model": ErrorResponse}},
+)
+async def scan_wifi_post(
+    req: WiFiScanRequest,
+    _auth: None = Depends(service._check_auth),
+) -> WiFiScanResponse:
+    """Perform a Wi-Fi scan using parameters in the request body."""
+    nets = await async_scan_wifi(interface=req.interface, timeout=req.timeout)
+    aps = [AccessPoint.model_validate(n.model_dump()) for n in nets]
+    return WiFiScanResponse(access_points=aps)

--- a/static/swagger-config.js
+++ b/static/swagger-config.js
@@ -1,0 +1,11 @@
+window.onload = () => {
+  window.ui = SwaggerUIBundle({
+    url: "/openapi.json",
+    dom_id: "#swagger-ui",
+    presets: [SwaggerUIBundle.presets.apis, SwaggerUIStandalonePreset],
+    layout: "BaseLayout",
+    docExpansion: "none",
+    validatorUrl: null,
+    oauth2RedirectUrl: window.location.origin + "/docs/oauth2-redirect",
+  });
+};

--- a/templates/api-docs.html
+++ b/templates/api-docs.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>PiWardrive API</title>
+    <link
+      rel="stylesheet"
+      href="https://unpkg.com/swagger-ui-dist@5/swagger-ui.css"
+    />
+    <style>
+      body {
+        margin: 0;
+        background: #fafafa;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="swagger-ui"></div>
+    <script src="https://unpkg.com/swagger-ui-dist@5/swagger-ui-bundle.js"></script>
+    <script src="https://unpkg.com/swagger-ui-dist@5/swagger-ui-standalone-preset.js"></script>
+    <script src="/static/swagger-config.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- configure custom OpenAPI in `service.py`
- define pydantic request/response models
- add Wi‑Fi scan router with secured endpoints
- create Swagger UI template and config
- provide usage examples in docs

## Testing
- `pre-commit run --files src/piwardrive/service.py src/piwardrive/routes/wifi.py src/piwardrive/models/api_models.py src/piwardrive/models/__init__.py templates/api-docs.html static/swagger-config.js docs/examples/python_examples.py docs/examples/javascript_examples.js docs/examples/curl_examples.sh docs/examples/api_responses.json` *(fails: ESLint couldn't find configuration)*
- `pytest -q` *(fails: 46 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_686338e1e4808333b0bc98fa2f8684ae