### PR TITLE
Add scan_sessions table migration and persistence

### DIFF
--- a/src/piwardrive/migrations/001_create_scan_sessions.py
+++ b/src/piwardrive/migrations/001_create_scan_sessions.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from .base import BaseMigration
+
+
+class Migration(BaseMigration):
+    """Create scan_sessions table."""
+
+    version = 1
+
+    async def apply(self, conn) -> None:
+        await conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS scan_sessions (
+                id TEXT PRIMARY KEY,
+                device_id TEXT NOT NULL,
+                scan_type TEXT NOT NULL,
+                started_at TIMESTAMP NOT NULL,
+                completed_at TIMESTAMP,
+                duration_seconds INTEGER,
+                location_start_lat REAL,
+                location_start_lon REAL,
+                location_end_lat REAL,
+                location_end_lon REAL,
+                interface_used TEXT,
+                scan_parameters TEXT,
+                total_detections INTEGER DEFAULT 0,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )
+            """
+        )
+        await conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_scan_sessions_device_time ON scan_sessions(device_id, started_at)"
+        )
+        await conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_scan_sessions_type ON scan_sessions(scan_type)"
+        )
+        await conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_scan_sessions_location ON scan_sessions(location_start_lat, location_start_lon)"
+        )
+
+    async def rollback(self, conn) -> None:
+        await conn.execute(
+            "DROP INDEX IF EXISTS idx_scan_sessions_device_time"
+        )
+        await conn.execute(
+            "DROP INDEX IF EXISTS idx_scan_sessions_type"
+        )
+        await conn.execute(
+            "DROP INDEX IF EXISTS idx_scan_sessions_location"
+        )
+        await conn.execute("DROP TABLE IF EXISTS scan_sessions")

--- a/src/piwardrive/migrations/__init__.py
+++ b/src/piwardrive/migrations/__init__.py
@@ -1,8 +1,9 @@
 """Database migration framework."""
 
 from .base import BaseMigration
+from .001_create_scan_sessions import Migration as Migration001
 
 # List of migration instances in version order
-MIGRATIONS: list[BaseMigration] = []
+MIGRATIONS: list[BaseMigration] = [Migration001()]
 
 __all__ = ["BaseMigration", "MIGRATIONS"]

--- a/src/piwardrive/persistence.py
+++ b/src/piwardrive/persistence.py
@@ -20,6 +20,10 @@ from .core.persistence import (
     shutdown_pool,
     backup_database,
     get_db_metrics,
+    ScanSession,
+    save_scan_session,
+    get_scan_session,
+    iter_scan_sessions,
 )
 
 
@@ -95,4 +99,8 @@ __all__ = [
     "get_user_by_token",
     "save_user",
     "update_user_token",
+    "ScanSession",
+    "save_scan_session",
+    "get_scan_session",
+    "iter_scan_sessions",
 ]


### PR DESCRIPTION
## Summary
- implement first migration to create `scan_sessions`
- register the migration
- support scan session CRUD functions in persistence

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'psutil')*

------
https://chatgpt.com/codex/tasks/task_e_68672c8ca87083338a8caf0a2d4d249d