### PR TITLE
Add materialized view refresh workflow

### DIFF
--- a/src/piwardrive/api/analytics/endpoints.py
+++ b/src/piwardrive/api/analytics/endpoints.py
@@ -4,7 +4,7 @@ from typing import Any
 
 from fastapi import APIRouter
 
-from piwardrive import service, persistence
+from piwardrive import persistence, service
 
 router = APIRouter(prefix="/analytics", tags=["analytics"])
 
@@ -20,3 +20,25 @@ async def get_network_analytics(
     return await persistence.load_network_analytics(
         bssid=bssid, start=start, end=end, limit=limit
     )
+
+
+@router.get("/daily-stats")
+async def get_daily_stats(
+    session_id: str | None = None,
+    start: str | None = None,
+    end: str | None = None,
+    limit: int | None = None,
+    _auth: Any = service.AUTH_DEP,
+) -> list[dict[str, Any]]:
+    return await persistence.load_daily_detection_stats(
+        session_id=session_id, start=start, end=end, limit=limit
+    )
+
+
+@router.get("/coverage-grid")
+async def get_coverage_grid(
+    limit: int | None = None,
+    offset: int = 0,
+    _auth: Any = service.AUTH_DEP,
+) -> list[dict[str, Any]]:
+    return await persistence.load_network_coverage_grid(limit=limit, offset=offset)

--- a/src/piwardrive/main.py
+++ b/src/piwardrive/main.py
@@ -2,12 +2,11 @@
 
 from __future__ import annotations
 
+import argparse
 import asyncio
 import logging
 import os
-import subprocess
 import time
-import argparse
 from dataclasses import asdict, fields
 from pathlib import Path
 from typing import Callable
@@ -28,6 +27,7 @@ from piwardrive.logging import init_logging
 from piwardrive.persistence import AppState, _db_path, load_app_state, save_app_state
 from piwardrive.scheduler import PollScheduler
 from piwardrive.security import hash_password
+from piwardrive.services.view_refresher import ViewRefresher
 
 logging.getLogger("urllib3").setLevel(logging.WARNING)
 
@@ -78,6 +78,7 @@ class PiWardriveApp:
             limit_mb=512,
             vacuum=True,
         )
+        self.view_refresher = ViewRefresher(self.scheduler)
         if (
             self.config_data.remote_sync_url
             and self.config_data.remote_sync_interval > 0
@@ -225,7 +226,6 @@ class PiWardriveApp:
         except OSError as exc:  # pragma: no cover - save failure
             logging.exception("Failed to save app state: %s", exc)
         utils.shutdown_async_loop()
-
 
 
 async def _run_migrations() -> None:

--- a/src/piwardrive/migrations/009_create_materialized_views.py
+++ b/src/piwardrive/migrations/009_create_materialized_views.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from .base import BaseMigration
+
+
+class Migration(BaseMigration):
+    """Create materialized view tables for analytics."""
+
+    version = 9
+
+    async def apply(self, conn) -> None:
+        await conn.execute("DROP TABLE IF EXISTS daily_detection_stats")
+        await conn.execute(
+            """
+            CREATE TABLE daily_detection_stats AS
+            SELECT
+                DATE(detection_timestamp) AS detection_date,
+                scan_session_id,
+                COUNT(*) AS total_detections,
+                COUNT(DISTINCT bssid) AS unique_networks,
+                AVG(signal_strength_dbm) AS avg_signal,
+                MIN(signal_strength_dbm) AS min_signal,
+                MAX(signal_strength_dbm) AS max_signal,
+                COUNT(DISTINCT channel) AS channels_used,
+                COUNT(
+                    CASE WHEN encryption_type = 'OPEN' THEN 1 END
+                ) AS open_networks,
+                COUNT(
+                    CASE WHEN encryption_type LIKE '%WEP%' THEN 1 END
+                ) AS wep_networks,
+                COUNT(
+                    CASE WHEN encryption_type LIKE '%WPA%' THEN 1 END
+                ) AS wpa_networks
+            FROM wifi_detections
+            GROUP BY DATE(detection_timestamp), scan_session_id
+            """
+        )
+        await conn.execute("DROP TABLE IF EXISTS network_coverage_grid")
+        await conn.execute(
+            """
+            CREATE TABLE network_coverage_grid AS
+            SELECT
+                ROUND(latitude, 4) AS lat_grid,
+                ROUND(longitude, 4) AS lon_grid,
+                COUNT(*) AS detection_count,
+                COUNT(DISTINCT bssid) AS unique_networks,
+                AVG(signal_strength_dbm) AS avg_signal,
+                MAX(signal_strength_dbm) AS max_signal
+            FROM wifi_detections
+            WHERE latitude IS NOT NULL AND longitude IS NOT NULL
+            GROUP BY ROUND(latitude, 4), ROUND(longitude, 4)
+            """
+        )
+        await conn.commit()
+
+    async def rollback(self, conn) -> None:
+        await conn.execute("DROP TABLE IF EXISTS network_coverage_grid")
+        await conn.execute("DROP TABLE IF EXISTS daily_detection_stats")
+        await conn.commit()

--- a/src/piwardrive/migrations/__init__.py
+++ b/src/piwardrive/migrations/__init__.py
@@ -12,6 +12,7 @@ Migration005 = import_module(f"{__name__}.005_create_cellular_detections").Migra
 Migration006 = import_module(f"{__name__}.006_create_network_fingerprints").Migration
 Migration007 = import_module(f"{__name__}.007_create_suspicious_activities").Migration
 Migration008 = import_module(f"{__name__}.008_create_network_analytics").Migration
+Migration009 = import_module(f"{__name__}.009_create_materialized_views").Migration
 
 # List of migration instances in version order
 MIGRATIONS: list[BaseMigration] = [
@@ -23,6 +24,7 @@ MIGRATIONS: list[BaseMigration] = [
     Migration006(),
     Migration007(),
     Migration008(),
+    Migration009(),
 ]
 
 __all__ = ["BaseMigration", "MIGRATIONS"]

--- a/src/piwardrive/persistence.py
+++ b/src/piwardrive/persistence.py
@@ -11,7 +11,7 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 
 from . import config
-from .core.persistence import *  # noqa: F401,F403
+from .core.persistence import *  # noqa: F401,F403,F405
 from .core.persistence import (
     ScanSession,
     _acquire_conn,
@@ -22,6 +22,10 @@ from .core.persistence import (
     get_db_metrics,
     get_scan_session,
     iter_scan_sessions,
+    load_daily_detection_stats,
+    load_network_coverage_grid,
+    refresh_daily_detection_stats,
+    refresh_network_coverage_grid,
     save_scan_session,
     shutdown_pool,
 )
@@ -82,7 +86,7 @@ async def update_user_token(*_a, **_k) -> None:
     """Stub for ``service`` imports."""
 
 
-__all__ = [
+__all__ = [  # noqa: F405
     *globals().get("__all__", []),
     "_db_path",
     "_get_conn",
@@ -109,4 +113,8 @@ __all__ = [
     "load_recent_suspicious",
     "save_network_analytics",
     "load_network_analytics",
+    "refresh_daily_detection_stats",
+    "refresh_network_coverage_grid",
+    "load_daily_detection_stats",
+    "load_network_coverage_grid",
 ]

--- a/src/piwardrive/services/view_refresher.py
+++ b/src/piwardrive/services/view_refresher.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from piwardrive import persistence
+from piwardrive.scheduler import PollScheduler
+from piwardrive.utils import run_async_task
+
+
+class ViewRefresher:
+    """Periodically refresh materialized view tables."""
+
+    def __init__(self, scheduler: PollScheduler, interval: int = 3600) -> None:
+        self._scheduler = scheduler
+        self._event = "view_refresher"
+        scheduler.schedule(
+            self._event, lambda _dt: run_async_task(self.run()), interval
+        )
+        run_async_task(self.run())
+
+    async def run(self) -> None:
+        await persistence.refresh_daily_detection_stats()
+        await persistence.refresh_network_coverage_grid()
+
+
+__all__ = ["ViewRefresher"]


### PR DESCRIPTION
## Summary
- implement materialized views for daily stats and coverage grid
- schedule a ViewRefresher service to rebuild the tables
- expose APIs to query the new views
- register new migration for these views

## Testing
- `pre-commit run --files src/piwardrive/api/analytics/endpoints.py src/piwardrive/core/persistence.py src/piwardrive/main.py src/piwardrive/migrations/__init__.py src/piwardrive/persistence.py src/piwardrive/migrations/009_create_materialized_views.py src/piwardrive/services/view_refresher.py` *(fails: mypy and npm tasks due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68674918407883338ed3098ecee2450d