### PR TITLE
Add DB performance monitoring and indexes

### DIFF
--- a/src/piwardrive/migrations/010_performance_indexes.py
+++ b/src/piwardrive/migrations/010_performance_indexes.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from .base import BaseMigration
+
+
+class Migration(BaseMigration):
+    """Add performance indexes for analysis queries."""
+
+    version = 10
+
+    async def apply(self, conn) -> None:
+        await conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_wifi_time_location ON wifi_detections(detection_timestamp, latitude, longitude)"
+        )
+        await conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_wifi_signal_channel ON wifi_detections(signal_strength_dbm, channel)"
+        )
+        await conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_wifi_vendor_encryption ON wifi_detections(vendor_name, encryption_type)"
+        )
+        await conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_wifi_ssid_bssid ON wifi_detections(ssid, bssid)"
+        )
+        await conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_wifi_ssid_fts ON wifi_detections(ssid)"
+        )
+        await conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_bt_name_fts ON bluetooth_detections(device_name)"
+        )
+        await conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_wifi_location_spatial ON wifi_detections(longitude, latitude)"
+        )
+        await conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_gps_location_spatial ON gps_tracks(longitude, latitude)"
+        )
+
+    async def rollback(self, conn) -> None:
+        await conn.execute("DROP INDEX IF EXISTS idx_gps_location_spatial")
+        await conn.execute("DROP INDEX IF EXISTS idx_wifi_location_spatial")
+        await conn.execute("DROP INDEX IF EXISTS idx_bt_name_fts")
+        await conn.execute("DROP INDEX IF EXISTS idx_wifi_ssid_fts")
+        await conn.execute("DROP INDEX IF EXISTS idx_wifi_ssid_bssid")
+        await conn.execute("DROP INDEX IF EXISTS idx_wifi_vendor_encryption")
+        await conn.execute("DROP INDEX IF EXISTS idx_wifi_signal_channel")
+        await conn.execute("DROP INDEX IF EXISTS idx_wifi_time_location")
+        await conn.commit()

--- a/src/piwardrive/migrations/__init__.py
+++ b/src/piwardrive/migrations/__init__.py
@@ -13,6 +13,7 @@ Migration006 = import_module(f"{__name__}.006_create_network_fingerprints").Migr
 Migration007 = import_module(f"{__name__}.007_create_suspicious_activities").Migration
 Migration008 = import_module(f"{__name__}.008_create_network_analytics").Migration
 Migration009 = import_module(f"{__name__}.009_create_materialized_views").Migration
+Migration010 = import_module(f"{__name__}.010_performance_indexes").Migration
 
 # List of migration instances in version order
 MIGRATIONS: list[BaseMigration] = [
@@ -25,6 +26,7 @@ MIGRATIONS: list[BaseMigration] = [
     Migration007(),
     Migration008(),
     Migration009(),
+    Migration010(),
 ]
 
 __all__ = ["BaseMigration", "MIGRATIONS"]

--- a/src/piwardrive/services/db_monitor.py
+++ b/src/piwardrive/services/db_monitor.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+"""Database monitoring utilities."""
+
+import logging
+from collections import defaultdict
+from typing import Any, Dict, List
+
+from piwardrive import persistence
+from piwardrive.database_service import db_service
+
+logger = logging.getLogger(__name__)
+
+# store query durations grouped by SQL verb
+_QUERY_METRICS: dict[str, List[float]] = defaultdict(list)
+
+
+def record_query(sql: str, duration: float) -> None:
+    """Record execution time for ``sql``."""
+    key = (sql.split() or ["?"])[0].upper()
+    _QUERY_METRICS[key].append(duration)
+    logger.debug("query %s took %.4f sec", key, duration)
+
+
+def get_query_metrics() -> Dict[str, Dict[str, float]]:
+    """Return aggregated query metrics."""
+    result: Dict[str, Dict[str, float]] = {}
+    for key, values in _QUERY_METRICS.items():
+        count = len(values)
+        avg = sum(values) / count if count else 0.0
+        result[key] = {"count": count, "avg": avg}
+    return result
+
+
+async def health_check() -> bool:
+    """Return ``True`` if the database is reachable."""
+    try:
+        await db_service.manager.execute("SELECT 1")
+    except Exception:
+        logger.exception("database health check failed")
+        return False
+    return True
+
+
+async def analyze_index_usage() -> List[Dict[str, Any]]:
+    """Return basic index size information using the ``dbstat`` virtual table."""
+    async with persistence._get_conn() as conn:
+        try:
+            cur = await conn.execute(
+                "SELECT name, SUM(pgsize) AS size FROM dbstat WHERE name IN (SELECT name FROM sqlite_master WHERE type='index') GROUP BY name ORDER BY size DESC"
+            )
+            rows = await cur.fetchall()
+        except Exception as exc:  # pragma: no cover - dbstat may not exist
+            logger.debug("index usage query failed: %s", exc)
+            return []
+    return [dict(row) for row in rows]
+
+
+__all__ = ["record_query", "get_query_metrics", "health_check", "analyze_index_usage"]


### PR DESCRIPTION
## Summary
- add performance indexes migration
- update migration list
- record query timings in DB manager
- add database monitoring service
- expose database health and index usage endpoints

## Testing
- `pre-commit run --files src/piwardrive/migrations/010_performance_indexes.py src/piwardrive/migrations/__init__.py src/piwardrive/db/manager.py src/piwardrive/services/db_monitor.py src/piwardrive/api/system/endpoints.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867f4fbe9548333b59116e4ff0cf406