### PR TITLE
Add real-time streaming processor

### DIFF
--- a/src/piwardrive/routes/websocket.py
+++ b/src/piwardrive/routes/websocket.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+"""WebSocket and SSE endpoints for live detections."""
+
+import json
+from typing import Any
+
+from fastapi import APIRouter, Request, WebSocket, WebSocketDisconnect
+from fastapi.responses import StreamingResponse
+
+from piwardrive import service
+from piwardrive.services.stream_processor import stream_processor
+
+router = APIRouter(prefix="/stream", tags=["stream"])
+
+
+@router.websocket("/ws/detections")
+async def ws_detections(websocket: WebSocket) -> None:
+    await websocket.accept()
+    queue = stream_processor.register_listener()
+    try:
+        while True:
+            data = await queue.get()
+            try:
+                await service.asyncio.wait_for(websocket.send_json(data), timeout=5)
+            except Exception:
+                break
+    except WebSocketDisconnect:
+        pass
+    finally:
+        stream_processor.unregister_listener(queue)
+        await websocket.close()
+
+
+@router.get("/sse/detections")
+async def sse_detections(request: Request) -> StreamingResponse:
+    async def _gen() -> Any:
+        queue = stream_processor.register_listener()
+        try:
+            while True:
+                if await request.is_disconnected():
+                    break
+                data = await queue.get()
+                yield f"data: {json.dumps(data)}\n\n"
+        finally:
+            stream_processor.unregister_listener(queue)
+
+    headers = {"Cache-Control": "no-cache", "X-Accel-Buffering": "no"}
+    return StreamingResponse(_gen(), media_type="text/event-stream", headers=headers)

--- a/src/piwardrive/routes/wifi.py
+++ b/src/piwardrive/routes/wifi.py
@@ -7,13 +7,14 @@ from datetime import datetime
 from fastapi import APIRouter, Depends
 
 from piwardrive import persistence, service
-from piwardrive.services import network_fingerprinting, security_analyzer
 from piwardrive.models import (
     AccessPoint,
     ErrorResponse,
     WiFiScanRequest,
     WiFiScanResponse,
 )
+from piwardrive.services import network_fingerprinting, security_analyzer
+from piwardrive.services.stream_processor import stream_processor
 from piwardrive.sigint_suite.wifi.scanner import async_scan_wifi
 
 router = APIRouter(prefix="/wifi", tags=["wifi"])
@@ -102,6 +103,7 @@ async def scan_wifi_get(
     await persistence.save_wifi_detections(records)
     await network_fingerprinting.fingerprint_wifi_records(records)
     await security_analyzer.analyze_wifi_records(records)
+    stream_processor.publish_wifi(records)
     return WiFiScanResponse(access_points=aps)
 
 
@@ -187,4 +189,5 @@ async def scan_wifi_post(
     await persistence.save_wifi_detections(records)
     await network_fingerprinting.fingerprint_wifi_records(records)
     await security_analyzer.analyze_wifi_records(records)
+    stream_processor.publish_wifi(records)
     return WiFiScanResponse(access_points=aps)

--- a/src/piwardrive/service.py
+++ b/src/piwardrive/service.py
@@ -36,6 +36,7 @@ from piwardrive.routes import analytics as analytics_routes
 from piwardrive.routes import bluetooth as bluetooth_routes
 from piwardrive.routes import cellular as cellular_routes
 from piwardrive.routes import security as security_routes
+from piwardrive.routes import websocket as websocket_routes
 from piwardrive.routes import wifi as wifi_routes
 
 app = FastAPI()
@@ -69,6 +70,7 @@ app.include_router(system_router)
 app.include_router(analytics_router)
 app.include_router(analysis_queries_router)
 app.include_router(ws_router)
+app.include_router(websocket_routes.router)
 
 __all__ = [
     "app",

--- a/src/piwardrive/services/bluetooth_scanner.py
+++ b/src/piwardrive/services/bluetooth_scanner.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from typing import Iterable, List
 
 from piwardrive import persistence, utils
+from piwardrive.services.stream_processor import stream_processor
 from piwardrive.sigint_suite.bluetooth.scanner import async_scan_bluetooth
 from piwardrive.sigint_suite.models import BluetoothDevice
 
@@ -70,6 +71,7 @@ async def record_bluetooth_detections(devices: Iterable[BluetoothDevice]) -> Non
         for dev in devices
     ]
     await persistence.save_bluetooth_detections(records)
+    stream_processor.publish_bluetooth(records)
 
 
 async def scan_and_save(timeout: int | None = None) -> List[BluetoothDevice]:

--- a/src/piwardrive/services/cellular_scanner.py
+++ b/src/piwardrive/services/cellular_scanner.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from typing import Iterable, List
 
 from piwardrive import persistence, utils
+from piwardrive.services.stream_processor import stream_processor
 from piwardrive.sigint_suite.cellular.tower_scanner import async_scan_towers
 
 
@@ -69,6 +70,7 @@ async def record_cellular_detections(towers: Iterable[object]) -> None:
         for t in towers
     ]
     await persistence.save_cellular_detections(records)
+    stream_processor.publish_cellular(records)
 
 
 async def scan_and_save(timeout: int | None = None) -> List[object]:

--- a/src/piwardrive/services/stream_processor.py
+++ b/src/piwardrive/services/stream_processor.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+"""Real-time detection processing service."""
+
+import asyncio
+import contextlib
+import time
+from typing import Any, Dict, Iterable, Mapping
+
+from piwardrive.services import network_fingerprinting, security_analyzer
+
+
+class StreamProcessor:
+    """Process detection events and broadcast results."""
+
+    def __init__(
+        self,
+        *,
+        max_queue: int = 1000,
+        listener_queue: int = 100,
+        rate_limit: float = 20.0,
+    ) -> None:
+        self._queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue(maxsize=max_queue)
+        self._listeners: set[asyncio.Queue[dict[str, Any]]] = set()
+        self._listener_size = listener_queue
+        self._rate_limit = rate_limit
+        self._task: asyncio.Task[None] | None = None
+        self._running = False
+        self.stats: Dict[str, int] = {
+            "wifi": 0,
+            "bluetooth": 0,
+            "cellular": 0,
+            "alerts": 0,
+        }
+
+    async def start(self) -> None:
+        if self._running:
+            return
+        self._running = True
+        self._task = asyncio.create_task(self._run())
+
+    async def stop(self) -> None:
+        self._running = False
+        if self._task is not None:
+            self._task.cancel()
+            with contextlib.suppress(Exception):
+                await self._task
+            self._task = None
+
+    def register_listener(self) -> asyncio.Queue[dict[str, Any]]:
+        q: asyncio.Queue[dict[str, Any]] = asyncio.Queue(maxsize=self._listener_size)
+        self._listeners.add(q)
+        if not self._running:
+            asyncio.create_task(self.start())
+        return q
+
+    def unregister_listener(self, q: asyncio.Queue[dict[str, Any]]) -> None:
+        self._listeners.discard(q)
+
+    def _enqueue(self, source: str, records: Iterable[Mapping[str, Any]]) -> None:
+        if not records:
+            return
+        try:
+            self._queue.put_nowait({"source": source, "records": list(records)})
+        except asyncio.QueueFull:
+            # drop the oldest item if queue is full
+            try:
+                _ = self._queue.get_nowait()
+                self._queue.task_done()
+                self._queue.put_nowait({"source": source, "records": list(records)})
+            except Exception:
+                pass
+
+    def publish_wifi(self, records: Iterable[Mapping[str, Any]]) -> None:
+        self._enqueue("wifi", records)
+
+    def publish_bluetooth(self, records: Iterable[Mapping[str, Any]]) -> None:
+        self._enqueue("bluetooth", records)
+
+    def publish_cellular(self, records: Iterable[Mapping[str, Any]]) -> None:
+        self._enqueue("cellular", records)
+
+    async def _process_wifi(self, records: list[dict[str, Any]]) -> None:
+        await network_fingerprinting.fingerprint_wifi_records(records)
+        await security_analyzer.analyze_wifi_records(records)
+
+    async def _run(self) -> None:
+        sleep = 1.0 / self._rate_limit if self._rate_limit > 0 else 0.0
+        while self._running:
+            event = await self._queue.get()
+            source = event.get("source")
+            records = event.get("records", [])
+            if source == "wifi":
+                await self._process_wifi(records)
+            self.stats[source] = self.stats.get(source, 0) + len(records)
+            payload = {
+                "timestamp": time.time(),
+                "source": source,
+                "records": records,
+                "stats": self.stats,
+            }
+            for q in list(self._listeners):
+                try:
+                    q.put_nowait(payload)
+                except asyncio.QueueFull:
+                    pass
+            self._queue.task_done()
+            if sleep:
+                await asyncio.sleep(sleep)
+
+
+stream_processor = StreamProcessor()


### PR DESCRIPTION
## Summary
- implement `StreamProcessor` for live data handling
- provide websocket and SSE endpoints for detection streaming
- publish detection events from wifi, bluetooth and cellular services
- expose new routes via FastAPI app

## Testing
- `black src/piwardrive/services/stream_processor.py src/piwardrive/routes/websocket.py src/piwardrive/routes/wifi.py src/piwardrive/service.py src/piwardrive/services/bluetooth_scanner.py src/piwardrive/services/cellular_scanner.py`
- `isort src/piwardrive/services/stream_processor.py src/piwardrive/routes/websocket.py src/piwardrive/routes/wifi.py src/piwardrive/service.py src/piwardrive/services/bluetooth_scanner.py src/piwardrive/services/cellular_scanner.py`
- `pytest -q` *(fails: ValueError during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68680ada982c83339284af75861b2225