### PR TITLE
Add database export CLI

### DIFF
--- a/scripts/export_db.py
+++ b/scripts/export_db.py
@@ -1,0 +1,34 @@
+"""Export Wi-Fi data from the PiWardrive database."""
+
+import argparse
+import asyncio
+import logging
+
+from piwardrive.logconfig import setup_logging
+
+from pwutils import database
+
+EXPORT_FORMATS = ("csv", "json", "gpx", "kml")
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Export access point cache to a file."""
+    parser = argparse.ArgumentParser(description="Export database records")
+    parser.add_argument("output", help="destination file")
+    parser.add_argument(
+        "--format",
+        "-f",
+        choices=EXPORT_FORMATS,
+        default="csv",
+        help="output format",
+    )
+    parser.add_argument("--fields", nargs="+", help="subset of fields to include")
+    args = parser.parse_args(argv)
+
+    setup_logging(stdout=True)
+    asyncio.run(database.export_ap_cache(args.output, args.format, args.fields))
+    logging.info("Saved %s", args.output)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation
+    main()

--- a/src/pwutils/database.py
+++ b/src/pwutils/database.py
@@ -1,0 +1,17 @@
+"""Database export utilities."""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+from piwardrive import export, persistence
+
+
+async def export_ap_cache(
+    path: str,
+    fmt: str,
+    fields: Sequence[str] | None = None,
+) -> None:
+    """Export Wi-Fi observations to ``path`` using ``fmt``."""
+    records = await persistence.load_ap_cache()
+    export.export_records(records, path, fmt, fields)

--- a/tests/test_export_db_script.py
+++ b/tests/test_export_db_script.py
@@ -1,0 +1,27 @@
+import json
+import sys
+
+import pytest
+
+
+@pytest.mark.parametrize("fmt,check", [
+    ("csv", lambda p: "ssid" in p.read_text()),
+    ("json", lambda p: json.loads(p.read_text())[0]["ssid"] == "A"),
+    ("gpx", lambda p: "<wpt" in p.read_text()),
+    ("kml", lambda p: "<Placemark>" in p.read_text()),
+])
+def test_export_db_script(monkeypatch, tmp_path, fmt, check):
+    records = [{"ssid": "A", "bssid": "AA", "lat": 1.0, "lon": 2.0}]
+
+    async def fake_load_ap_cache():
+        return records
+
+    if "piwardrive.scripts.export_db" in sys.modules:
+        del sys.modules["piwardrive.scripts.export_db"]
+    import piwardrive.scripts.export_db as ed
+
+    monkeypatch.setattr(ed.database.persistence, "load_ap_cache", fake_load_ap_cache)
+
+    out = tmp_path / f"data.{fmt}"
+    ed.main([str(out), "--format", fmt])
+    assert check(out)


### PR DESCRIPTION
## Summary
- add database export utility in `pwutils`
- create CLI script `export_db.py`
- test exporting in CSV, JSON, GPX and KML formats

## Testing
- `pytest tests/test_export_db_script.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6866e223ca3083339c1cd2b5c413569f