### PR TITLE
Increase coverage for GPS and config modules

### DIFF
--- a/tests/test_config_env_webhooks.py
+++ b/tests/test_config_env_webhooks.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+
+import pytest
+
+
+def setup_tmp(tmp_path: Path) -> None:
+    from piwardrive import config
+
+    config.CONFIG_DIR = str(tmp_path)
+    config.CONFIG_PATH = str(tmp_path / "config.json")
+    config.PROFILES_DIR = str(tmp_path / "profiles")
+    config.ACTIVE_PROFILE_FILE = str(tmp_path / "active_profile")
+    Path(config.CONFIG_DIR).mkdir(parents=True, exist_ok=True)
+    Path(config.CONFIG_PATH).write_text("{}")
+
+
+def test_env_override_list(monkeypatch, tmp_path: Path) -> None:
+    pytest.importorskip("pydantic")
+    setup_tmp(tmp_path)
+    monkeypatch.setenv("PW_NOTIFICATION_WEBHOOKS", '["http://a","http://b"]')
+    from piwardrive import config
+
+    cfg = config.AppConfig.load()
+    assert cfg.notification_webhooks == ["http://a", "http://b"]  # nosec B101

--- a/tests/test_database_counts.py
+++ b/tests/test_database_counts.py
@@ -1,0 +1,38 @@
+import asyncio
+import os
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _stub_pydantic(monkeypatch):
+    module = SimpleNamespace(
+        BaseModel=object,
+        Field=lambda *a, **k: None,
+        ValidationError=Exception,
+        field_validator=lambda *a, **k: (lambda f: f),
+    )
+    monkeypatch.setitem(sys.modules, "pydantic", module)
+
+
+def setup_tmp(tmp_path):
+    from piwardrive import config
+
+    config.CONFIG_DIR = str(tmp_path)
+    os.environ["PW_DB_PATH"] = str(tmp_path / "app.db")
+
+
+def test_get_table_counts(tmp_path):
+    import pytest
+
+    pytest.importorskip("aiosqlite")
+    from piwardrive.core import persistence
+
+    setup_tmp(tmp_path)
+    rec = persistence.HealthRecord("t", 1.0, 1.0, 1.0, 1.0)
+    asyncio.run(persistence.save_health_record(rec))
+    asyncio.run(persistence.flush_health_records())
+    counts = asyncio.run(persistence.get_table_counts())
+    assert counts.get("health_records") == 1  # nosec B101

--- a/tests/test_gpsd_client_async_more.py
+++ b/tests/test_gpsd_client_async_more.py
@@ -1,0 +1,49 @@
+import asyncio
+
+from piwardrive.gpsd_client_async import AsyncGPSDClient
+
+
+def run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+def test_get_position_async(monkeypatch):
+    client = AsyncGPSDClient()
+
+    async def fake_poll():
+        return {"lat": 1.0, "lon": 2.0}
+
+    monkeypatch.setattr(client, "_poll", fake_poll)
+    assert run(client.get_position_async()) == (1.0, 2.0)  # nosec B101
+
+
+def test_get_accuracy_async(monkeypatch):
+    client = AsyncGPSDClient()
+
+    async def fake_poll():
+        return {"epx": 3.0, "epy": 4.0}
+
+    monkeypatch.setattr(client, "_poll", fake_poll)
+    assert run(client.get_accuracy_async()) == 4.0  # nosec B101
+
+
+def test_get_fix_quality_async(monkeypatch):
+    client = AsyncGPSDClient()
+
+    async def fake_poll():
+        return {"mode": 2}
+
+    monkeypatch.setattr(client, "_poll", fake_poll)
+    assert run(client.get_fix_quality_async()) == "2D"  # nosec B101
+
+
+def test_async_methods_none(monkeypatch):
+    client = AsyncGPSDClient()
+
+    async def fake_poll():
+        return None
+
+    monkeypatch.setattr(client, "_poll", fake_poll)
+    assert run(client.get_position_async()) is None  # nosec B101
+    assert run(client.get_accuracy_async()) is None  # nosec B101
+    assert run(client.get_fix_quality_async()) == "Unknown"  # nosec B101

--- a/tests/test_web_server_missing.py
+++ b/tests/test_web_server_missing.py
@@ -1,0 +1,27 @@
+import importlib
+import sys
+from types import ModuleType
+
+import pytest
+
+
+def test_create_app_missing_dist(tmp_path, monkeypatch):
+    pytest.importorskip("fastapi")
+    sys.modules.setdefault("uvicorn", ModuleType("uvicorn"))
+    web_server = importlib.import_module("piwardrive.web_server")
+
+    dist = tmp_path / "dist"
+
+    orig_join = web_server.os.path.join
+
+    def fake_join(*parts: str) -> str:
+        path = orig_join(*parts)
+        if path.endswith(orig_join("webui", "dist")):
+            return str(dist)
+        return path
+
+    monkeypatch.setattr(web_server.os.path, "join", fake_join)
+    monkeypatch.setattr(web_server.os.path, "isdir", lambda p: False)
+
+    with pytest.raises(RuntimeError):
+        web_server.create_app()


### PR DESCRIPTION
## Summary
- add tests for async GPSD client helper
- cover env override list logic in config
- add integration test for database table counts
- ensure web server errors on missing static build

## Testing
- `pre-commit run --files tests/test_gpsd_client_async_more.py tests/test_config_env_webhooks.py tests/test_database_counts.py tests/test_web_server_missing.py`

------
https://chatgpt.com/codex/tasks/task_e_6866e63922708333833f88f4814a4b16