### PR TITLE
Implement pooled DB adapters with monitoring

### DIFF
--- a/docs/db_migration.md
+++ b/docs/db_migration.md
@@ -3,6 +3,14 @@
 The new persistence layer introduces connection pooling and optional sharding.
 Existing databases remain compatible.
 
+## Connection Pool Migration
+
+`DatabaseManager` now manages pooled adapters for SQLite, PostgreSQL and MySQL.
+Existing code using the old single-connection pattern should simply call
+``DatabaseManager.connect()`` once during startup and ``close()`` on shutdown.
+Adapters will handle connection reuse transparently. Metrics are available via
+``DatabaseManager.get_metrics()`` for monitoring pool health.
+
 ## Migrating Existing Installations
 
 1. Stop all running PiWardrive services to flush buffers:

--- a/src/piwardrive/db/adapter.py
+++ b/src/piwardrive/db/adapter.py
@@ -24,3 +24,7 @@ class DatabaseAdapter:
     async def transaction(self) -> AsyncIterator[None]:
         """Context manager for transactions."""
         raise NotImplementedError
+
+    def get_metrics(self) -> dict[str, int]:
+        """Return connection metrics if available."""
+        return {}

--- a/src/piwardrive/db/manager.py
+++ b/src/piwardrive/db/manager.py
@@ -2,36 +2,64 @@ from __future__ import annotations
 
 import asyncio
 from contextlib import asynccontextmanager
-from typing import AsyncIterator, Dict
+from typing import AsyncIterator, Dict, Callable
+
+from ..resource_manager import ResourceManager
 
 from .adapter import DatabaseAdapter
 
 
 class DatabaseManager:
-    """Manage adapters with optional distributed locking."""
+    """Manage one or more adapters with optional distributed locking."""
 
-    def __init__(self, adapter: DatabaseAdapter) -> None:
-        self.adapter = adapter
+    def __init__(
+        self,
+        adapter: DatabaseAdapter | dict[str, DatabaseAdapter],
+        *,
+        shard_func: Callable[[str], str] | None = None,
+        resource_manager: ResourceManager | None = None,
+    ) -> None:
+        if isinstance(adapter, dict):
+            self.adapters = adapter
+        else:
+            self.adapters = {"default": adapter}
+        self._shard_func = shard_func or (lambda key: "default")
         self._lock = asyncio.Lock()
+        self._rm = resource_manager
+        if self._rm is not None:
+            self._rm.register(self, lambda: asyncio.run(self.close()))
 
     async def connect(self) -> None:
-        await self.adapter.connect()
+        for adapter in self.adapters.values():
+            await adapter.connect()
 
     async def close(self) -> None:
-        await self.adapter.close()
+        for adapter in self.adapters.values():
+            await adapter.close()
 
     @asynccontextmanager
-    async def distributed_lock(self) -> AsyncIterator[None]:
+    async def distributed_lock(self, key: str | None = None) -> AsyncIterator[None]:
         """Simple async lock for critical sections."""
         async with self._lock:
-            async with self.adapter.transaction():
+            async with self._get_adapter(key).transaction():
                 yield None
 
-    async def execute(self, query: str, *args) -> None:
-        await self.adapter.execute(query, *args)
+    def _get_adapter(self, key: str | None = None) -> DatabaseAdapter:
+        if len(self.adapters) == 1:
+            return next(iter(self.adapters.values()))
+        if key is None:
+            raise ValueError("key required for sharded manager")
+        shard = self._shard_func(key)
+        return self.adapters[shard]
 
-    async def executemany(self, query: str, args_iter) -> None:
-        await self.adapter.executemany(query, args_iter)
+    async def execute(self, query: str, *args, key: str | None = None) -> None:
+        await self._get_adapter(key).execute(query, *args)
 
-    async def fetchall(self, query: str, *args) -> list[Dict]:
-        return await self.adapter.fetchall(query, *args)
+    async def executemany(self, query: str, args_iter, key: str | None = None) -> None:
+        await self._get_adapter(key).executemany(query, args_iter)
+
+    async def fetchall(self, query: str, *args, key: str | None = None) -> list[Dict]:
+        return await self._get_adapter(key).fetchall(query, *args)
+
+    def get_metrics(self) -> dict[str, Dict[str, int]]:
+        return {name: adapter.get_metrics() for name, adapter in self.adapters.items()}

--- a/src/piwardrive/db/mysql.py
+++ b/src/piwardrive/db/mysql.py
@@ -11,14 +11,28 @@ from .adapter import DatabaseAdapter
 class MySQLAdapter(DatabaseAdapter):
     """MySQL backend using aiomysql connection pooling."""
 
-    def __init__(self, dsn: str, pool_size: int = 10) -> None:
+    def __init__(
+        self,
+        dsn: str,
+        *,
+        min_size: int = 1,
+        max_size: int = 10,
+        connect_timeout: float = 10.0,
+    ) -> None:
         self.dsn = dsn
-        self.pool_size = pool_size
+        self.min_size = min_size
+        self.max_size = max_size
+        self.connect_timeout = connect_timeout
         self.pool: aiomysql.Pool | None = None
+        self.metrics = {"acquired": 0, "released": 0, "failed": 0}
 
     async def connect(self) -> None:
         self.pool = await aiomysql.create_pool(
-            self.dsn, minsize=1, maxsize=self.pool_size, autocommit=True
+            self.dsn,
+            minsize=self.min_size,
+            maxsize=self.max_size,
+            autocommit=True,
+            connect_timeout=self.connect_timeout,
         )
 
     async def close(self) -> None:
@@ -27,35 +41,57 @@ class MySQLAdapter(DatabaseAdapter):
             await self.pool.wait_closed()
             self.pool = None
 
-    async def execute(self, query: str, *args: Any) -> None:
+    async def _acquire(self) -> aiomysql.Connection:
         assert self.pool
-        async with self.pool.acquire() as conn:
+        conn = await self.pool.acquire()
+        try:
             async with conn.cursor() as cur:
-                await cur.execute(query, args)
+                await cur.execute("SELECT 1")
+        except Exception:
+            self.metrics["failed"] += 1
+            await conn.ensure_closed()
+            conn = await self.pool.acquire()
+        self.metrics["acquired"] += 1
+        return conn
+
+    async def _release(self, conn: aiomysql.Connection) -> None:
+        assert self.pool
+        self.pool.release(conn)
+        self.metrics["released"] += 1
+
+    async def execute(self, query: str, *args: Any) -> None:
+        conn = await self._acquire()
+        async with conn.cursor() as cur:
+            await cur.execute(query, args)
+        await self._release(conn)
 
     async def executemany(self, query: str, args_iter: Iterable[Iterable[Any]]) -> None:
-        assert self.pool
-        async with self.pool.acquire() as conn:
-            async with conn.cursor() as cur:
-                await cur.executemany(query, list(args_iter))
+        conn = await self._acquire()
+        async with conn.cursor() as cur:
+            await cur.executemany(query, list(args_iter))
+        await self._release(conn)
 
     async def fetchall(self, query: str, *args: Any) -> list[dict[str, Any]]:
-        assert self.pool
-        async with self.pool.acquire() as conn:
-            async with conn.cursor(aiomysql.DictCursor) as cur:
-                await cur.execute(query, args)
-                return list(await cur.fetchall())
+        conn = await self._acquire()
+        async with conn.cursor(aiomysql.DictCursor) as cur:
+            await cur.execute(query, args)
+            rows = list(await cur.fetchall())
+        await self._release(conn)
+        return rows
 
     @asynccontextmanager
     async def transaction(self) -> AsyncIterator[None]:
-        assert self.pool
-        async with self.pool.acquire() as conn:
-            async with conn.cursor() as cur:
-                await cur.execute("START TRANSACTION")
-                try:
-                    yield None
-                except Exception:
-                    await conn.rollback()
-                    raise
-                else:
-                    await conn.commit()
+        conn = await self._acquire()
+        async with conn.cursor() as cur:
+            await cur.execute("START TRANSACTION")
+            try:
+                yield None
+            except Exception:
+                await conn.rollback()
+                raise
+            else:
+                await conn.commit()
+        await self._release(conn)
+
+    def get_metrics(self) -> dict[str, int]:
+        return dict(self.metrics)

--- a/src/piwardrive/db/postgres.py
+++ b/src/piwardrive/db/postgres.py
@@ -12,22 +12,37 @@ class PostgresAdapter(DatabaseAdapter):
     """PostgreSQL backend using asyncpg connection pooling."""
 
     def __init__(
-        self, dsn: str, read_replicas: list[str] | None = None, pool_size: int = 10
+        self,
+        dsn: str,
+        read_replicas: list[str] | None = None,
+        *,
+        min_size: int = 1,
+        max_size: int = 10,
+        timeout: float = 60.0,
     ) -> None:
         self.dsn = dsn
         self.read_replicas = read_replicas or []
-        self.pool_size = pool_size
+        self.min_size = min_size
+        self.max_size = max_size
+        self.timeout = timeout
         self.pool: asyncpg.Pool | None = None
         self._rr_index = 0
         self.replica_pools: list[asyncpg.Pool] = []
+        self.metrics = {"acquired": 0, "released": 0, "failed": 0}
 
     async def connect(self) -> None:
         self.pool = await asyncpg.create_pool(
-            self.dsn, min_size=1, max_size=self.pool_size
+            self.dsn,
+            min_size=self.min_size,
+            max_size=self.max_size,
+            timeout=self.timeout,
         )
         for replica in self.read_replicas:
             pool = await asyncpg.create_pool(
-                replica, min_size=1, max_size=self.pool_size
+                replica,
+                min_size=self.min_size,
+                max_size=self.max_size,
+                timeout=self.timeout,
             )
             self.replica_pools.append(pool)
 
@@ -47,30 +62,51 @@ class PostgresAdapter(DatabaseAdapter):
         self._rr_index = (self._rr_index + 1) % len(self.replica_pools)
         return pool
 
+    async def _acquire(self, *, read: bool = False) -> tuple[asyncpg.Connection, asyncpg.Pool]:
+        pool = await self._get_read_pool() if read else self.pool
+        assert pool
+        conn = await pool.acquire()
+        try:
+            await conn.execute("SELECT 1")
+        except Exception:
+            self.metrics["failed"] += 1
+            await conn.close()
+            conn = await pool.acquire()
+        self.metrics["acquired"] += 1
+        return conn, pool
+
+    async def _release(self, pool: asyncpg.Pool, conn: asyncpg.Connection) -> None:
+        await pool.release(conn)
+        self.metrics["released"] += 1
+
     async def execute(self, query: str, *args: Any) -> None:
-        assert self.pool
-        async with self.pool.acquire() as conn:
-            await conn.execute(query, *args)
+        conn, pool = await self._acquire()
+        await conn.execute(query, *args)
+        await self._release(pool, conn)
 
     async def executemany(self, query: str, args_iter: Iterable[Iterable[Any]]) -> None:
-        assert self.pool
-        async with self.pool.acquire() as conn:
-            await conn.executemany(query, list(args_iter))
+        conn, pool = await self._acquire()
+        await conn.executemany(query, list(args_iter))
+        await self._release(pool, conn)
 
     async def fetchall(self, query: str, *args: Any) -> list[dict[str, Any]]:
-        pool = await self._get_read_pool()
-        async with pool.acquire() as conn:
-            rows = await conn.fetch(query, *args)
+        conn, pool = await self._acquire(read=True)
+        rows = await conn.fetch(query, *args)
+        await self._release(pool, conn)
         return [dict(row) for row in rows]
 
     @asynccontextmanager
     async def transaction(self) -> AsyncIterator[None]:
-        assert self.pool
-        async with self.pool.acquire() as conn:
-            async with conn.transaction():
-                await conn.execute("SELECT pg_advisory_xact_lock(1)")
-                try:
-                    yield None
-                finally:
-                    # lock released automatically at transaction end
-                    pass
+        conn, pool = await self._acquire()
+        async with conn.transaction(isolation="repeatable_read"):
+            await conn.execute("SELECT pg_advisory_xact_lock(1)")
+            try:
+                yield None
+            except asyncpg.DeadlockDetectedError:
+                await conn.execute("ROLLBACK")
+                self.metrics["failed"] += 1
+                raise
+        await self._release(pool, conn)
+
+    def get_metrics(self) -> dict[str, int]:
+        return dict(self.metrics)

--- a/src/piwardrive/db/sqlite.py
+++ b/src/piwardrive/db/sqlite.py
@@ -2,50 +2,122 @@ from __future__ import annotations
 
 from typing import Any, AsyncIterator, Iterable
 
+import asyncio
+
 import aiosqlite
 
 from .adapter import DatabaseAdapter
 
 
 class SQLiteAdapter(DatabaseAdapter):
-    """SQLite backend using aiosqlite."""
+    """SQLite backend using aiosqlite with connection pooling."""
 
-    def __init__(self, path: str) -> None:
+    def __init__(
+        self,
+        path: str,
+        *,
+        pool_size: int = 5,
+        read_replicas: list[str] | None = None,
+    ) -> None:
         self.path = path
-        self.conn: aiosqlite.Connection | None = None
+        self.pool_size = pool_size
+        self.read_replicas = read_replicas or []
+        self.pool: asyncio.Queue[aiosqlite.Connection] | None = None
+        self.replica_pools: list[asyncio.Queue[aiosqlite.Connection]] = []
+        self._rr_index = 0
+        self.metrics = {"acquired": 0, "released": 0}
+
+    async def _create_conn(self, path: str, *, readonly: bool = False) -> aiosqlite.Connection:
+        if readonly:
+            conn = await aiosqlite.connect(f"file:{path}?mode=ro", uri=True)
+        else:
+            conn = await aiosqlite.connect(path)
+        pragmas = {
+            "journal_mode": "WAL",
+            "synchronous": "NORMAL",
+            "temp_store": "MEMORY",
+            "cache_size": 10000,
+        }
+        for k, v in pragmas.items():
+            await conn.execute(f"PRAGMA {k}={v}")
+        conn.row_factory = aiosqlite.Row
+        return conn
 
     async def connect(self) -> None:
-        self.conn = await aiosqlite.connect(self.path)
-        self.conn.row_factory = aiosqlite.Row
+        self.pool = asyncio.Queue(maxsize=self.pool_size)
+        for _ in range(self.pool_size):
+            conn = await self._create_conn(self.path)
+            await self.pool.put(conn)
+        for replica in self.read_replicas:
+            rp = asyncio.Queue(maxsize=self.pool_size)
+            for _ in range(self.pool_size):
+                conn = await self._create_conn(replica, readonly=True)
+                await rp.put(conn)
+            self.replica_pools.append(rp)
+
+    async def _close_pool(self, pool: asyncio.Queue[aiosqlite.Connection]) -> None:
+        while not pool.empty():
+            conn = await pool.get()
+            await conn.close()
 
     async def close(self) -> None:
-        if self.conn:
-            await self.conn.close()
-            self.conn = None
+        if self.pool:
+            await self._close_pool(self.pool)
+            self.pool = None
+        for rp in self.replica_pools:
+            await self._close_pool(rp)
+        self.replica_pools.clear()
+
+    async def _acquire(self, *, read: bool = False) -> tuple[aiosqlite.Connection, asyncio.Queue[aiosqlite.Connection]]:
+        if read and self.replica_pools:
+            pool = self.replica_pools[self._rr_index]
+            self._rr_index = (self._rr_index + 1) % len(self.replica_pools)
+        else:
+            assert self.pool
+            pool = self.pool
+        conn = await pool.get()
+        try:
+            await conn.execute("SELECT 1")
+        except Exception:
+            path = self.path if not read else self.read_replicas[self._rr_index - 1]
+            conn = await self._create_conn(path, readonly=read)
+        self.metrics["acquired"] += 1
+        return conn, pool
+
+    async def _release(self, pool: asyncio.Queue[aiosqlite.Connection], conn: aiosqlite.Connection) -> None:
+        await pool.put(conn)
+        self.metrics["released"] += 1
 
     async def execute(self, query: str, *args: Any) -> None:
-        assert self.conn
-        await self.conn.execute(query, args)
-        await self.conn.commit()
+        conn, pool = await self._acquire()
+        await conn.execute(query, args)
+        await conn.commit()
+        await self._release(pool, conn)
 
     async def executemany(self, query: str, args_iter: Iterable[Iterable[Any]]) -> None:
-        assert self.conn
-        await self.conn.executemany(query, args_iter)
-        await self.conn.commit()
+        conn, pool = await self._acquire()
+        await conn.executemany(query, list(args_iter))
+        await conn.commit()
+        await self._release(pool, conn)
 
     async def fetchall(self, query: str, *args: Any) -> list[dict[str, Any]]:
-        assert self.conn
-        cur = await self.conn.execute(query, args)
+        conn, pool = await self._acquire(read=True)
+        cur = await conn.execute(query, args)
         rows = await cur.fetchall()
+        await self._release(pool, conn)
         return [dict(row) for row in rows]
 
     async def transaction(self) -> AsyncIterator[None]:
-        assert self.conn
-        async with self.conn.execute("BEGIN"):
+        conn, pool = await self._acquire()
+        async with conn.execute("BEGIN"):
             try:
                 yield None
             except Exception:
-                await self.conn.rollback()
+                await conn.rollback()
                 raise
             else:
-                await self.conn.commit()
+                await conn.commit()
+        await self._release(pool, conn)
+
+    def get_metrics(self) -> dict[str, int]:
+        return dict(self.metrics)


### PR DESCRIPTION
## Summary
- expand DatabaseAdapter interface with `get_metrics`
- implement async connection pooling for SQLite, MySQL and PostgreSQL
- add shard-aware DatabaseManager with metrics and resource cleanup
- document migration to pooled adapters

## Testing
- `pytest tests/test_resource_manager.py::test_file_and_db_cleanup -q`
- `pytest tests/test_resource_manager.py::test_task_cancel -q`
- `pytest tests/test_database_counts.py::test_get_table_counts -q`
- `pytest tests/test_remote_sync_pkg.py::test_sync_database_retry -q`


------
https://chatgpt.com/codex/tasks/task_e_68672454a2f48333a749a2cfb6d51d30