### PR TITLE
Improve docs and onboarding

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,13 @@ pip install -r requirements-dev.txt
 pre-commit install
 ```
 
+1. Fork the repository and create a feature branch off of `main`.
+2. Make your changes following the existing code style. Formatting is enforced with [Black](https://black.readthedocs.io/) and [isort](https://pycqa.github.io/isort/).
+3. Run `pre-commit run --all-files` and `make test` to execute Python and Node tests.
+4. Commit your work with descriptive messages and open a pull request on GitHub.
+
+All new features should include accompanying tests and documentation when applicable.
+
 Some tests rely on additional scientific packages such as `numpy`, `pandas`
 and `scikit-learn`. Install them via `pip install .[tests]` (or
 `pip install -r requirements.txt`) if you plan to run the full suite.
@@ -26,5 +33,6 @@ Use the following convenience targets during development:
 
 During development you can automatically restart the backend service when files
 change by running `scripts/watch_service.py` (requires the `watchgod` package).
+We use the [Developer Certificate of Origin](https://developercertificate.org/). By submitting code you certify that you have the right to license it under the project's MIT terms.
 
 Contributions should pass these checks before you submit a pull request.

--- a/README.md
+++ b/README.md
@@ -118,6 +118,17 @@ aid troubleshooting periodic jobs during development.
 
 ## Advanced Analytics
 
+## Installation Prerequisites
+
+Ensure the following base packages are installed before proceeding with the full installation steps.
+
+- **Python** >= 3.10 with the `venv` module
+- **Node.js** >= 18 for building the React dashboard
+- **System packages**: `kismet`, `gpsd`, `bettercap`, `evtest`, `git`, `build-essential`, `cmake`
+- **R base packages**: `r-base` and `r-base-dev` (optional, for advanced analytics)
+
+For a more complete walkthrough see [docs/installation.md](docs/installation.md).
+
 Health metrics can be analyzed beyond simple averages. The `health_stats`
 script accepts a `--forecast N` option to predict CPU temperature for the next
 `N` intervals using an ARIMA or Prophet model.
@@ -556,6 +567,12 @@ port and `PW_ORIENTATION_MAP_FILE` for loading a heading correction map (see
 [docs/orientation.rst](docs/orientation.rst)). A JSON schema describing all
 fields is provided at `docs/config_schema.json`.
 Password hashing guidelines are covered in [docs/security.rst](docs/security.rst).
+Key environment variables:
+
+- `PW_WEBUI_PORT` – port for the web interface (default `8000`)
+- `PW_DISABLE_ANOMALY_DETECTION` – set to `1` to disable health monitoring
+- `PW_PROFILE_NAME` – load a specific configuration profile
+- `PW_REMOTE_SYNC_URL` – optional endpoint for database uploads
 
 ### Automatic Anomaly Detection
 
@@ -567,6 +584,8 @@ model. The detector is enabled automatically when running the backend via
 ## Additional Documentation
 
 Comprehensive guides and API references live in the `docs/` directory. Run `make html` there to build the Sphinx site. High level summaries are collected in [REFERENCE.md](REFERENCE.md).
+In particular see [CONTRIBUTING.md](CONTRIBUTING.md) for development guidelines, [docs/api_overview.md](docs/api_overview.md) for the REST API, and [docs/architecture_overview.md](docs/architecture_overview.md) for a high-level system diagram.
+
 Detailed examples for each command line helper are available in [docs/cli_tools.rst](docs/cli_tools.rst).
 See [docs/notifications.rst](docs/notifications.rst) for enabling webhook alerts.
 
@@ -658,3 +677,7 @@ generating coverage reports.
 ## Legal Notice
 
 Ensure all wireless and Bluetooth scans comply with local laws and have proper authorization. The authors are not responsible for misuse of this software.
+
+## License
+
+PiWardrive is released under the terms of the [MIT License](LICENSE).

--- a/docs/api_overview.md
+++ b/docs/api_overview.md
@@ -1,0 +1,15 @@
+# PiWardrive API Overview
+
+PiWardrive exposes a REST API served by FastAPI. The base URL is `http://localhost:8000/api` unless overridden by `PW_WEBUI_PORT`.
+
+Common endpoints include:
+
+| Endpoint               | Method  | Description                      |
+| ---------------------- | ------- | -------------------------------- |
+| `/status/health`       | GET     | Return system health information |
+| `/wifi/scan`           | POST    | Start a Wi-Fi scan               |
+| `/wifi/scan/{scan_id}` | GET     | Retrieve results for a scan      |
+| `/config`              | GET/PUT | Read or update configuration     |
+| `/export/scans`        | GET     | Export scan data                 |
+
+See `docs/api.md` for the complete OpenAPI specification and advanced examples.

--- a/docs/architecture_overview.md
+++ b/docs/architecture_overview.md
@@ -1,0 +1,12 @@
+# Architecture Overview
+
+The project follows a modular design with a FastAPI backend and a React frontend. Data is collected by scheduled tasks and stored in SQLite. Optional services such as GPS or Bluetooth can be enabled via configuration.
+
+```
+[React Dashboard] <--REST--> [FastAPI Service] <---> [SQLite DB]
+                              |
+                              +--[Scheduler & Diagnostics]
+                              +--[External Tools: Kismet, BetterCAP]
+```
+
+Additional diagrams and a deep dive into each component are available in `docs/architecture.md`.


### PR DESCRIPTION
## Summary
- outline minimal installation prerequisites in README
- link to new API and architecture docs
- reference project license
- expand contributor guidelines
- add short API and architecture overviews

## Testing
- `pre-commit run --files README.md CONTRIBUTING.md docs/api_overview.md docs/architecture_overview.md` *(fails: ESLint config missing)*
- `pytest` *(fails: 48 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6866e63dd61c8333ba21189218c492dd