### PR TITLE
Add production orchestration configs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+__pycache__
+*.pyc
+*.pyo
+*.pyd
+.Python
+env/
+build/
+dist/
+.git
+.gitignore
+docker-compose*
+benchmarks/
+examples/
+docs/
+tests/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,34 @@
-FROM python:3.12-slim
+# syntax=docker/dockerfile:1
 
-WORKDIR /app
+FROM python:3.12-slim AS build
+WORKDIR /build
+
+# Install build tools and node for frontend
+RUN apt-get update \ 
+    && apt-get install -y --no-install-recommends \
+        build-essential libdbus-1-dev libglib2.0-dev nodejs npm git \ 
+    && rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt requirements-dev.txt ./
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
-        build-essential libdbus-1-dev libglib2.0-dev \
-        nodejs npm \
-    && rm -rf /var/lib/apt/lists/* \
-    && pip install --no-cache-dir -r requirements.txt -r requirements-dev.txt
+RUN pip install --prefix=/install --no-cache-dir -r requirements.txt
 
 COPY . .
-RUN pip install --no-cache-dir -e .
+RUN pip install --prefix=/install --no-cache-dir -e .
+RUN cd webui && npm ci && npm run build
 
-# Build the React frontend
-RUN cd webui && npm ci && npm run build && cd ..
+FROM python:3.12-slim
+WORKDIR /app
+
+COPY --from=build /install /usr/local
+COPY --from=build /build/webui/dist ./webui/dist
+COPY --from=build /build/src ./src
+COPY --from=build /build/server ./server
+COPY --from=build /build/main.py ./
+
+RUN apt-get update \ 
+    && apt-get install -y --no-install-recommends libdbus-1-3 libglib2.0-0 \ 
+    && rm -rf /var/lib/apt/lists/*
+
+HEALTHCHECK CMD python -m piwardrive.scripts.health_export --check || exit 1
+
 CMD ["piwardrive-webui"]
-

--- a/deploy/charts/piwardrive/Chart.yaml
+++ b/deploy/charts/piwardrive/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: piwardrive
+version: 0.1.0
+appVersion: "1.0"
+description: Helm chart for deploying PiWardrive

--- a/deploy/charts/piwardrive/templates/_helpers.tpl
+++ b/deploy/charts/piwardrive/templates/_helpers.tpl
@@ -1,0 +1,7 @@
+{{- define "piwardrive.name" -}}
+piwardrive
+{{- end -}}
+
+{{- define "piwardrive.fullname" -}}
+{{ include "piwardrive.name" . }}
+{{- end -}}

--- a/deploy/charts/piwardrive/templates/deployment.yaml
+++ b/deploy/charts/piwardrive/templates/deployment.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "piwardrive.fullname" . }}
+  labels:
+    app: {{ include "piwardrive.name" . }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ include "piwardrive.name" . }}
+  template:
+    metadata:
+      labels:
+        app: {{ include "piwardrive.name" . }}
+    spec:
+      containers:
+        - name: piwardrive
+          image: {{ .Values.image }}
+          ports:
+            - containerPort: 8000

--- a/deploy/charts/piwardrive/templates/hpa.yaml
+++ b/deploy/charts/piwardrive/templates/hpa.yaml
@@ -1,0 +1,18 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "piwardrive.fullname" . }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "piwardrive.fullname" . }}
+  minReplicas: 1
+  maxReplicas: 5
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 80

--- a/deploy/charts/piwardrive/templates/ingress.yaml
+++ b/deploy/charts/piwardrive/templates/ingress.yaml
@@ -1,0 +1,15 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "piwardrive.fullname" . }}
+spec:
+  rules:
+    - http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "piwardrive.fullname" . }}
+                port:
+                  number: {{ .Values.service.port }}

--- a/deploy/charts/piwardrive/templates/service.yaml
+++ b/deploy/charts/piwardrive/templates/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "piwardrive.fullname" . }}
+  labels:
+    app: {{ include "piwardrive.name" . }}
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+    app: {{ include "piwardrive.name" . }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: 8000

--- a/deploy/charts/piwardrive/values.yaml
+++ b/deploy/charts/piwardrive/values.yaml
@@ -1,0 +1,8 @@
+image: piwardrive/prod
+replicaCount: 1
+
+service:
+  type: ClusterIP
+  port: 80
+
+resources: {}

--- a/deploy/config/.env.production.example
+++ b/deploy/config/.env.production.example
@@ -1,0 +1,2 @@
+PIWARDRIVE_ENV=production
+DB_PASSWORD=changeme

--- a/deploy/config/nginx.conf
+++ b/deploy/config/nginx.conf
@@ -1,0 +1,19 @@
+worker_processes 1;
+
+events { worker_connections 1024; }
+
+http {
+    server {
+        listen 80;
+        listen 443 ssl;
+        ssl_certificate /etc/nginx/ssl/cert.pem;
+        ssl_certificate_key /etc/nginx/ssl/key.pem;
+
+        location / {
+            proxy_pass http://piwardrive:8000;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+    }
+}

--- a/deploy/config/prometheus.yml
+++ b/deploy/config/prometheus.yml
@@ -1,0 +1,7 @@
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: 'piwardrive'
+    static_configs:
+      - targets: ['piwardrive:8000']

--- a/deploy/docker-compose.production.yml
+++ b/deploy/docker-compose.production.yml
@@ -1,0 +1,87 @@
+version: "3.9"
+
+services:
+  piwardrive:
+    build: ..
+    image: piwardrive/prod
+    restart: always
+    environment:
+      - PIWARDRIVE_ENV=production
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/api/v1/system/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+    depends_on:
+      - postgres
+      - redis
+    volumes:
+      - piwardrive_data:/data
+      - piwardrive_logs:/var/log/piwardrive
+    networks:
+      - internal
+
+  postgres:
+    image: postgres:16-alpine
+    restart: always
+    environment:
+      - POSTGRES_DB=piwardrive
+      - POSTGRES_USER=piwardrive
+      - POSTGRES_PASSWORD=${DB_PASSWORD}
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    networks:
+      - internal
+
+  redis:
+    image: redis:7-alpine
+    restart: always
+    command: redis-server --appendonly yes
+    volumes:
+      - redis_data:/data
+    networks:
+      - internal
+
+  prometheus:
+    image: prom/prometheus
+    volumes:
+      - ./config/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+    networks:
+      - internal
+    ports:
+      - "9090:9090"
+
+  grafana:
+    image: grafana/grafana
+    depends_on:
+      - prometheus
+    networks:
+      - internal
+    ports:
+      - "3000:3000"
+    volumes:
+      - grafana_data:/var/lib/grafana
+
+  nginx:
+    image: nginx:alpine
+    restart: always
+    depends_on:
+      - piwardrive
+    volumes:
+      - ./config/nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./ssl:/etc/nginx/ssl:ro
+    ports:
+      - "80:80"
+      - "443:443"
+    networks:
+      - internal
+
+volumes:
+  postgres_data:
+  redis_data:
+  grafana_data:
+  piwardrive_data:
+  piwardrive_logs:
+
+networks:
+  internal:

--- a/deploy/k8s/grafana.yaml
+++ b/deploy/k8s/grafana.yaml
@@ -1,0 +1,32 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: grafana
+  namespace: piwardrive
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: grafana
+  template:
+    metadata:
+      labels:
+        app: grafana
+    spec:
+      containers:
+        - name: grafana
+          image: grafana/grafana
+          ports:
+            - containerPort: 3000
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: grafana
+  namespace: piwardrive
+spec:
+  selector:
+    app: grafana
+  ports:
+    - port: 3000
+      targetPort: 3000

--- a/deploy/k8s/nginx.yaml
+++ b/deploy/k8s/nginx.yaml
@@ -1,0 +1,84 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx
+  namespace: piwardrive
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:alpine
+          ports:
+            - containerPort: 80
+            - containerPort: 443
+          volumeMounts:
+            - name: nginx-conf
+              mountPath: /etc/nginx/nginx.conf
+              subPath: nginx.conf
+            - name: ssl
+              mountPath: /etc/nginx/ssl
+      volumes:
+        - name: nginx-conf
+          configMap:
+            name: nginx-config
+        - name: ssl
+          secret:
+            secretName: nginx-cert
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx-config
+  namespace: piwardrive
+  labels:
+    app: nginx
+
+data:
+  nginx.conf: |
+    worker_processes 1;
+    events { worker_connections 1024; }
+    http {
+      server {
+        listen 80;
+        listen 443 ssl;
+        ssl_certificate /etc/nginx/ssl/cert.pem;
+        ssl_certificate_key /etc/nginx/ssl/key.pem;
+        location / {
+          proxy_pass http://piwardrive:80;
+        }
+      }
+    }
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: nginx-cert
+  namespace: piwardrive
+stringData:
+  cert.pem: |
+    dummy
+  key.pem: |
+    dummy
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx
+  namespace: piwardrive
+spec:
+  type: LoadBalancer
+  selector:
+    app: nginx
+  ports:
+    - port: 80
+      targetPort: 80
+    - port: 443
+      targetPort: 443

--- a/deploy/k8s/piwardrive.yaml
+++ b/deploy/k8s/piwardrive.yaml
@@ -1,0 +1,79 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: piwardrive
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: db-secret
+  namespace: piwardrive
+stringData:
+  POSTGRES_PASSWORD: changeme
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: piwardrive
+  namespace: piwardrive
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: piwardrive
+  template:
+    metadata:
+      labels:
+        app: piwardrive
+    spec:
+      containers:
+        - name: piwardrive
+          image: piwardrive/prod
+          env:
+            - name: PIWARDRIVE_ENV
+              value: "production"
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: db-secret
+                  key: POSTGRES_PASSWORD
+          ports:
+            - containerPort: 8000
+          livenessProbe:
+            httpGet:
+              path: /api/v1/system/health
+              port: 8000
+            initialDelaySeconds: 30
+            periodSeconds: 30
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: piwardrive
+  namespace: piwardrive
+spec:
+  selector:
+    app: piwardrive
+  ports:
+    - port: 80
+      targetPort: 8000
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: piwardrive
+  namespace: piwardrive
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: piwardrive
+  minReplicas: 1
+  maxReplicas: 5
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 80

--- a/deploy/k8s/postgres.yaml
+++ b/deploy/k8s/postgres.yaml
@@ -1,0 +1,58 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgres
+  namespace: piwardrive
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgres
+  template:
+    metadata:
+      labels:
+        app: postgres
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:16-alpine
+          env:
+            - name: POSTGRES_DB
+              value: piwardrive
+            - name: POSTGRES_USER
+              value: piwardrive
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: db-secret
+                  key: POSTGRES_PASSWORD
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: postgres-data
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: postgres-data
+  namespace: piwardrive
+spec:
+  accessModes: ["ReadWriteOnce"]
+  resources:
+    requests:
+      storage: 1Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+  namespace: piwardrive
+spec:
+  selector:
+    app: postgres
+  ports:
+    - port: 5432
+      targetPort: 5432

--- a/deploy/k8s/prometheus.yaml
+++ b/deploy/k8s/prometheus.yaml
@@ -1,0 +1,56 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prometheus
+  namespace: piwardrive
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: prometheus
+  template:
+    metadata:
+      labels:
+        app: prometheus
+    spec:
+      containers:
+        - name: prometheus
+          image: prom/prometheus
+          args:
+            - "--config.file=/etc/prometheus/prometheus.yml"
+          volumeMounts:
+            - name: config
+              mountPath: /etc/prometheus
+      volumes:
+        - name: config
+          configMap:
+            name: prometheus-config
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-config
+  namespace: piwardrive
+  labels:
+    app: prometheus
+
+data:
+  prometheus.yml: |
+    global:
+      scrape_interval: 15s
+    scrape_configs:
+      - job_name: 'piwardrive'
+        static_configs:
+          - targets: ['piwardrive:80']
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus
+  namespace: piwardrive
+spec:
+  selector:
+    app: prometheus
+  ports:
+    - port: 9090
+      targetPort: 9090

--- a/deploy/k8s/redis.yaml
+++ b/deploy/k8s/redis.yaml
@@ -1,0 +1,37 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis
+  namespace: piwardrive
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: redis
+  template:
+    metadata:
+      labels:
+        app: redis
+    spec:
+      containers:
+        - name: redis
+          image: redis:7-alpine
+          command: ["redis-server", "--appendonly", "yes"]
+          volumeMounts:
+            - name: redis-data
+              mountPath: /data
+      volumes:
+        - name: redis-data
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+  namespace: piwardrive
+spec:
+  selector:
+    app: redis
+  ports:
+    - port: 6379
+      targetPort: 6379

--- a/docs/backup_recovery.md
+++ b/docs/backup_recovery.md
@@ -1,0 +1,29 @@
+# Backup and Disaster Recovery
+
+This document outlines basic backup and recovery operations for a production
+PiWardrive deployment.
+
+## Database Backups
+
+Run scheduled `pg_dump` jobs from the PostgreSQL container:
+
+```bash
+docker compose --file deploy/docker-compose.production.yml exec postgres \
+  pg_dump -U piwardrive piwardrive | gzip > /backups/piwardrive.sql.gz
+```
+
+## Redis Backups
+
+The Redis container stores data under `/data`. Create snapshots with:
+
+```bash
+docker compose --file deploy/docker-compose.production.yml exec redis \
+  redis-cli save
+```
+
+## Restore Procedure
+
+1. Stop the application containers.
+2. Restore the PostgreSQL dump using `pg_restore`.
+3. Copy Redis dump files back to the volume.
+4. Start the stack and verify the application health endpoint.

--- a/docs/production-deployment.md
+++ b/docs/production-deployment.md
@@ -38,6 +38,22 @@ This guide covers deploying PiWardrive in production environments, from single-s
 - **Monitoring** (Real-time observability)
 - **Compliance** (Audit trails and data protection)
 
+### Containerized Deployment
+
+The `deploy/` directory contains production-ready configuration for both
+Docker Compose and Kubernetes. The Compose file `docker-compose.production.yml`
+orchestrates PiWardrive with PostgreSQL, Redis, Prometheus, Grafana and an
+Nginx reverse proxy with SSL termination. Kubernetes manifests in
+`deploy/k8s/` provide the same stack along with a Horizontal Pod Autoscaler for
+automatic scaling. A Helm chart under `deploy/charts/piwardrive` simplifies
+cluster deployments and exposes common settings through `values.yaml`.
+
+### Backup and Recovery
+
+Regular database dumps and Redis snapshots are essential for production
+reliability. Example scripts are provided in `docs/backup_recovery.md` and can
+be scheduled via `cron` or Kubernetes `CronJob` resources.
+
 ## Architecture Planning
 
 ### Reference Architectures


### PR DESCRIPTION
## Summary
- create docker ignore file
- optimize Dockerfile with multi-stage build and healthcheck
- add production Docker Compose config including monitoring and reverse proxy
- provide Kubernetes manifests and Helm chart for scaling
- document containerized deployment and backup procedures

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867246df23c8333b2701cb6b741dc9a