### PR TITLE
Improve async DB operations with pooling and paging

### DIFF
--- a/scripts/localize_aps.py
+++ b/scripts/localize_aps.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import asyncio
 import json
 import logging
 from pathlib import Path
@@ -43,7 +44,7 @@ def main(argv: list[str] | None = None) -> None:
 
     setup_logging(stdout=True)
     cfg = load_config(args.config)
-    data = load_kismet_data(args.database)
+    data = asyncio.run(load_kismet_data(args.database))
     coords = localize_aps(data, cfg)
 
     if folium is not None:

--- a/src/remote_sync/__init__.py
+++ b/src/remote_sync/__init__.py
@@ -6,11 +6,11 @@ import asyncio
 import json
 import logging
 import os
-import sqlite3
 import tempfile
 import time
 
 import aiohttp
+import aiosqlite
 
 logger = logging.getLogger(__name__)
 
@@ -51,13 +51,13 @@ def get_metrics() -> dict[str, float | int]:
     }
 
 
-def _make_range_db(src: str, start: int, end: int) -> str:
+async def _make_range_db(src: str, start: int, end: int) -> str:
     """Return path to a temporary DB with rows ``start``..``end`` from ``src``."""
     with tempfile.NamedTemporaryFile(delete=False, suffix=".db") as tmp:
         dest = tmp.name
 
-    with sqlite3.connect(src) as src_db, sqlite3.connect(dest) as dst_db:
-        dst_db.execute(
+    async with aiosqlite.connect(src) as src_db, aiosqlite.connect(dest) as dst_db:
+        await dst_db.execute(
             """CREATE TABLE health_records (
                 timestamp TEXT PRIMARY KEY,
                 cpu_temp REAL,
@@ -66,7 +66,7 @@ def _make_range_db(src: str, start: int, end: int) -> str:
                 disk_percent REAL
             )"""
         )
-        dst_db.execute(
+        await dst_db.execute(
             """CREATE TABLE ap_cache (
                 bssid TEXT,
                 ssid TEXT,
@@ -77,23 +77,25 @@ def _make_range_db(src: str, start: int, end: int) -> str:
             )"""
         )
 
-        cur = src_db.execute(
+        cur = await src_db.execute(
             "SELECT timestamp, cpu_temp, cpu_percent, memory_percent, disk_percent"
             " FROM health_records WHERE rowid BETWEEN ? AND ?",
             (start, end),
         )
-        dst_db.executemany(
+        rows = await cur.fetchall()
+        await dst_db.executemany(
             "INSERT INTO health_records VALUES (?, ?, ?, ?, ?)",
-            cur,
+            rows,
         )
 
-        cur = src_db.execute(
+        cur = await src_db.execute(
             "SELECT bssid, ssid, encryption, lat, lon, last_time FROM ap_cache "
             "WHERE rowid BETWEEN ? AND ?",
             (start, end),
         )
-        dst_db.executemany("INSERT INTO ap_cache VALUES (?, ?, ?, ?, ?, ?)", cur)
-        dst_db.commit()
+        rows = await cur.fetchall()
+        await dst_db.executemany("INSERT INTO ap_cache VALUES (?, ?, ?, ?, ?, ?)", rows)
+        await dst_db.commit()
 
     return dest
 
@@ -132,9 +134,10 @@ async def sync_new_records(
 
     last_id = _load_sync_state(state_file)
 
-    with sqlite3.connect(db_path) as db:
-        cur = db.execute("SELECT MAX(rowid) FROM health_records")
-        max_id = cur.fetchone()[0] or 0
+    async with aiosqlite.connect(db_path) as db:
+        cur = await db.execute("SELECT MAX(rowid) FROM health_records")
+        row = await cur.fetchone()
+        max_id = row[0] if row else 0
     if max_id <= last_id:
         return 0
 
@@ -171,13 +174,13 @@ async def sync_database_to_server(
     delay = INITIAL_RETRY_DELAY
     temp_path = None
     if row_range is not None:
-        start, end = row_range
-        temp_path = _make_range_db(db_path, start, end)
+        start_id, end_id = row_range
+        temp_path = await _make_range_db(db_path, start_id, end_id)
         path = temp_path
     else:
         path = db_path
 
-    start = time.perf_counter() if _METRICS_ENABLED else 0.0
+    start_time = time.perf_counter() if _METRICS_ENABLED else 0.0
     with open(path, "rb") as fh:
         for attempt in range(1, retries + 1):
             try:
@@ -193,7 +196,7 @@ async def sync_database_to_server(
                     os.unlink(temp_path)
                 if _METRICS_ENABLED:
                     _SUCCESS_TOTAL += 1
-                    _LAST_DURATION = time.perf_counter() - start
+                    _LAST_DURATION = time.perf_counter() - start_time
                 return
             except Exception as exc:  # pragma: no cover - network errors
                 if attempt >= retries:
@@ -202,7 +205,7 @@ async def sync_database_to_server(
                         os.unlink(temp_path)
                     if _METRICS_ENABLED:
                         _FAILURE_TOTAL += 1
-                        _LAST_DURATION = time.perf_counter() - start
+                        _LAST_DURATION = time.perf_counter() - start_time
                     raise
                 await asyncio.sleep(delay)
                 delay *= 2

--- a/tests/test_load_kismet_data.py
+++ b/tests/test_load_kismet_data.py
@@ -1,7 +1,6 @@
+import asyncio
 import sqlite3
 from pathlib import Path
-
-import pandas as pd
 
 from piwardrive.advanced_localization import load_kismet_data
 
@@ -10,10 +9,12 @@ def create_kismet_db(path: Path) -> None:
     """Create a minimal kismet-like database with sample rows."""
     with sqlite3.connect(path) as conn:
         conn.execute(
-            "CREATE TABLE devices (devicekey INTEGER PRIMARY KEY, macaddr TEXT, ssid TEXT, type TEXT)"
+            "CREATE TABLE devices (devicekey INTEGER PRIMARY KEY, macaddr TEXT,"
+            " ssid TEXT, type TEXT)"
         )
         conn.execute(
-            "CREATE TABLE packets (devicekey INTEGER, lat REAL, lon REAL, signal INTEGER, gpstime INTEGER)"
+            "CREATE TABLE packets (devicekey INTEGER, lat REAL, lon REAL, signal "
+            "INTEGER, gpstime INTEGER)"
         )
         conn.execute(
             "INSERT INTO devices VALUES (1, 'aa:bb:cc', 'test', 'infrastructure')"
@@ -28,7 +29,7 @@ def test_load_kismet_data_filters_and_returns_dataframe(tmp_path: Path) -> None:
     db = tmp_path / "kismet.db"
     create_kismet_db(db)
 
-    df = load_kismet_data(db)
+    df = asyncio.run(load_kismet_data(db))
 
     assert list(df.columns) == [
         "macaddr",

--- a/tests/test_remote_sync.py
+++ b/tests/test_remote_sync.py
@@ -11,10 +11,14 @@ aiohttp_mod = ModuleType("aiohttp")
 aiohttp_mod.ClientSession = object  # type: ignore[attr-defined]
 aiohttp_mod.ClientTimeout = lambda *a, **k: None  # type: ignore[attr-defined]
 aiohttp_mod.ClientError = Exception  # type: ignore[attr-defined]
-aiohttp_mod.FormData = lambda: type("FormData", (), {"add_field": lambda *a, **k: None})()  # type: ignore[attr-defined]
+aiohttp_mod.FormData = lambda: type(
+    "FormData",
+    (),
+    {"add_field": lambda *a, **k: None},
+)()  # type: ignore[attr-defined]
 sys.modules.setdefault("aiohttp", aiohttp_mod)
 
-import piwardrive.remote_sync as rs
+import piwardrive.remote_sync as rs  # noqa: E402
 
 
 class DummyResp:
@@ -202,7 +206,7 @@ def test_make_range_db(tmp_path):
             )
         db.commit()
 
-    path = rs._make_range_db(str(db_path), 2, 3)
+    path = asyncio.run(rs._make_range_db(str(db_path), 2, 3))
     import os
 
     try:
@@ -252,14 +256,12 @@ def test_make_range_db_empty_range(tmp_path):
             )
         db.commit()
 
-    path = rs._make_range_db(str(db_path), 5, 4)
+    path = asyncio.run(rs._make_range_db(str(db_path), 5, 4))
     import os
 
     try:
         with sqlite3.connect(path) as db:
-            rows = db.execute(
-                "SELECT COUNT(*) FROM health_records"
-            ).fetchone()
+            rows = db.execute("SELECT COUNT(*) FROM health_records").fetchone()
             assert rows[0] == 0
             rows = db.execute("SELECT COUNT(*) FROM ap_cache").fetchone()
             assert rows[0] == 0


### PR DESCRIPTION
## Summary
- implement a connection pool for the aggregation service
- convert Kismet loader and remote sync helpers to async
- support pagination in persistence APIs
- update CLI/localization script for new async call
- update tests for async helpers

## Testing
- `pytest -q tests/test_load_kismet_data.py tests/test_remote_sync.py`

------
https://chatgpt.com/codex/tasks/task_e_6866e4733a2483338e6c74ffc644a718