### PR TITLE
Centralize structured logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -574,13 +574,15 @@ See [docs/notifications.rst](docs/notifications.rst) for enabling webhook alerts
 
 Below are minimal snippets that can be validated with `doctest`.
 
-### setup_logging
+### init_logging
 
 ```python
 >>> import sys, types, json, os
 >>> sys.modules['piwardrive.config'] = types.SimpleNamespace(CONFIG_DIR='.')
 >>> sys.path.insert(0, 'src')
+>>> from piwardrive.logging import init_logging
 >>> from piwardrive.logconfig import setup_logging
+>>> init_logging()
 >>> logger = setup_logging('./temp.log')
 >>> logger.warning('issue')
 >>> json.loads(open('./temp.log').read().splitlines()[0])['level']

--- a/docs/architecture.rst
+++ b/docs/architecture.rst
@@ -52,9 +52,9 @@ the scheduler.
 External services such as Kismet, BetterCAP and ``gpsd`` are controlled via
 shell commands. They run outside the Python process but are monitored by the
 application. Structured JSON logs are produced through
-``logconfig.setup_logging`` and written to ``~/.config/piwardrive/app.log`` by
-default. The logger can also emit to ``stdout`` or extra handlers passed into
-``setup_logging`` for easier debugging.
+``piwardrive.logging.init_logging`` and written to ``~/.config/piwardrive/app.log`` by
+default. The logger can also emit to ``stdout`` or extra handlers by calling
+``logconfig.setup_logging`` for simple scripts.
 
 Startup Sequence
 ~~~~~~~~~~~~~~~~

--- a/docs/logging.rst
+++ b/docs/logging.rst
@@ -3,20 +3,20 @@ Logging
 .. note::
    Please read the legal notice in the project `README.md` before using PiWardrive.
 
-PiWardrive uses structured JSON logging configured by :func:`logconfig.setup_logging`.
+PiWardrive uses structured JSON logging configured by
+:func:`piwardrive.logging.init_logging`.
 The main log file is ``~/.config/piwardrive/app.log``. Set the ``PW_LOG_LEVEL``
-environment variable to control verbosity or pass ``level`` to ``setup_logging``.
+environment variable to control verbosity or pass ``PW_LOG_LEVEL`` when calling
+``init_logging``.
 Common levels are ``DEBUG``, ``INFO``, ``WARNING`` and ``ERROR``.
 
 Example::
 
-    from piwardrive.logconfig import setup_logging
+    from piwardrive.logging import init_logging
     import logging
 
-    logger = setup_logging(
-        "/tmp/piwardrive.log", level=logging.DEBUG, stdout=True
-    )
-    logger.info("PiWardrive initialized")
+    init_logging()
+    logging.info("PiWardrive initialized")
 
 Logs from external tools are stored separately. ``kismet_logdir`` points to the
 capture directory for Kismet (``/mnt/ssd/kismet_logs`` by default) while
@@ -28,7 +28,7 @@ Periodic cleanup compresses and rotates files under ``/var/log`` and any entries
 from ``log_paths``. Adjust ``log_rotate_interval`` and ``log_rotate_archives`` in
 ``config.json`` or disable the behaviour entirely with ``cleanup_rotated_logs``.
 
-Passing ``stdout=True`` to ``setup_logging`` duplicates output to the console,
+Passing ``stdout=True`` to :func:`logconfig.setup_logging` duplicates output to the console,
 which is useful during development or when running inside Docker.
 
 Rotating Logs Manually

--- a/src/piwardrive/integrations/sigint_suite/__init__.py
+++ b/src/piwardrive/integrations/sigint_suite/__init__.py
@@ -4,15 +4,18 @@ import logging
 import os
 from typing import Any
 
+from piwardrive.logging import init_logging
+
 from . import plugins as _plugins
 
 _DEBUG_FLAG = "SIGINT_DEBUG"
 
 
 def _setup_logging() -> None:
-    """Configure basic logging based on ``SIGINT_DEBUG``."""
-    level = logging.DEBUG if os.getenv(_DEBUG_FLAG) else logging.INFO
-    logging.basicConfig(level=level, format="%(levelname)s: %(message)s")
+    """Configure logging using :func:`init_logging`."""
+    init_logging()
+    if os.getenv(_DEBUG_FLAG):
+        logging.getLogger().setLevel(logging.DEBUG)
 
 
 _setup_logging()

--- a/src/piwardrive/logging/__init__.py
+++ b/src/piwardrive/logging/__init__.py
@@ -1,18 +1,24 @@
+from .config import LoggingConfig
 from .structured_logger import (
     LogContext,
-    StructuredFormatter,
     PiWardriveLogger,
-    set_log_context,
+    StructuredFormatter,
     get_logger,
+    set_log_context,
 )
-from .config import LoggingConfig
+
+
+def init_logging(config_path: str | None = None) -> None:
+    """Apply logging configuration from ``config_path`` if provided."""
+    LoggingConfig(config_path).apply()
+
 
 __all__ = [
     "LogContext",
     "StructuredFormatter",
     "PiWardriveLogger",
     "LoggingConfig",
+    "init_logging",
     "set_log_context",
     "get_logger",
 ]
-

--- a/src/piwardrive/lora_scanner.py
+++ b/src/piwardrive/lora_scanner.py
@@ -27,7 +27,7 @@ from dataclasses import dataclass
 from typing import Callable, List, ParamSpec, Sequence, TypeVar
 
 from .core import config
-from .logconfig import setup_logging
+from .logging import init_logging
 from .scheduler import PollScheduler
 
 P = ParamSpec("P")
@@ -304,7 +304,7 @@ def main() -> None:  # pragma: no cover - CLI helper
     parser.add_argument("--json", action="store_true", help="print as JSON")
     args = parser.parse_args()
 
-    setup_logging(stdout=True)
+    init_logging()
 
     lines = scan_lora(args.iface)
     if args.json:

--- a/src/piwardrive/main.py
+++ b/src/piwardrive/main.py
@@ -11,6 +11,8 @@ from dataclasses import asdict, fields
 from pathlib import Path
 from typing import Callable
 
+from watchdog.observers import Observer
+
 from piwardrive import diagnostics, exception_handler, notifications, remote_sync, utils
 from piwardrive.config import (
     CONFIG_PATH,
@@ -20,9 +22,8 @@ from piwardrive.config import (
     save_config,
 )
 from piwardrive.config_watcher import watch_config
-from watchdog.observers import Observer
 from piwardrive.di import Container
-from piwardrive.logconfig import setup_logging
+from piwardrive.logging import init_logging
 from piwardrive.persistence import AppState, _db_path, load_app_state, save_app_state
 from piwardrive.scheduler import PollScheduler
 from piwardrive.security import hash_password
@@ -46,7 +47,7 @@ class PiWardriveApp:
         pw = os.getenv("PW_ADMIN_PASSWORD")
         if pw and not self.config_data.admin_password_hash:
             self.config_data.admin_password_hash = hash_password(pw)
-        setup_logging(level=logging.INFO)
+        init_logging()
         exception_handler.install()
         if not self.container.has("scheduler"):
             self.container.register_instance("scheduler", PollScheduler())

--- a/src/piwardrive/scripts/service_status.py
+++ b/src/piwardrive/scripts/service_status.py
@@ -5,11 +5,11 @@ import json
 import logging
 from types import SimpleNamespace
 
-from piwardrive.logconfig import setup_logging
+from piwardrive.logging import init_logging
 
 
 def _get_service_statuses(
-    services: tuple[str, ...] | list[str] | None = None
+    services: tuple[str, ...] | list[str] | None = None,
 ) -> dict[str, bool]:
     """Import :mod:`piwardrive.diagnostics` lazily and get statuses."""
     from piwardrive import diagnostics as _diag
@@ -29,7 +29,7 @@ def main(argv: list[str] | None = None) -> None:
         help="Services to check (defaults to kismet, bettercap, gpsd)",
     )
     args = parser.parse_args(argv)
-    setup_logging(stdout=True)
+    init_logging()
     statuses = diagnostics.get_service_statuses(args.services or None)
     logging.info(json.dumps(statuses))
 

--- a/src/piwardrive/service.py
+++ b/src/piwardrive/service.py
@@ -10,6 +10,8 @@ from dataclasses import asdict
 from http import HTTPStatus
 from typing import TYPE_CHECKING
 
+from piwardrive.logging import init_logging
+
 try:  # pragma: no cover - optional FastAPI dependency
     from fastapi import (
         Body,
@@ -22,11 +24,8 @@ try:  # pragma: no cover - optional FastAPI dependency
     )
     from fastapi.middleware.cors import CORSMiddleware
     from fastapi.openapi.utils import get_openapi
-    from fastapi.responses import (  # noqa: E402
-        HTMLResponse,
-        Response,
-        StreamingResponse,
-    )
+    from fastapi.responses import Response  # noqa: E402
+    from fastapi.responses import HTMLResponse, StreamingResponse
     from fastapi.security import (
         HTTPBasic,
         HTTPBasicCredentials,
@@ -191,10 +190,8 @@ except Exception:  # pragma: no cover - fall back to real module
     from piwardrive import lora_scanner as _lora_scanner
 
 try:  # allow tests to stub out analytics
-    from analytics.baseline import (  # type: ignore
-        analyze_health_baseline,
-        load_baseline_health,
-    )
+    from analytics.baseline import analyze_health_baseline  # type: ignore
+    from analytics.baseline import load_baseline_health
 except Exception:  # pragma: no cover - fall back to real module
     from piwardrive.analytics.baseline import (
         analyze_health_baseline,
@@ -1283,6 +1280,8 @@ async def sse_history(
 async def main() -> None:
     """Run the FastAPI app using ``uvicorn``."""
     import uvicorn
+
+    init_logging()
 
     port_str = os.getenv("PW_SERVICE_PORT", "8000")
     try:


### PR DESCRIPTION
## Summary
- provide `init_logging` helper in logging package
- use centralized logging in main application and tools
- document new structured logging entry point

## Testing
- `pre-commit run --files README.md docs/architecture.rst docs/logging.rst src/piwardrive/integrations/sigint_suite/__init__.py src/piwardrive/logging/__init__.py src/piwardrive/lora_scanner.py src/piwardrive/main.py src/piwardrive/scripts/service_status.py src/piwardrive/service.py`

------
https://chatgpt.com/codex/tasks/task_e_6866e632d2f483339415672d8262d1c1