### PR TITLE
Add Bluetooth detections support

### DIFF
--- a/src/piwardrive/core/persistence.py
+++ b/src/piwardrive/core/persistence.py
@@ -744,6 +744,34 @@ async def save_wifi_detections(records: list[dict[str, Any]]) -> None:
         await conn.commit()
 
 
+async def save_bluetooth_detections(records: list[dict[str, Any]]) -> None:
+    """Insert ``records`` into the ``bluetooth_detections`` table."""
+    if not records:
+        return
+    async with _get_conn() as conn:
+        await conn.executemany(
+            """
+            INSERT INTO bluetooth_detections (
+                scan_session_id, detection_timestamp, mac_address, device_name,
+                device_class, device_type, manufacturer_id, manufacturer_name,
+                rssi_dbm, tx_power_dbm, bluetooth_version, supported_services,
+                is_connectable, is_paired, latitude, longitude, altitude_meters,
+                accuracy_meters, heading_degrees, speed_kmh, first_seen,
+                last_seen, detection_count
+            ) VALUES (
+                :scan_session_id, :detection_timestamp, :mac_address, :device_name,
+                :device_class, :device_type, :manufacturer_id, :manufacturer_name,
+                :rssi_dbm, :tx_power_dbm, :bluetooth_version, :supported_services,
+                :is_connectable, :is_paired, :latitude, :longitude, :altitude_meters,
+                :accuracy_meters, :heading_degrees, :speed_kmh, :first_seen,
+                :last_seen, :detection_count
+            )
+            """,
+            records,
+        )
+        await conn.commit()
+
+
 async def get_table_counts() -> dict[str, int]:
     """Return row counts for all user tables."""
     path = _db_path()

--- a/src/piwardrive/migrations/003_create_bluetooth_detections.py
+++ b/src/piwardrive/migrations/003_create_bluetooth_detections.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from .base import BaseMigration
+
+
+class Migration(BaseMigration):
+    """Create bluetooth_detections table."""
+
+    version = 3
+
+    async def apply(self, conn) -> None:
+        await conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS bluetooth_detections (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                scan_session_id TEXT NOT NULL,
+                detection_timestamp TIMESTAMP NOT NULL,
+                mac_address TEXT NOT NULL,
+                device_name TEXT,
+                device_class INTEGER,
+                device_type TEXT,
+                manufacturer_id INTEGER,
+                manufacturer_name TEXT,
+                rssi_dbm INTEGER,
+                tx_power_dbm INTEGER,
+                bluetooth_version TEXT,
+                supported_services TEXT,
+                is_connectable BOOLEAN DEFAULT FALSE,
+                is_paired BOOLEAN DEFAULT FALSE,
+                latitude REAL,
+                longitude REAL,
+                altitude_meters REAL,
+                accuracy_meters REAL,
+                heading_degrees REAL,
+                speed_kmh REAL,
+                first_seen TIMESTAMP NOT NULL,
+                last_seen TIMESTAMP NOT NULL,
+                detection_count INTEGER DEFAULT 1,
+                FOREIGN KEY (scan_session_id) REFERENCES scan_sessions(id)
+            )
+            """
+        )
+        await conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_bt_detections_session ON bluetooth_detections(scan_session_id)"
+        )
+        await conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_bt_detections_mac ON bluetooth_detections(mac_address)"
+        )
+        await conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_bt_detections_time ON bluetooth_detections(detection_timestamp)"
+        )
+        await conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_bt_detections_location ON bluetooth_detections(latitude, longitude)"
+        )
+        await conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_bt_detections_rssi ON bluetooth_detections(rssi_dbm)"
+        )
+
+    async def rollback(self, conn) -> None:
+        await conn.execute("DROP INDEX IF EXISTS idx_bt_detections_rssi")
+        await conn.execute("DROP INDEX IF EXISTS idx_bt_detections_location")
+        await conn.execute("DROP INDEX IF EXISTS idx_bt_detections_time")
+        await conn.execute("DROP INDEX IF EXISTS idx_bt_detections_mac")
+        await conn.execute("DROP INDEX IF EXISTS idx_bt_detections_session")
+        await conn.execute("DROP TABLE IF EXISTS bluetooth_detections")

--- a/src/piwardrive/migrations/__init__.py
+++ b/src/piwardrive/migrations/__init__.py
@@ -6,8 +6,9 @@ from .base import BaseMigration
 
 Migration001 = import_module(f"{__name__}.001_create_scan_sessions").Migration
 Migration002 = import_module(f"{__name__}.002_enhance_wifi_detections").Migration
+Migration003 = import_module(f"{__name__}.003_create_bluetooth_detections").Migration
 
 # List of migration instances in version order
-MIGRATIONS: list[BaseMigration] = [Migration001(), Migration002()]
+MIGRATIONS: list[BaseMigration] = [Migration001(), Migration002(), Migration003()]
 
 __all__ = ["BaseMigration", "MIGRATIONS"]

--- a/src/piwardrive/models/__init__.py
+++ b/src/piwardrive/models/__init__.py
@@ -2,6 +2,9 @@
 
 from .api_models import (
     AccessPoint,
+    BluetoothDevice,
+    BluetoothScanRequest,
+    BluetoothScanResponse,
     ErrorResponse,
     SystemStats,
     WiFiScanRequest,
@@ -10,6 +13,9 @@ from .api_models import (
 
 __all__ = [
     "AccessPoint",
+    "BluetoothDevice",
+    "BluetoothScanRequest",
+    "BluetoothScanResponse",
     "ErrorResponse",
     "SystemStats",
     "WiFiScanRequest",

--- a/src/piwardrive/models/api_models.py
+++ b/src/piwardrive/models/api_models.py
@@ -71,6 +71,52 @@ class WiFiScanResponse(BaseModel):
     )
 
 
+class BluetoothScanRequest(BaseModel):
+    """Parameters for initiating a Bluetooth scan."""
+
+    timeout: int | None = Field(
+        None,
+        description="Optional timeout in seconds for the scan process",
+        examples=[10],
+    )
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class BluetoothDevice(BaseModel):
+    """Information about a discovered Bluetooth device."""
+
+    address: str = Field(..., description="Device MAC address")
+    name: str | None = Field(None, description="Reported device name")
+
+    model_config = ConfigDict(
+        from_attributes=True,
+        json_schema_extra={
+            "example": {"address": "AA:BB:CC:DD:EE:FF", "name": "Phone"}
+        },
+    )
+
+
+class BluetoothScanResponse(BaseModel):
+    """Bluetooth scan result."""
+
+    devices: list[BluetoothDevice] = Field(
+        default_factory=list,
+        description="List of discovered Bluetooth devices",
+    )
+
+    model_config = ConfigDict(
+        from_attributes=True,
+        json_schema_extra={
+            "example": {
+                "devices": [
+                    BluetoothDevice.model_config["json_schema_extra"]["example"]
+                ]
+            }
+        },
+    )
+
+
 class SystemStats(BaseModel):
     """System resource utilization metrics."""
 

--- a/src/piwardrive/routes/bluetooth.py
+++ b/src/piwardrive/routes/bluetooth.py
@@ -1,0 +1,48 @@
+"""Bluetooth scanning API routes."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+
+from piwardrive import service
+from piwardrive.models import (
+    BluetoothDevice,
+    BluetoothScanRequest,
+    BluetoothScanResponse,
+    ErrorResponse,
+)
+from piwardrive.services import bluetooth_scanner
+
+router = APIRouter(prefix="/bluetooth", tags=["bluetooth"])
+
+
+@router.get(
+    "/scan",
+    response_model=BluetoothScanResponse,
+    responses={401: {"model": ErrorResponse}},
+)
+async def scan_bluetooth_get(
+    timeout: int | None = None,
+    _auth: None = Depends(service._check_auth),
+) -> BluetoothScanResponse:
+    """Perform a Bluetooth scan and return discovered devices."""
+    devices = await bluetooth_scanner.scan_bluetooth_devices(timeout=timeout)
+    result = [BluetoothDevice.model_validate(d.model_dump()) for d in devices]
+    await bluetooth_scanner.record_bluetooth_detections(result)
+    return BluetoothScanResponse(devices=result)
+
+
+@router.post(
+    "/scan",
+    response_model=BluetoothScanResponse,
+    responses={401: {"model": ErrorResponse}},
+)
+async def scan_bluetooth_post(
+    req: BluetoothScanRequest,
+    _auth: None = Depends(service._check_auth),
+) -> BluetoothScanResponse:
+    """Perform a Bluetooth scan using parameters in the request body."""
+    devices = await bluetooth_scanner.scan_bluetooth_devices(timeout=req.timeout)
+    result = [BluetoothDevice.model_validate(d.model_dump()) for d in devices]
+    await bluetooth_scanner.record_bluetooth_detections(result)
+    return BluetoothScanResponse(devices=result)

--- a/src/piwardrive/service.py
+++ b/src/piwardrive/service.py
@@ -27,15 +27,21 @@ from piwardrive.api.common import (
 )
 from piwardrive.api.auth import router as auth_router, AuthMiddleware, AUTH_DEP
 from piwardrive.api.health import router as health_router
-from piwardrive.api.system import router as system_router, collect_widget_metrics as _collect_widget_metrics
+from piwardrive.api.system import (
+    router as system_router,
+    collect_widget_metrics as _collect_widget_metrics,
+)
 from piwardrive.api.websockets import router as ws_router
 from piwardrive.api.widgets import router as widgets_router
 from piwardrive.routes import wifi as wifi_routes
+from piwardrive.routes import bluetooth as bluetooth_routes
 
 
 app = FastAPI()
 
-cors_origins = [o.strip() for o in os.getenv("PW_CORS_ORIGINS", "").split(",") if o.strip()]
+cors_origins = [
+    o.strip() for o in os.getenv("PW_CORS_ORIGINS", "").split(",") if o.strip()
+]
 if cors_origins:
     app.add_middleware(
         CORSMiddleware,
@@ -50,6 +56,7 @@ add_error_middleware(app)
 
 
 app.include_router(wifi_routes.router)
+app.include_router(bluetooth_routes.router)
 app.include_router(auth_router)
 app.include_router(health_router)
 app.include_router(widgets_router)
@@ -73,5 +80,3 @@ __all__ = [
     "run_service_cmd",
     "_collect_widget_metrics",
 ]
-
-

--- a/src/piwardrive/services/bluetooth_scanner.py
+++ b/src/piwardrive/services/bluetooth_scanner.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Iterable, List
+
+from piwardrive import persistence
+from piwardrive.sigint_suite.bluetooth.scanner import async_scan_bluetooth
+from piwardrive.sigint_suite.models import BluetoothDevice
+
+
+async def scan_bluetooth_devices(timeout: int | None = None) -> List[BluetoothDevice]:
+    """Return nearby Bluetooth devices using the Sigint Suite scanner."""
+    return await async_scan_bluetooth(timeout=timeout)
+
+
+async def record_bluetooth_detections(devices: Iterable[BluetoothDevice]) -> None:
+    """Persist ``devices`` to the ``bluetooth_detections`` table."""
+    timestamp = datetime.utcnow().isoformat()
+    records = [
+        {
+            "scan_session_id": "adhoc",
+            "detection_timestamp": timestamp,
+            "mac_address": dev.address,
+            "device_name": dev.name,
+            "device_class": None,
+            "device_type": None,
+            "manufacturer_id": None,
+            "manufacturer_name": None,
+            "rssi_dbm": None,
+            "tx_power_dbm": None,
+            "bluetooth_version": None,
+            "supported_services": None,
+            "is_connectable": False,
+            "is_paired": False,
+            "latitude": getattr(dev, "lat", None),
+            "longitude": getattr(dev, "lon", None),
+            "altitude_meters": None,
+            "accuracy_meters": None,
+            "heading_degrees": None,
+            "speed_kmh": None,
+            "first_seen": timestamp,
+            "last_seen": timestamp,
+            "detection_count": 1,
+        }
+        for dev in devices
+    ]
+    await persistence.save_bluetooth_detections(records)
+
+
+async def scan_and_save(timeout: int | None = None) -> List[BluetoothDevice]:
+    """Scan for Bluetooth devices and store detection records."""
+    devices = await scan_bluetooth_devices(timeout=timeout)
+    await record_bluetooth_detections(devices)
+    return devices


### PR DESCRIPTION
## Summary
- create bluetooth_detections table and indexes via new migration
- expose bluetooth scanning service and persistence helpers
- add Bluetooth API models and `/bluetooth/scan` endpoints
- integrate Bluetooth router with main FastAPI app

## Testing
- `pip install -q -r requirements.txt` *(fails: dbus build dependency missing)*
- `pytest -q` *(fails: ModuleNotFoundError: psutil)*

------
https://chatgpt.com/codex/tasks/task_e_686732e196bc8333825aab6d84ef7bf1