### PR TITLE
Enhance API security

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -948,6 +948,14 @@ proxy_pass http://localhost:8080;
 proxy_set_header X-Forwarded-Proto https;
 }
 }
+
+### Security Headers
+
+The API enforces CORS based on the ``PW_CORS_ORIGINS`` environment variable.
+All responses include a configurable ``Content-Security-Policy`` header and
+rate limiting metadata. Set ``PW_CONTENT_SECURITY_POLICY`` to customize the
+CSP value. Use ``PIWARDRIVE_RATE_LIMIT_REQUESTS`` and
+``PIWARDRIVE_RATE_LIMIT_WINDOW`` to tune rate limits.
 ```
 
 ### Input Validation

--- a/docs/environment.rst
+++ b/docs/environment.rst
@@ -90,6 +90,15 @@ General
 ``PW_CORS_ORIGINS``
     Comma-separated origins allowed by CORS.
 
+``PW_CONTENT_SECURITY_POLICY``
+    Value for the ``Content-Security-Policy`` response header.
+
+``PIWARDRIVE_RATE_LIMIT_REQUESTS``
+    Requests allowed per ``PIWARDRIVE_RATE_LIMIT_WINDOW`` seconds.
+
+``PIWARDRIVE_RATE_LIMIT_WINDOW``
+    Time window in seconds for rate limiting.
+
 ``PW_DB_KEY``
     Passphrase for optional SQLCipher database encryption.
 


### PR DESCRIPTION
## Summary
- enforce Content-Security-Policy and add simple rate limiting
- document environment variables for security headers and limits

## Testing
- `pytest tests/test_security_headers.py` *(fails: ModuleNotFoundError: No module named 'graphene')*

------
https://chatgpt.com/codex/tasks/task_e_6866e2a3bedc8333be747096899d757e