### PR TITLE
Add python-gps requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -33,6 +33,7 @@ watchdog==6.0.0
 ## pybluez>=0.23
 ## Re-enable this after testing is done. It is breaking the environment
 gps==3.19
+python-gps
 orjson==3.10.18
 pandas==2.3.0
 pyprof2calltree==1.4.5


### PR DESCRIPTION
## Summary
- include python-gps in `requirements.txt`
- ensure package imports compile and `pip check` passes

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip check`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6866e26dfc28833399f5c3530aabca27