### PR TITLE
Add Redis caching support

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -137,7 +137,7 @@ services:
 
 | Variable | Type | Default | Description |
 |----------|------|---------|-------------|
-| `PIWARDRIVE_REDIS_URL` | string | `""` | Redis connection URL (optional) |
+| `PIWARDRIVE_REDIS_URL` | string | `""` | Redis connection URL used for caching (optional) |
 | `PIWARDRIVE_INFLUXDB_URL` | string | `""` | InfluxDB connection URL (optional) |
 | `PIWARDRIVE_GPS_ENABLED` | boolean | `false` | Enable GPS functionality |
 | `PIWARDRIVE_GPS_DEVICE` | string | `"/dev/ttyUSB0"` | GPS device path |

--- a/docs/docker-deployment.md
+++ b/docs/docker-deployment.md
@@ -330,7 +330,7 @@ services:
       - PIWARDRIVE_API_HOST=0.0.0.0
       - PIWARDRIVE_API_PORT=8080
       - PIWARDRIVE_DATABASE_URL=postgresql://piwardrive:${DB_PASSWORD}@piwardrive-db:5432/piwardrive
-      - PIWARDRIVE_REDIS_URL=redis://piwardrive-redis:6379/0
+      - PIWARDRIVE_REDIS_URL=redis://piwardrive-redis:6379/0  # Enables Redis caching
       - PIWARDRIVE_SECRET_KEY=${PIWARDRIVE_SECRET_KEY}
       - PIWARDRIVE_LOG_LEVEL=INFO
     
@@ -361,7 +361,7 @@ services:
     
     environment:
       - PIWARDRIVE_WIFI_INTERFACE=wlan0
-      - PIWARDRIVE_REDIS_URL=redis://piwardrive-redis:6379/0
+      - PIWARDRIVE_REDIS_URL=redis://piwardrive-redis:6379/0  # Enables Redis caching
       - PIWARDRIVE_LOG_LEVEL=INFO
     
     volumes:
@@ -776,7 +776,7 @@ services:
       - PIWARDRIVE_DEBUG=false
       - PIWARDRIVE_LOG_LEVEL=WARNING
       - PIWARDRIVE_DATABASE_URL=postgresql://piwardrive:${DB_PASSWORD}@piwardrive-db:5432/piwardrive
-      - PIWARDRIVE_REDIS_URL=redis://piwardrive-redis:6379/0
+      - PIWARDRIVE_REDIS_URL=redis://piwardrive-redis:6379/0  # Enables Redis caching
       - PIWARDRIVE_SECRET_KEY=${PIWARDRIVE_SECRET_KEY}
       - PIWARDRIVE_CORS_ORIGINS=${PIWARDRIVE_CORS_ORIGINS}
     
@@ -2029,6 +2029,7 @@ services:
       - PIWARDRIVE_CACHE_TTL=300
       - PIWARDRIVE_CACHE_MAX_SIZE=1000
 ```
+The API automatically uses Redis for caching when `PIWARDRIVE_REDIS_URL` is set.
 
 ### Database Optimization
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,6 +8,7 @@ pytest==8.4.0
 pytest-cov==6.2.1
 radon==6.0.1
 pydocstyle==6.3.0
+redis==5.0.4
 pre-commit==3.7.1
 black==25.1.0
 isort==6.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ requests-cache==1.2.1
 cachetools==6.1.0
 psutil==5.9.6
 gpsd-py3==0.3.0
+redis==5.0.4
 aiofiles==24.1.0
 scipy==1.15.3
 pyrtlsdr==0.3.0

--- a/src/piwardrive/core/utils.py
+++ b/src/piwardrive/core/utils.py
@@ -11,6 +11,7 @@ import os
 import subprocess
 import threading
 import time
+import pickle
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from datetime import datetime
@@ -42,6 +43,11 @@ from enum import IntEnum
 import psutil
 import requests
 from cachetools import TTLCache
+
+try:  # pragma: no cover - optional dependency
+    import redis.asyncio as aioredis
+except Exception:  # pragma: no cover - redis not installed
+    aioredis = None
 
 try:
     import requests_cache
@@ -132,6 +138,25 @@ _SAFE_REQUEST_CACHE: TTLCache[str, requests.Response | Any] = TTLCache(
 
 _SAFE_REQUEST_CACHE_LOCK = threading.Lock()
 
+# Optional Redis client for cross-process caching
+_REDIS_CLIENT: aioredis.Redis | None = None
+
+
+def _get_redis_client() -> aioredis.Redis | None:
+    """Return Redis client if ``PIWARDRIVE_REDIS_URL`` is configured."""
+    global _REDIS_CLIENT
+    if _REDIS_CLIENT is not None:
+        return _REDIS_CLIENT
+    url = os.getenv("PIWARDRIVE_REDIS_URL")
+    if not url or aioredis is None:
+        return None
+    try:
+        _REDIS_CLIENT = aioredis.from_url(url)
+    except Exception:  # pragma: no cover - Redis misconfiguration
+        logging.exception("Failed to initialize Redis client")
+        _REDIS_CLIENT = None
+    return _REDIS_CLIENT
+
 
 def _safe_request_cache_pruner() -> None:
     """Background task expiring old safe request cache entries."""
@@ -207,9 +232,30 @@ def async_ttl_cache(
                 entry = cache.get(key)
                 if entry and now is not None and now - entry[0] <= ttl:
                     return entry[1]
+            redis_cli = _get_redis_client()
+            redis_key = None
+            if redis_cli is not None:
+                redis_key = f"async_cache:{func.__module__}:{func.__name__}:{hash(key)}"
+                try:
+                    data = await redis_cli.get(redis_key)
+                    if data:
+                        ts, res = pickle.loads(data)
+                        if now is not None and now - ts <= ttl:
+                            return res
+                except Exception:
+                    logging.debug("Redis get failed", exc_info=True)
             result = await func(*args, **kwargs)
             async with lock:
                 cache[key] = ((0.0 if now is None else now), result)
+            if redis_cli is not None and redis_key is not None:
+                try:
+                    await redis_cli.set(
+                        redis_key,
+                        pickle.dumps((0.0 if now is None else now, result)),
+                        ex=int(ttl),
+                    )
+                except Exception:
+                    logging.debug("Redis set failed", exc_info=True)
             return result
 
         return wrapper


### PR DESCRIPTION
## Summary
- connect to Redis when `PIWARDRIVE_REDIS_URL` is set
- store async cached values in Redis
- document Redis caching in configuration and docker deployment guides
- include redis package in requirements

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6866e61e271c833399c6100ac0664c42