### PR TITLE
Fix imports for tests

### DIFF
--- a/src/piwardrive/scheduler.py
+++ b/src/piwardrive/scheduler.py
@@ -129,7 +129,11 @@ class PollScheduler:
 
         self._next_runs[name] = time.time() + interval
         self._durations[name] = float("nan")
-        self._tasks[name] = asyncio.create_task(_runner())
+        try:
+            self._tasks[name] = asyncio.create_task(_runner())
+        except RuntimeError:
+            utils.run_async_task(_runner())
+            self._tasks[name] = None
 
     # ------------------------------------------------------------------
     # Widget helpers

--- a/src/piwardrive/service.py
+++ b/src/piwardrive/service.py
@@ -562,10 +562,7 @@ def WEBSOCKET(*args: typing.Any, **kwargs: typing.Any) -> typing.Callable[[F], F
     return _wrap_route(app.websocket, *args, **kwargs)
 
 
-# Include route modules
-from piwardrive.routes import wifi as wifi_routes
 
-app.include_router(wifi_routes.router)
 
 
 # Allowed log file paths for the /logs endpoint
@@ -641,6 +638,9 @@ async def token_login(
 
 
 AUTH_DEP = Depends(_check_auth)
+
+from piwardrive.routes import wifi as wifi_routes
+app.include_router(wifi_routes.router)
 
 
 @POST("/auth/login")

--- a/src/piwardrive/utils.py
+++ b/src/piwardrive/utils.py
@@ -74,6 +74,18 @@ except Exception:
         ) -> float | None:  # type: ignore[misc]
             return None
 
+        def haversine_distance(
+            _p1: tuple[float, float], _p2: tuple[float, float]
+        ) -> float:
+            return 0.0
+
+        def tail_file(path: str, lines: int = 50) -> list[str]:
+            try:
+                with open(path, "r", encoding="utf-8", errors="ignore") as f:
+                    return f.read().splitlines()[-lines:]
+            except Exception:
+                return []
+
         __all__ += [
             "MetricsResult",
             "get_gps_fix_quality",
@@ -83,6 +95,8 @@ except Exception:
             "fetch_kismet_devices_async",
             "run_async_task",
             "get_avg_rssi",
+            "haversine_distance",
+            "tail_file",
         ]
 
 


### PR DESCRIPTION
## Summary
- patch scheduler fallback when async loop isn't running
- expose more util stubs for tests
- defer wifi route import until after auth dependency is defined

## Testing
- `pytest --maxfail=1 -q`

------
https://chatgpt.com/codex/tasks/task_e_686423fbb42c83339feb3bb77b71d907