### PR TITLE
Add async performance utilities and CPU pool

### DIFF
--- a/docs/async_performance.md
+++ b/docs/async_performance.md
@@ -1,0 +1,23 @@
+# Async Performance Optimization
+
+This guide summarizes best practices for combining asyncio with CPU-bound workloads in PiWardrive.
+
+## Process pool
+
+Use `piwardrive.cpu_pool.run_cpu_bound` to execute expensive computations in a separate `ProcessPoolExecutor`. This prevents blocking the main event loop and allows multiple CPU cores to be utilized.
+
+## Task priority
+
+Background jobs can be scheduled using `PriorityTaskQueue` which processes tasks based on priority values. Lower numbers run first.
+
+## Distributed caching
+
+`RedisCache` stores results across processes. Call `.set(key, value, ttl)` to persist values and `.invalidate(key)` to remove them.
+
+## Monitoring
+
+Wrap critical sections with `performance.record(name)` to capture execution times. Metrics are available via `performance.get_metrics()` and can be visualized in Grafana.
+
+## Circuit breaker
+
+External services may become unreliable. Wrap async calls with `CircuitBreaker` to stop issuing requests after repeated failures and automatically recover after a timeout.

--- a/src/piwardrive/__init__.py
+++ b/src/piwardrive/__init__.py
@@ -37,6 +37,10 @@ for _mod in (
     "diagnostics",
     "exception_handler",
     "task_queue",
+    "cpu_pool",
+    "cache",
+    "circuit_breaker",
+    "performance",
 ):
     try:  # pragma: no cover - optional imports may fail
         module = import_module(f"piwardrive.{_mod}")

--- a/src/piwardrive/analytics/baseline.py
+++ b/src/piwardrive/analytics/baseline.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta
-from typing import Iterable, Dict, Any, List
+from typing import Any, Dict, Iterable, List
 
 from ..analysis import compute_health_stats
 from ..persistence import HealthRecord, _get_conn, flush_health_records
@@ -44,3 +44,24 @@ def analyze_health_baseline(
         "delta": delta,
         "anomalies": anomalies,
     }
+
+
+from ..cpu_pool import run_cpu_bound
+
+
+async def analyze_health_baseline_async(
+    recent: Iterable[HealthRecord],
+    baseline: Iterable[HealthRecord],
+    threshold: float = 5.0,
+) -> Dict[str, Any]:
+    """Async wrapper for :func:`analyze_health_baseline`."""
+    return await run_cpu_bound(
+        analyze_health_baseline, list(recent), list(baseline), threshold
+    )
+
+
+__all__ = [
+    "load_baseline_health",
+    "analyze_health_baseline",
+    "analyze_health_baseline_async",
+]

--- a/src/piwardrive/cache.py
+++ b/src/piwardrive/cache.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import pickle
+from typing import Any
+
+from .core.utils import _get_redis_client
+
+
+class RedisCache:
+    """Lightweight async Redis cache with optional TTL."""
+
+    def __init__(self, prefix: str = "cache") -> None:
+        self._prefix = prefix
+
+    def _key(self, key: str) -> str:
+        return f"{self._prefix}:{key}"
+
+    async def get(self, key: str) -> Any:
+        cli = _get_redis_client()
+        if cli is None:
+            return None
+        data = await cli.get(self._key(key))
+        return pickle.loads(data) if data else None
+
+    async def set(self, key: str, value: Any, ttl: int | None = None) -> None:
+        cli = _get_redis_client()
+        if cli is None:
+            return
+        data = pickle.dumps(value)
+        await cli.set(self._key(key), data, ex=ttl)
+
+    async def invalidate(self, key: str) -> None:
+        cli = _get_redis_client()
+        if cli is None:
+            return
+        await cli.delete(self._key(key))
+
+    async def clear(self) -> None:
+        cli = _get_redis_client()
+        if cli is None:
+            return
+        keys = await cli.keys(f"{self._prefix}:*")
+        if keys:
+            await cli.delete(*keys)
+
+
+__all__ = ["RedisCache"]

--- a/src/piwardrive/circuit_breaker.py
+++ b/src/piwardrive/circuit_breaker.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import time
+from typing import Any, Awaitable, Callable
+
+
+class CircuitBreaker:
+    """Simple circuit breaker for async functions."""
+
+    def __init__(self, max_failures: int = 3, reset_timeout: float = 30.0) -> None:
+        self.max_failures = max_failures
+        self.reset_timeout = reset_timeout
+        self.failures = 0
+        self.last_failure = 0.0
+        self.open = False
+
+    async def call(
+        self, func: Callable[..., Awaitable[Any]], *args: Any, **kwargs: Any
+    ) -> Any:
+        if self.open and time.time() - self.last_failure < self.reset_timeout:
+            raise RuntimeError("Circuit open")
+        try:
+            result = await func(*args, **kwargs)
+        except Exception:
+            self.failures += 1
+            self.last_failure = time.time()
+            if self.failures >= self.max_failures:
+                self.open = True
+            raise
+        else:
+            self.failures = 0
+            self.open = False
+            return result
+
+
+__all__ = ["CircuitBreaker"]

--- a/src/piwardrive/cpu_pool.py
+++ b/src/piwardrive/cpu_pool.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import asyncio
+import os
+from concurrent.futures import ProcessPoolExecutor
+from typing import Any, Callable
+
+_CPU_POOL: ProcessPoolExecutor | None = None
+
+
+def get_cpu_pool() -> ProcessPoolExecutor:
+    """Return a global :class:`ProcessPoolExecutor`."""
+    global _CPU_POOL
+    if _CPU_POOL is None:
+        size = int(os.getenv("PW_CPU_POOL_SIZE", os.cpu_count() or 1))
+        _CPU_POOL = ProcessPoolExecutor(max_workers=size)
+    return _CPU_POOL
+
+
+async def run_cpu_bound(func: Callable[..., Any], *args: Any) -> Any:
+    """Run ``func`` in the shared process pool and return the result."""
+    loop = asyncio.get_running_loop()
+    return await loop.run_in_executor(get_cpu_pool(), func, *args)
+
+
+def shutdown_cpu_pool() -> None:
+    """Clean up the global process pool."""
+    global _CPU_POOL
+    if _CPU_POOL is not None:
+        _CPU_POOL.shutdown()
+        _CPU_POOL = None
+
+
+__all__ = ["get_cpu_pool", "run_cpu_bound", "shutdown_cpu_pool"]

--- a/src/piwardrive/performance.py
+++ b/src/piwardrive/performance.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import time
+from collections import defaultdict
+from contextlib import contextmanager
+from typing import Dict, List
+
+_METRICS: Dict[str, List[float]] = defaultdict(list)
+
+
+@contextmanager
+def record(name: str) -> None:
+    """Context manager recording execution time under ``name``."""
+    start = time.perf_counter()
+    try:
+        yield
+    finally:
+        _METRICS[name].append(time.perf_counter() - start)
+
+
+def get_metrics() -> Dict[str, Dict[str, float]]:
+    """Return average duration metrics."""
+    result: Dict[str, Dict[str, float]] = {}
+    for key, values in _METRICS.items():
+        count = len(values)
+        avg = sum(values) / count if count else 0.0
+        result[key] = {"count": count, "avg": avg}
+    return result
+
+
+def clear() -> None:
+    _METRICS.clear()
+
+
+__all__ = ["record", "get_metrics", "clear"]

--- a/src/piwardrive/service.py
+++ b/src/piwardrive/service.py
@@ -11,8 +11,9 @@ from dataclasses import asdict
 from http import HTTPStatus
 from typing import TYPE_CHECKING
 
-from piwardrive.logging import init_logging
 from starlette.middleware.base import BaseHTTPMiddleware
+
+from piwardrive.logging import init_logging
 
 try:  # pragma: no cover - optional FastAPI dependency
     from fastapi import (
@@ -158,10 +159,11 @@ except Exception:  # pragma: no cover - fall back to real module
 
 try:  # allow tests to stub out analytics
     from analytics.baseline import analyze_health_baseline  # type: ignore
-    from analytics.baseline import load_baseline_health
+    from analytics.baseline import analyze_health_baseline_async, load_baseline_health
 except Exception:  # pragma: no cover - fall back to real module
     from piwardrive.analytics.baseline import (
         analyze_health_baseline,
+        analyze_health_baseline_async,
         load_baseline_health,
     )
 
@@ -714,7 +716,7 @@ async def baseline_analysis_endpoint(
     baseline = load_baseline_health(days, limit)
     if inspect.isawaitable(baseline):
         baseline = await baseline
-    return analyze_health_baseline(recent, baseline, threshold)
+    return await analyze_health_baseline_async(recent, baseline, threshold)
 
 
 async def _collect_widget_metrics() -> WidgetMetrics:

--- a/src/piwardrive/task_queue.py
+++ b/src/piwardrive/task_queue.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import asyncio
 import logging
 from typing import Any, Awaitable, Callable
@@ -41,3 +43,47 @@ class BackgroundTaskQueue:
     def enqueue(self, func: Callable[[], Awaitable[Any]]) -> None:
         """Queue ``func`` to be executed by a worker."""
         self._queue.put_nowait(func)
+
+
+class PriorityTaskQueue:
+    """Worker pool processing jobs based on priority."""
+
+    def __init__(self, workers: int = 1) -> None:
+        self._queue: asyncio.PriorityQueue[tuple[int, Callable[[], Awaitable[Any]]]] = (
+            asyncio.PriorityQueue()
+        )
+        self._tasks: list[asyncio.Task[None]] = []
+        self._running = False
+        self.workers = workers
+
+    async def _worker(self) -> None:
+        while self._running:
+            priority, job = await self._queue.get()
+            try:
+                await job()
+            except Exception as exc:  # pragma: no cover - background errors
+                logging.exception("Background task failed: %s", exc)
+            finally:
+                self._queue.task_done()
+
+    async def start(self) -> None:
+        if self._running:
+            return
+        self._running = True
+        for _ in range(self.workers):
+            self._tasks.append(asyncio.create_task(self._worker()))
+
+    async def stop(self) -> None:
+        self._running = False
+        await self._queue.join()
+        for task in self._tasks:
+            task.cancel()
+        if self._tasks:
+            await asyncio.gather(*self._tasks, return_exceptions=True)
+        self._tasks.clear()
+
+    def enqueue(self, func: Callable[[], Awaitable[Any]], priority: int = 0) -> None:
+        self._queue.put_nowait((priority, func))
+
+
+__all__ = ["BackgroundTaskQueue", "PriorityTaskQueue"]

--- a/tests/test_circuit_breaker.py
+++ b/tests/test_circuit_breaker.py
@@ -1,0 +1,25 @@
+import asyncio
+
+import pytest
+
+from piwardrive.circuit_breaker import CircuitBreaker
+
+
+@pytest.mark.asyncio
+async def test_circuit_breaker() -> None:
+    cb = CircuitBreaker(max_failures=2, reset_timeout=0.1)
+
+    async def fail() -> None:
+        raise ValueError("boom")
+
+    async def ok() -> str:
+        return "ok"
+
+    with pytest.raises(ValueError):
+        await cb.call(fail)
+    with pytest.raises(ValueError):
+        await cb.call(fail)
+    with pytest.raises(RuntimeError):
+        await cb.call(ok)
+    await asyncio.sleep(0.11)
+    assert await cb.call(ok) == "ok"

--- a/tests/test_cpu_pool.py
+++ b/tests/test_cpu_pool.py
@@ -1,0 +1,15 @@
+import asyncio
+
+import pytest
+
+from piwardrive.cpu_pool import run_cpu_bound
+
+
+def _square(x: int) -> int:
+    return x * x
+
+
+@pytest.mark.asyncio
+async def test_run_cpu_bound() -> None:
+    result = await run_cpu_bound(_square, 5)
+    assert result == 25

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -1,0 +1,9 @@
+from piwardrive import performance
+
+
+def test_record_metrics() -> None:
+    performance.clear()
+    with performance.record("a"):
+        pass
+    metrics = performance.get_metrics()
+    assert metrics["a"]["count"] == 1

--- a/tests/test_priority_queue.py
+++ b/tests/test_priority_queue.py
@@ -1,0 +1,21 @@
+import asyncio
+
+import pytest
+
+from piwardrive.task_queue import PriorityTaskQueue
+
+
+@pytest.mark.asyncio
+async def test_priority_order() -> None:
+    q = PriorityTaskQueue(workers=1)
+    results: list[int] = []
+
+    async def make_task(val: int) -> None:
+        results.append(val)
+
+    await q.start()
+    q.enqueue(lambda: make_task(1), priority=1)
+    q.enqueue(lambda: make_task(0), priority=0)
+    await asyncio.sleep(0.1)
+    await q.stop()
+    assert results == [0, 1]


### PR DESCRIPTION
## Summary
- add ProcessPool executor helpers for CPU-bound tasks
- add RedisCache wrapper
- add PriorityTaskQueue and performance metrics helpers
- expose new modules at package init
- add async baseline analysis endpoint
- provide async performance docs
- test new utilities

## Testing
- `pre-commit run --files docs/async_performance.md src/piwardrive/__init__.py src/piwardrive/analytics/baseline.py src/piwardrive/service.py src/piwardrive/task_queue.py src/piwardrive/cache.py src/piwardrive/circuit_breaker.py src/piwardrive/cpu_pool.py src/piwardrive/performance.py tests/test_circuit_breaker.py tests/test_cpu_pool.py tests/test_performance.py tests/test_priority_queue.py --skip flake8 --skip mypy --skip bandit --skip npm-lint --skip npm-test --skip pytest`
- `pytest tests/test_cpu_pool.py tests/test_priority_queue.py tests/test_circuit_breaker.py tests/test_performance.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68670692e6788333a664d68608f384c3