### PR TITLE
Enforce security scanning

### DIFF
--- a/.github/ISSUE_TEMPLATE/security_issue.md
+++ b/.github/ISSUE_TEMPLATE/security_issue.md
@@ -1,0 +1,20 @@
+---
+name: "Security Issue"
+about: Report a security vulnerability
+labels: security
+---
+
+**Description**
+A clear and concise description of the vulnerability.
+
+**Steps to Reproduce**
+
+1. Go to '...'
+2. Run '...'
+3. Observe '...'
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Additional context**
+Add any other context or screenshots about the security issue.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+    - package-ecosystem: "pip"
+      directory: "/"
+      schedule:
+          interval: "weekly"
+      open-pull-requests-limit: 5
+      assignees:
+          - "${{ github.repository_owner }}"
+    - package-ecosystem: "github-actions"
+      directory: "/"
+      schedule:
+          interval: "weekly"

--- a/.github/workflows/dependency-update.yml
+++ b/.github/workflows/dependency-update.yml
@@ -1,0 +1,33 @@
+name: Dependency Updates
+
+on:
+    schedule:
+        - cron: "0 5 * * 1"
+    workflow_dispatch:
+
+jobs:
+    update:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+            - uses: actions/setup-python@v5
+              with:
+                  python-version: "3.12"
+                  cache: "pip"
+            - name: Upgrade packages
+              run: |
+                  pip install -r requirements.txt -r requirements-dev.txt
+                  pip list --outdated --format=freeze | cut -d= -f1 | xargs -n1 pip install -U
+                  pip freeze > requirements.txt
+                  pip freeze > requirements-dev.txt
+            - name: Run tests
+              run: |
+                  pip install -r requirements.txt
+                  pip install -r requirements-dev.txt
+                  pytest -q
+            - name: Create Pull Request
+              uses: peter-evans/create-pull-request@v6
+              with:
+                  commit-message: "chore: update dependencies"
+                  title: "chore: automated dependency update"
+                  body: "Automated dependency updates with successful test run."

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -19,8 +19,26 @@ jobs:
                   pip install -r requirements.txt
                   pip install -r requirements-dev.txt
             - name: Run bandit
-              run: bandit -r src || true
+              run: bandit -r src --severity-level medium -f sarif -o bandit.sarif
+
             - name: Run pip-audit
-              run: pip-audit -r requirements.txt || true
+              run: pip-audit -r requirements.txt -f sarif -o pip_audit.sarif
+
             - name: Run safety
-              run: safety check -r requirements.txt || true
+              run: safety check -r requirements.txt --json > safety.json
+
+            - name: Upload Bandit results
+              uses: github/codeql-action/upload-sarif@v3
+              with:
+                  sarif_file: bandit.sarif
+
+            - name: Upload pip-audit results
+              uses: github/codeql-action/upload-sarif@v3
+              with:
+                  sarif_file: pip_audit.sarif
+
+            - name: Upload safety report
+              uses: actions/upload-artifact@v4
+              with:
+                  name: safety-report
+                  path: safety.json

--- a/README.md
+++ b/README.md
@@ -686,6 +686,14 @@ docker compose run --rm tests
 The Makefile's `coverage` target also runs `pytest` and `npm test` when
 generating coverage reports.
 
+## Security Compliance
+
+All pull requests trigger the [Security Scan](.github/workflows/security.yml)
+workflow which runs Bandit, pip-audit and Safety. Results are uploaded in
+SARIF or JSON format and critical findings block the merge. Weekly scans and
+automated dependency updates keep the project in line with the
+[security compliance](docs/security_compliance.md) policy.
+
 ## Legal Notice
 
 Ensure all wireless and Bluetooth scans comply with local laws and have proper authorization. The authors are not responsible for misuse of this software.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,7 @@
+# Reporting Security Issues
+
+If you discover a vulnerability in this project please open a new issue using the **Security Issue** template. Provide as much detail as possible so the maintainers can reproduce the problem.
+
+The team monitors the security workflow and Dependabot alerts. Critical issues are prioritized immediately and patches will be released as soon as possible.
+
+See [docs/security_compliance.md](docs/security_compliance.md) for our security baseline.

--- a/docs/security_compliance.md
+++ b/docs/security_compliance.md
@@ -1,0 +1,18 @@
+# Security Compliance
+
+This document describes the security standards enforced in the PiWardrive project.
+
+## Baseline
+
+-   All source code is scanned on every pull request using Bandit, pip-audit and Safety.
+-   Dependency updates are automated via Dependabot.
+-   Security scan results are uploaded in SARIF/JSON format for analysis in the GitHub Security tab.
+-   Critical vulnerabilities block merges until resolved.
+
+## Continuous Monitoring
+
+Scheduled scans run weekly and generate historical reports. These reports are kept in the Security tab and as build artifacts.
+
+## Incident Response
+
+Security issues should be reported via the `Security Issue` template. The maintainers will triage and address issues according to severity.

--- a/docs/security_incident_response.md
+++ b/docs/security_incident_response.md
@@ -1,0 +1,7 @@
+# Security Incident Response
+
+1. **Report**: Use the [Security Issue](../.github/ISSUE_TEMPLATE/security_issue.md) template to disclose vulnerabilities.
+2. **Triage**: Maintainers label the issue with a severity level.
+3. **Fix**: A remediation branch is created and security tests are executed.
+4. **Release**: Patches are merged and released after passing all CI checks.
+5. **Notify**: A summary of the incident is added to the release notes.


### PR DESCRIPTION
## Summary
- enforce all security scan steps
- capture Bandit and pip-audit results as SARIF
- track safety results as artifacts
- add dependabot for updates
- introduce automated dependency update workflow
- document security compliance and incident response
- add SECURITY.md and issue template
- document security workflow in README

## Testing
- `pre-commit run --files .github/workflows/security.yml .github/dependabot.yml .github/workflows/dependency-update.yml docs/security_compliance.md docs/security_incident_response.md SECURITY.md .github/ISSUE_TEMPLATE/security_issue.md README.md`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'boto3')*

------
https://chatgpt.com/codex/tasks/task_e_686724696fac83339cdde63e439f86c9