### PR TITLE
Improve security middleware and add security scanning

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,26 @@
+name: Security Scan
+
+on:
+    pull_request:
+    schedule:
+        - cron: "0 4 * * 1"
+
+jobs:
+    scan:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+            - uses: actions/setup-python@v5
+              with:
+                  python-version: "3.12"
+                  cache: "pip"
+            - name: Install dependencies
+              run: |
+                  pip install -r requirements.txt
+                  pip install -r requirements-dev.txt
+            - name: Run bandit
+              run: bandit -r src || true
+            - name: Run pip-audit
+              run: pip-audit -r requirements.txt || true
+            - name: Run safety
+              run: safety check -r requirements.txt || true

--- a/docs/security_audit.md
+++ b/docs/security_audit.md
@@ -1,0 +1,21 @@
+# Security Audit Report
+
+The project dependencies were scanned using **bandit**, **pip-audit** and **safety**.
+
+## Bandit
+
+Summary:
+
+-   59 low severity issues
+-   5 medium severity issues
+-   0 high severity issues
+
+## pip-audit
+
+`pip-audit` failed to complete due to missing build dependencies for `dbus-python`.
+
+## safety
+
+`safety` could not connect to the vulnerability database because of network restrictions.
+
+These tools are executed automatically in the `Security Scan` workflow.

--- a/docs/security_config.md
+++ b/docs/security_config.md
@@ -1,0 +1,13 @@
+# Security Configuration
+
+The API enforces authentication when `PW_API_PASSWORD_HASH` is set. The username defaults to `admin` and can be overridden with `PW_API_USER`.
+
+Rate limiting is enabled via `PIWARDRIVE_RATE_LIMIT_REQUESTS` and `PIWARDRIVE_RATE_LIMIT_WINDOW`.
+
+CORS origins can be specified in `PW_CORS_ORIGINS`.
+
+Content Security Policy can be customised with `PW_CONTENT_SECURITY_POLICY`.
+
+The service adds HTTP security headers (HSTS, CSP, X-Frame-Options, X-Content-Type-Options).
+
+Automated security scanning runs in CI (`.github/workflows/security.yml`).

--- a/tests/test_webui_server.py
+++ b/tests/test_webui_server.py
@@ -45,6 +45,7 @@ def test_webui_authentication(tmp_path, monkeypatch):
 
     pw_hash = security.hash_password("pw")
     monkeypatch.setenv("PW_API_PASSWORD_HASH", pw_hash)
+    monkeypatch.setenv("PW_API_USER", "u")
 
     stub_widgets = SimpleNamespace(__all__=["W"])
     monkeypatch.setattr(service.importlib, "import_module", lambda n: stub_widgets)

--- a/web/app.py
+++ b/web/app.py
@@ -1,32 +1,45 @@
-import os
-import base64
 import asyncio
+import base64
+import hmac
+import os
+
 from fastapi import FastAPI, Request, WebSocket, WebSocketDisconnect
 from fastapi.staticfiles import StaticFiles
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.responses import Response
 
-from piwardrive.service import app as api_app
-from piwardrive.service import list_widgets, _collect_widget_metrics
 from piwardrive.security import verify_password
+from piwardrive.service import _collect_widget_metrics
+from piwardrive.service import app as api_app
+from piwardrive.service import list_widgets
 
 DEF_BUILD_DIR = os.path.join(os.path.dirname(__file__), os.pardir, "webui", "dist")
 
+
 class BasicAuthMiddleware(BaseHTTPMiddleware):
+    """HTTP basic authentication using constant-time credential checks."""
+
+    def __init__(self, app: FastAPI) -> None:
+        super().__init__(app)
+        self.user = os.getenv("PW_API_USER", "admin")
+        self.pw_hash = os.getenv("PW_API_PASSWORD_HASH")
+
     async def dispatch(self, request: Request, call_next):
-        pw_hash = os.getenv("PW_API_PASSWORD_HASH")
-        if pw_hash and request.url.path.startswith("/api"):
+        if self.pw_hash and request.url.path.startswith("/api"):
             header = request.headers.get("Authorization", "")
             if not header.startswith("Basic "):
                 return Response(status_code=401, headers={"WWW-Authenticate": "Basic"})
             try:
                 creds = base64.b64decode(header[6:]).decode()
-                password = creds.split(":", 1)[1]
+                username, password = creds.split(":", 1)
             except Exception:
                 return Response(status_code=401, headers={"WWW-Authenticate": "Basic"})
-            if not verify_password(password, pw_hash):
+            valid_user = hmac.compare_digest(username, self.user)
+            valid_pw = verify_password(password, self.pw_hash)
+            if not (valid_user and valid_pw):
                 return Response(status_code=401, headers={"WWW-Authenticate": "Basic"})
         return await call_next(request)
+
 
 def create_app() -> FastAPI:
     app = FastAPI()
@@ -54,10 +67,13 @@ def create_app() -> FastAPI:
         )
     return app
 
+
 def main() -> None:
     import uvicorn
+
     port = int(os.environ.get("PW_WEBUI_PORT", 8000))
     uvicorn.run(create_app(), host="127.0.0.1", port=port)
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- strengthen BasicAuth with constant-time checks
- add HSTS, X-Frame-Options and X-Content-Type-Options
- implement token bucket rate limiting
- validate service names on endpoints
- document security scanning results and configuration
- add CI workflow for pip-audit, safety and bandit

## Testing
- `pre-commit run --files web/app.py src/piwardrive/service.py tests/test_webui_server.py docs/security_audit.md docs/security_config.md .github/workflows/security.yml`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'boto3')*

------
https://chatgpt.com/codex/tasks/task_e_68670685f5c083338ca316aff63faeb4