### PR TITLE
Add network fingerprinting

### DIFF
--- a/src/piwardrive/migrations/006_create_network_fingerprints.py
+++ b/src/piwardrive/migrations/006_create_network_fingerprints.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from .base import BaseMigration
+
+
+class Migration(BaseMigration):
+    """Create network_fingerprints table."""
+
+    version = 6
+
+    async def apply(self, conn) -> None:
+        await conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS network_fingerprints (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                bssid TEXT NOT NULL,
+                ssid TEXT,
+                fingerprint_hash TEXT NOT NULL,
+                confidence_score REAL,
+                device_model TEXT,
+                firmware_version TEXT,
+                characteristics TEXT,
+                classification TEXT,
+                risk_level TEXT,
+                tags TEXT,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )
+            """
+        )
+        await conn.execute(
+            "CREATE UNIQUE INDEX IF NOT EXISTS idx_fingerprints_bssid ON network_fingerprints(bssid)"
+        )
+        await conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_fingerprints_hash ON network_fingerprints(fingerprint_hash)"
+        )
+        await conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_fingerprints_classification ON network_fingerprints(classification)"
+        )
+
+    async def rollback(self, conn) -> None:
+        await conn.execute("DROP INDEX IF EXISTS idx_fingerprints_classification")
+        await conn.execute("DROP INDEX IF EXISTS idx_fingerprints_hash")
+        await conn.execute("DROP INDEX IF EXISTS idx_fingerprints_bssid")
+        await conn.execute("DROP TABLE IF EXISTS network_fingerprints")
+        await conn.commit()

--- a/src/piwardrive/migrations/__init__.py
+++ b/src/piwardrive/migrations/__init__.py
@@ -9,6 +9,7 @@ Migration002 = import_module(f"{__name__}.002_enhance_wifi_detections").Migratio
 Migration003 = import_module(f"{__name__}.003_create_bluetooth_detections").Migration
 Migration004 = import_module(f"{__name__}.004_create_gps_tracks").Migration
 Migration005 = import_module(f"{__name__}.005_create_cellular_detections").Migration
+Migration006 = import_module(f"{__name__}.006_create_network_fingerprints").Migration
 
 # List of migration instances in version order
 MIGRATIONS: list[BaseMigration] = [
@@ -17,6 +18,7 @@ MIGRATIONS: list[BaseMigration] = [
     Migration003(),
     Migration004(),
     Migration005(),
+    Migration006(),
 ]
 
 __all__ = ["BaseMigration", "MIGRATIONS"]

--- a/src/piwardrive/routes/wifi.py
+++ b/src/piwardrive/routes/wifi.py
@@ -7,6 +7,7 @@ from datetime import datetime
 from fastapi import APIRouter, Depends
 
 from piwardrive import persistence, service
+from piwardrive.services import network_fingerprinting
 from piwardrive.models import (
     AccessPoint,
     ErrorResponse,
@@ -99,6 +100,7 @@ async def scan_wifi_get(
         for ap in aps
     ]
     await persistence.save_wifi_detections(records)
+    await network_fingerprinting.fingerprint_wifi_records(records)
     return WiFiScanResponse(access_points=aps)
 
 
@@ -182,4 +184,5 @@ async def scan_wifi_post(
         for ap in aps
     ]
     await persistence.save_wifi_detections(records)
+    await network_fingerprinting.fingerprint_wifi_records(records)
     return WiFiScanResponse(access_points=aps)

--- a/src/piwardrive/services/network_fingerprinting.py
+++ b/src/piwardrive/services/network_fingerprinting.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Iterable, Any
+
+from piwardrive import persistence
+
+
+def _extract_characteristics(record: dict[str, Any]) -> dict[str, Any]:
+    keys = [
+        "vendor_oui",
+        "vendor_name",
+        "encryption_type",
+        "cipher_suite",
+        "authentication_method",
+        "beacon_interval_ms",
+        "dtim_period",
+        "ht_capabilities",
+        "vht_capabilities",
+        "he_capabilities",
+        "country_code",
+        "regulatory_domain",
+        "channel",
+        "frequency_mhz",
+        "tx_power_dbm",
+        "device_type",
+    ]
+    return {k: record.get(k) for k in keys if record.get(k) is not None}
+
+
+def _classify(record: dict[str, Any]) -> tuple[str, str]:
+    enc = (record.get("encryption_type") or "").upper()
+    vendor = (record.get("vendor_name") or "").lower()
+    if enc in {"", "OPEN"}:
+        classification = "public"
+        risk = "medium"
+    elif "CISCO" in vendor or "ubiquiti" in vendor:
+        classification = "business"
+        risk = "low"
+    else:
+        classification = "home"
+        risk = "low"
+    if "WEP" in enc:
+        risk = "high"
+    return classification, risk
+
+
+def _fingerprint_hash(char: dict[str, Any]) -> str:
+    data = json.dumps(char, sort_keys=True).encode()
+    return hashlib.sha1(data).hexdigest()
+
+
+def _make_row(record: dict[str, Any]) -> dict[str, Any]:
+    char = _extract_characteristics(record)
+    fp_hash = _fingerprint_hash(char)
+    classification, risk = _classify(record)
+    confidence = min(1.0, len(char) / 10.0)
+    return {
+        "bssid": record.get("bssid"),
+        "ssid": record.get("ssid"),
+        "fingerprint_hash": fp_hash,
+        "confidence_score": confidence,
+        "device_model": None,
+        "firmware_version": None,
+        "characteristics": json.dumps(char),
+        "classification": classification,
+        "risk_level": risk,
+        "tags": json.dumps(list(char.keys())),
+    }
+
+
+async def fingerprint_wifi_records(records: Iterable[dict[str, Any]]) -> None:
+    """Generate fingerprints for Wi-Fi detection ``records``."""
+    rows = [_make_row(r) for r in records if r.get("bssid")]
+    if rows:
+        await persistence.save_network_fingerprints(rows)


### PR DESCRIPTION
## Summary
- add database migration for network_fingerprints table
- implement fingerprint storage in persistence layer
- create network_fingerprinting service for wifi detections
- store fingerprints when wifi scans run

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68673ebbe6348333b50ec8dc210fc1b4