### PR TITLE
Add formatting configs and cleanup import

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+
+[*.py]
+indent_size = 4
+
+[*.{js,jsx,ts,tsx}]
+indent_size = 2
+

--- a/src/piwardrive/integrations/sigint_suite/cellular/imsi_catcher/scanner.py
+++ b/src/piwardrive/integrations/sigint_suite/cellular/imsi_catcher/scanner.py
@@ -2,7 +2,6 @@
 
 import asyncio
 import logging
-import os
 import subprocess
 from typing import Any, Callable, List, Optional, cast
 

--- a/webui/.eslintrc.cjs
+++ b/webui/.eslintrc.cjs
@@ -1,0 +1,18 @@
+module.exports = {
+    root: true,
+    env: {
+        browser: true,
+        es2021: true,
+    },
+    parserOptions: {
+        ecmaVersion: 'latest',
+        sourceType: 'module',
+        ecmaFeatures: {
+            jsx: true,
+        },
+    },
+    extends: [
+        'eslint:recommended',
+        'plugin:react/recommended',
+    ],
+};


### PR DESCRIPTION
## Summary
- add `.editorconfig` for editor standardization
- configure ESLint via `.eslintrc.cjs`
- remove unused import in IMSI scanner

## Testing
- `pytest -q` *(fails: 48 errors during collection)*
- `flake8`

------
https://chatgpt.com/codex/tasks/task_e_6866e2c684dc83339eadc1ddbff850e6