### PR TITLE
Add analytics processing jobs

### DIFF
--- a/src/piwardrive/api/analytics_jobs.py
+++ b/src/piwardrive/api/analytics_jobs.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from fastapi import APIRouter
+
+from piwardrive import service
+from piwardrive.jobs import analytics_jobs
+
+router = APIRouter(prefix="/analytics-jobs", tags=["analytics-jobs"])
+
+
+@router.get("/status")
+async def get_job_status(_auth: Any = service.AUTH_DEP) -> Dict[str, Dict[str, Any]]:
+    """Return execution status for background analytics jobs."""
+    mgr = analytics_jobs.job_manager
+    if mgr is None:
+        return {}
+    return mgr.get_status()
+
+
+__all__ = ["router"]

--- a/src/piwardrive/jobs/analytics_jobs.py
+++ b/src/piwardrive/jobs/analytics_jobs.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+"""Background job scheduler for analytics tasks."""
+
+import logging
+from datetime import datetime
+from typing import Any, Awaitable, Callable, Dict
+
+from piwardrive.scheduler import AsyncScheduler
+from piwardrive.services.analytics_processor import (
+    cleanup_old_data,
+    detect_anomalies,
+    process_hourly_analytics,
+    update_fingerprints,
+)
+from piwardrive.task_queue import BackgroundTaskQueue
+
+logger = logging.getLogger(__name__)
+
+
+class AnalyticsJobManager:
+    """Schedule analytics jobs and track their status."""
+
+    def __init__(self, scheduler: AsyncScheduler, queue: BackgroundTaskQueue) -> None:
+        self._scheduler = scheduler
+        self._queue = queue
+        self._status: Dict[str, Dict[str, Any]] = {}
+
+        self._scheduler.schedule(
+            "hourly_analytics",
+            lambda: self.enqueue("hourly_analytics", process_hourly_analytics),
+            3600,
+        )
+        self._scheduler.schedule(
+            "detect_anomalies",
+            lambda: self.enqueue("detect_anomalies", detect_anomalies),
+            1800,
+        )
+        self._scheduler.schedule(
+            "update_fingerprints",
+            lambda: self.enqueue("update_fingerprints", update_fingerprints),
+            3600,
+        )
+        self._scheduler.schedule(
+            "cleanup_old_data",
+            lambda: self.enqueue("cleanup_old_data", cleanup_old_data),
+            86400,
+        )
+
+    # ------------------------------------------------------------------
+    def enqueue(self, name: str, func: Callable[[], Awaitable[None]]) -> None:
+        async def _run() -> None:
+            self._status[name] = {
+                "status": "running",
+                "started": datetime.utcnow().isoformat(),
+            }
+            try:
+                await func()
+            except Exception as exc:  # pragma: no cover - background errors
+                logger.exception("Job %s failed: %s", name, exc)
+                self._status[name] = {
+                    "status": "error",
+                    "error": str(exc),
+                    "finished": datetime.utcnow().isoformat(),
+                }
+            else:
+                self._status[name] = {
+                    "status": "completed",
+                    "finished": datetime.utcnow().isoformat(),
+                }
+
+        self._queue.enqueue(_run)
+
+    def get_status(self) -> Dict[str, Dict[str, Any]]:
+        """Return status for all scheduled jobs."""
+        return self._status
+
+
+job_manager: AnalyticsJobManager | None = None
+
+
+def init_jobs(scheduler: AsyncScheduler, queue: BackgroundTaskQueue) -> None:
+    """Initialize background analytics jobs."""
+    global job_manager
+    job_manager = AnalyticsJobManager(scheduler, queue)

--- a/src/piwardrive/service.py
+++ b/src/piwardrive/service.py
@@ -9,6 +9,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from piwardrive.api.analysis_queries import router as analysis_queries_router
 from piwardrive.api.analytics import router as analytics_router
+from piwardrive.api.analytics_jobs import router as jobs_router
 from piwardrive.api.auth import AUTH_DEP, AuthMiddleware
 from piwardrive.api.auth import router as auth_router
 from piwardrive.api.common import (
@@ -59,6 +60,7 @@ app.include_router(wifi_routes.router)
 app.include_router(bluetooth_routes.router)
 app.include_router(cellular_routes.router)
 app.include_router(analytics_routes.router)
+app.include_router(jobs_router)
 app.include_router(security_routes.router)
 app.include_router(auth_router)
 app.include_router(health_router)

--- a/src/piwardrive/services/analytics_processor.py
+++ b/src/piwardrive/services/analytics_processor.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+"""Background analytics processing tasks."""
+
+import logging
+from datetime import datetime, timedelta
+from typing import Any
+
+import numpy as np
+
+from piwardrive import network_analytics as heuristics
+from piwardrive import persistence
+from piwardrive.services import network_fingerprinting
+
+logger = logging.getLogger(__name__)
+
+
+async def process_hourly_analytics() -> None:
+    """Calculate network statistics for the previous hour."""
+    end = datetime.utcnow().replace(minute=0, second=0, microsecond=0)
+    start = end - timedelta(hours=1)
+    async with persistence._get_conn() as conn:
+        cur = await conn.execute(
+            """
+            SELECT bssid, ssid, channel, encryption_type,
+                   signal_strength_dbm, latitude, longitude
+            FROM wifi_detections
+            WHERE detection_timestamp >= ? AND detection_timestamp < ?
+            """,
+            (start.isoformat(), end.isoformat()),
+        )
+        rows = await cur.fetchall()
+    records = [dict(r) for r in rows]
+
+    grouped: dict[str, list[dict[str, Any]]] = {}
+    for rec in records:
+        bssid = rec.get("bssid")
+        if not bssid:
+            continue
+        grouped.setdefault(bssid, []).append(rec)
+
+    out_rows: list[dict[str, Any]] = []
+    for bssid, items in grouped.items():
+        total = len(items)
+        signals = [
+            float(r["signal_strength_dbm"])
+            for r in items
+            if isinstance(r.get("signal_strength_dbm"), (int, float))
+        ]
+        avg_sig = float(np.mean(signals)) if signals else None
+        max_sig = max(signals) if signals else None
+        min_sig = min(signals) if signals else None
+        var_sig = float(np.var(signals)) if signals else None
+        encs = {r.get("encryption_type") for r in items if r.get("encryption_type")}
+        ssids = {r.get("ssid") for r in items if r.get("ssid")}
+        chans = {r.get("channel") for r in items if r.get("channel") is not None}
+        susp = heuristics.find_suspicious_aps(items)
+        out_rows.append(
+            {
+                "bssid": bssid,
+                "analysis_date": start.isoformat(),
+                "total_detections": total,
+                "unique_locations": None,
+                "avg_signal_strength": avg_sig,
+                "max_signal_strength": max_sig,
+                "min_signal_strength": min_sig,
+                "signal_variance": var_sig,
+                "coverage_radius_meters": None,
+                "mobility_score": None,
+                "encryption_changes": max(0, len(encs) - 1),
+                "ssid_changes": max(0, len(ssids) - 1),
+                "channel_changes": max(0, len(chans) - 1),
+                "suspicious_score": min(1.0, len(susp) / total) if total else 0.0,
+                "last_analyzed": datetime.utcnow().isoformat(),
+            }
+        )
+
+    if out_rows:
+        await persistence.save_network_analytics(out_rows)
+
+
+async def detect_anomalies() -> None:
+    """Identify unusual network patterns."""
+    end = datetime.utcnow()
+    start = end - timedelta(hours=1)
+    async with persistence._get_conn() as conn:
+        cur = await conn.execute(
+            """
+            SELECT scan_session_id, bssid, ssid, channel, encryption_type,
+                   signal_strength_dbm AS signal_dbm, latitude, longitude
+            FROM wifi_detections
+            WHERE detection_timestamp >= ? AND detection_timestamp < ?
+            """,
+            (start.isoformat(), end.isoformat()),
+        )
+        rows = await cur.fetchall()
+    records = [dict(r) for r in rows]
+    anomalies = heuristics.detect_rogue_devices(records)
+    if anomalies:
+        await persistence.save_suspicious_activities(
+            [
+                {
+                    "scan_session_id": a.get("scan_session_id", "adhoc"),
+                    "activity_type": "rogue_ap",
+                    "severity": "medium",
+                    "target_bssid": a.get("bssid"),
+                    "target_ssid": a.get("ssid"),
+                    "evidence": "{}",
+                    "description": "Possible rogue access point",
+                    "detected_at": datetime.utcnow().isoformat(),
+                    "latitude": a.get("latitude"),
+                    "longitude": a.get("longitude"),
+                    "false_positive": False,
+                    "analyst_notes": None,
+                }
+                for a in anomalies
+            ]
+        )
+
+
+async def update_fingerprints() -> None:
+    """Update the device fingerprint database."""
+    end = datetime.utcnow()
+    start = end - timedelta(hours=1)
+    async with persistence._get_conn() as conn:
+        cur = await conn.execute(
+            """
+            SELECT * FROM wifi_detections
+            WHERE detection_timestamp >= ? AND detection_timestamp < ?
+            """,
+            (start.isoformat(), end.isoformat()),
+        )
+        rows = await cur.fetchall()
+    records = [dict(r) for r in rows]
+    await network_fingerprinting.fingerprint_wifi_records(records)
+
+
+async def cleanup_old_data(days: int = 30) -> None:
+    """Remove old records based on the retention policy."""
+    await persistence.purge_old_health(days)
+    await persistence.vacuum()
+
+
+__all__ = [
+    "process_hourly_analytics",
+    "detect_anomalies",
+    "update_fingerprints",
+    "cleanup_old_data",
+]


### PR DESCRIPTION
## Summary
- create analytics background task functions
- schedule analytics jobs and provide status tracking
- expose analytics job status API
- integrate analytics job startup with main app

## Testing
- `pre-commit run --files src/piwardrive/main.py src/piwardrive/service.py src/piwardrive/services/analytics_processor.py src/piwardrive/jobs/analytics_jobs.py src/piwardrive/api/analytics_jobs.py` *(fails: eslint config missing)*
- `pytest` *(fails: 55 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_686807e2e0d08333ae877d9abdb19f8c