### PR TITLE
Implement python GPS handler

### DIFF
--- a/src/gps_handler.py
+++ b/src/gps_handler.py
@@ -1,0 +1,129 @@
+"""High level GPS helper using ``python-gps``.
+
+This module wraps the :mod:`gps` package to obtain the current GPS fix from
+``gpsd``.  It provides convenience methods mirroring
+:mod:`piwardrive.gpsd_client` but uses the official ``python-gps`` bindings.
+
+Functions automatically reconnect on failure and gracefully handle timeouts so
+callers do not block indefinitely when no GPS data is available.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from typing import Any
+
+try:  # pragma: no cover - optional dependency may be missing
+    from gps import gps, WATCH_ENABLE, WATCH_NEWSTYLE
+except Exception as exc:  # pragma: no cover - missing dependency
+    gps = None
+    WATCH_ENABLE = WATCH_NEWSTYLE = 0  # type: ignore[assignment]
+    logging.getLogger(__name__).error("python-gps not available: %s", exc)
+
+logger = logging.getLogger(__name__)
+
+
+class GPSHandler:
+    """Simple wrapper around :mod:`gps` providing timeout handling."""
+
+    def __init__(self, host: str | None = None, port: int | None = None, *, timeout: float = 1.0) -> None:
+        self.host = host or os.getenv("PW_GPSD_HOST", "127.0.0.1")
+        self.port = port or int(os.getenv("PW_GPSD_PORT", 2947))
+        self.timeout = timeout
+        self._session: Any | None = None
+        self._connected = False
+
+    # Internal helpers -------------------------------------------------
+    def _connect(self) -> None:
+        if gps is None:
+            return
+        try:
+            self._session = gps(host=self.host, port=self.port)
+            self._session.stream(WATCH_ENABLE | WATCH_NEWSTYLE)
+            self._connected = True
+        except Exception as exc:  # pragma: no cover - connection errors
+            logger.error("GPS connect failed: %s", exc)
+            self._connected = False
+            self._session = None
+
+    def _ensure_connection(self) -> None:
+        if not self._connected:
+            self._connect()
+
+    def _get_report(self, timeout: float | None = None) -> Any | None:
+        """Return the latest TPV report or ``None`` on timeout/error."""
+
+        self._ensure_connection()
+        if not self._connected or self._session is None:
+            return None
+        to = self.timeout if timeout is None else timeout
+        try:
+            if not self._session.waiting(to):
+                logger.warning("GPS timeout after %.1fs", to)
+                return None
+            return self._session.next()
+        except StopIteration:  # pragma: no cover - no data available
+            logger.warning("GPS timed out")
+            return None
+        except Exception as exc:  # pragma: no cover - runtime errors
+            logger.error("GPS read failed: %s", exc)
+            self._connected = False
+            self._session = None
+            return None
+
+    # Public API -------------------------------------------------------
+    def get_position(self, timeout: float | None = None) -> tuple[float, float] | None:
+        report = self._get_report(timeout)
+        if not report or getattr(report, "class", None) != "TPV":
+            return None
+        lat = getattr(report, "lat", None)
+        lon = getattr(report, "lon", None)
+        if lat is None or lon is None:
+            return None
+        try:
+            return float(lat), float(lon)
+        except Exception:
+            return None
+
+    def get_accuracy(self, timeout: float | None = None) -> float | None:
+        report = self._get_report(timeout)
+        if not report or getattr(report, "class", None) != "TPV":
+            return None
+        epx = getattr(report, "epx", None)
+        epy = getattr(report, "epy", None)
+        if epx is None or epy is None:
+            return None
+        try:
+            return float(max(epx, epy))
+        except Exception:
+            return None
+
+    def get_fix_quality(self, timeout: float | None = None) -> str:
+        report = self._get_report(timeout)
+        if not report or getattr(report, "class", None) != "TPV":
+            return "Unknown"
+        mode_map = {1: "No Fix", 2: "2D", 3: "3D", 4: "DGPS"}
+        try:
+            mode = getattr(report, "mode", None)
+            if isinstance(mode, int):
+                return mode_map.get(mode, str(mode))
+        except Exception:
+            pass
+        return "Unknown"
+
+    def close(self) -> None:
+        session = self._session
+        self._session = None
+        self._connected = False
+        if session is not None:
+            try:
+                session.close()
+            except Exception:  # pragma: no cover - close errors
+                pass
+
+
+handler = GPSHandler()
+
+__all__ = ["GPSHandler", "handler"]

--- a/tests/test_gps_handler.py
+++ b/tests/test_gps_handler.py
@@ -1,0 +1,61 @@
+import importlib
+import sys
+import types
+
+import gps_handler
+
+
+def _reload_with_dummy(monkeypatch, gps_cls):
+    dummy_mod = types.SimpleNamespace(gps=gps_cls, WATCH_ENABLE=1, WATCH_NEWSTYLE=2)
+    monkeypatch.setitem(sys.modules, "gps", dummy_mod)
+    return importlib.reload(gps_handler)
+
+
+class _DummyBase:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def stream(self, flags):
+        pass
+
+    def close(self):
+        pass
+
+
+def test_position_none_on_connect_failure(monkeypatch):
+    class Dummy(_DummyBase):
+        def __init__(self, *args, **kwargs):
+            raise OSError("fail")
+
+    mod = _reload_with_dummy(monkeypatch, Dummy)
+    assert mod.handler.get_position() is None
+
+
+def test_timeout_returns_none(monkeypatch):
+    class Dummy(_DummyBase):
+        def waiting(self, timeout=0):
+            return False
+
+        def next(self):  # pragma: no cover - not called
+            return {}
+
+    mod = _reload_with_dummy(monkeypatch, Dummy)
+    assert mod.handler.get_position(timeout=0.1) is None
+
+
+def test_reconnect_after_error(monkeypatch):
+    packet = types.SimpleNamespace(class_="TPV", lat=1.0, lon=2.0, epx=1.0, epy=1.0, mode=3)
+    calls = [True, False]
+
+    class Dummy(_DummyBase):
+        def waiting(self, timeout=0):
+            return True
+
+        def next(self):
+            if calls.pop(0):
+                raise RuntimeError("boom")
+            return packet
+
+    mod = _reload_with_dummy(monkeypatch, Dummy)
+    assert mod.handler.get_position() is None
+    assert mod.handler.get_position() == (1.0, 2.0)


### PR DESCRIPTION
## Summary
- add GPS handler using python-gps with timeout handling
- provide unit tests for new gps_handler
- ensure `gps` dependency already listed in requirements

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6866e217e8d48333936c12bd67d21098