### PR TITLE
Add database maintenance services

### DIFF
--- a/src/piwardrive/api/maintenance_jobs.py
+++ b/src/piwardrive/api/maintenance_jobs.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+"""API endpoints exposing maintenance job status."""
+
+from typing import Any, Dict
+
+from fastapi import APIRouter
+
+from piwardrive import service
+from piwardrive.jobs import maintenance_jobs
+
+router = APIRouter(prefix="/maintenance-jobs", tags=["maintenance-jobs"])
+
+
+@router.get("/status")
+async def get_job_status(_auth: Any = service.AUTH_DEP) -> Dict[str, Dict[str, Any]]:
+    """Return execution status for background maintenance jobs."""
+    mgr = maintenance_jobs.job_manager
+    if mgr is None:
+        return {}
+    return mgr.get_status()
+
+
+__all__ = ["router"]

--- a/src/piwardrive/jobs/maintenance_jobs.py
+++ b/src/piwardrive/jobs/maintenance_jobs.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+"""Background scheduler for maintenance tasks."""
+
+import inspect
+import logging
+from datetime import datetime
+from typing import Any, Awaitable, Callable, Dict
+
+from piwardrive.scheduler import AsyncScheduler
+from piwardrive.services import maintenance
+from piwardrive.task_queue import BackgroundTaskQueue
+
+logger = logging.getLogger(__name__)
+
+
+class MaintenanceJobManager:
+    """Schedule database maintenance tasks and track their status."""
+
+    def __init__(self, scheduler: AsyncScheduler, queue: BackgroundTaskQueue) -> None:
+        self._scheduler = scheduler
+        self._queue = queue
+        self._status: Dict[str, Dict[str, Any]] = {}
+
+        self._scheduler.schedule(
+            "vacuum_database",
+            lambda: self.enqueue("vacuum_database", maintenance.vacuum_database),
+            86400,
+        )
+        self._scheduler.schedule(
+            "optimize_indexes",
+            lambda: self.enqueue(
+                "optimize_indexes", maintenance.optimize_database_indexes
+            ),
+            604800,
+        )
+        self._scheduler.schedule(
+            "archive_old_data",
+            lambda: self.enqueue("archive_old_data", maintenance.archive_old_data),
+            604800,
+        )
+        self._scheduler.schedule(
+            "health_reports",
+            lambda: self.enqueue("health_reports", maintenance.generate_health_reports),
+            86400,
+        )
+        self._scheduler.schedule(
+            "backup_database",
+            lambda: self.enqueue("backup_database", maintenance.automatic_backup),
+            86400,
+        )
+        self._scheduler.schedule(
+            "db_health_check",
+            lambda: self.enqueue("db_health_check", maintenance.check_database_health),
+            300,
+        )
+
+    # ------------------------------------------------------------------
+    def enqueue(self, name: str, func: Callable[[], Awaitable[Any]]) -> None:
+        async def _run() -> None:
+            self._status[name] = {
+                "status": "running",
+                "started": datetime.utcnow().isoformat(),
+            }
+            try:
+                result = func()
+                if inspect.isawaitable(result):
+                    await result
+            except Exception as exc:  # pragma: no cover - background errors
+                logger.exception("Job %s failed: %s", name, exc)
+                self._status[name] = {
+                    "status": "error",
+                    "error": str(exc),
+                    "finished": datetime.utcnow().isoformat(),
+                }
+            else:
+                self._status[name] = {
+                    "status": "completed",
+                    "finished": datetime.utcnow().isoformat(),
+                }
+
+        self._queue.enqueue(_run)
+
+    def get_status(self) -> Dict[str, Dict[str, Any]]:
+        """Return status for all scheduled jobs."""
+        return self._status
+
+
+job_manager: MaintenanceJobManager | None = None
+
+
+def init_jobs(scheduler: AsyncScheduler, queue: BackgroundTaskQueue) -> None:
+    """Initialize background maintenance jobs."""
+    global job_manager
+    job_manager = MaintenanceJobManager(scheduler, queue)

--- a/src/piwardrive/service.py
+++ b/src/piwardrive/service.py
@@ -27,6 +27,7 @@ from piwardrive.api.common import (
     service_status_async,
 )
 from piwardrive.api.health import router as health_router
+from piwardrive.api.maintenance_jobs import router as maintenance_jobs_router
 from piwardrive.api.system import collect_widget_metrics as _collect_widget_metrics
 from piwardrive.api.system import router as system_router
 from piwardrive.api.websockets import router as ws_router
@@ -62,6 +63,7 @@ app.include_router(bluetooth_routes.router)
 app.include_router(cellular_routes.router)
 app.include_router(analytics_routes.router)
 app.include_router(jobs_router)
+app.include_router(maintenance_jobs_router)
 app.include_router(security_routes.router)
 app.include_router(auth_router)
 app.include_router(health_router)

--- a/src/piwardrive/services/maintenance.py
+++ b/src/piwardrive/services/maintenance.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+"""Database maintenance and optimization utilities."""
+
+import asyncio
+import csv
+import json
+import logging
+import os
+import shutil
+from dataclasses import asdict
+from datetime import datetime, timedelta
+
+from piwardrive import config, r_integration
+from piwardrive.database_service import db_service
+from piwardrive.notifications import NotificationManager
+from piwardrive.persistence import _db_path, _get_conn, backup_database, shutdown_pool
+from piwardrive.services import db_monitor
+
+logger = logging.getLogger(__name__)
+
+
+async def optimize_database_indexes() -> None:
+    """Run ANALYZE and REINDEX on the active database."""
+    async with _get_conn() as conn:
+        await conn.execute("ANALYZE")
+        await conn.execute("REINDEX")
+        await conn.commit()
+
+
+async def vacuum_database() -> None:
+    """Run VACUUM on the active database."""
+    await db_service.vacuum()
+
+
+async def archive_old_data(days: int = 30) -> None:
+    """Move records older than ``days`` into archive tables."""
+    cutoff = (datetime.utcnow() - timedelta(days=days)).isoformat()
+    tables: dict[str, str] = {
+        "wifi_detections": "detection_timestamp",
+        "bluetooth_detections": "detection_timestamp",
+        "cellular_detections": "detection_timestamp",
+        "gps_tracks": "timestamp",
+    }
+    async with _get_conn() as conn:
+        for table, ts_col in tables.items():
+            archive = f"{table}_archive"
+            await conn.execute(
+                f"CREATE TABLE IF NOT EXISTS {archive} AS SELECT * FROM {table} WHERE 0"
+            )
+            await conn.execute(
+                f"INSERT INTO {archive} SELECT * FROM {table} WHERE {ts_col} < ?",
+                (cutoff,),
+            )
+            await conn.execute(
+                f"DELETE FROM {table} WHERE {ts_col} < ?",
+                (cutoff,),
+            )
+        await conn.commit()
+
+
+async def generate_health_reports() -> None:
+    """Write daily health summary reports to the configured reports directory."""
+    records = await db_service.load_recent_health(10000)
+    if not records:
+        return
+    cfg = config.AppConfig.load()
+    os.makedirs(cfg.reports_dir, exist_ok=True)
+    date = datetime.utcnow().strftime("%Y%m%d")
+    csv_path = os.path.join(cfg.reports_dir, f"health_{date}.csv")
+    with open(csv_path, "w", newline="", encoding="utf-8") as fh:
+        writer = csv.DictWriter(
+            fh,
+            fieldnames=[
+                "timestamp",
+                "cpu_temp",
+                "cpu_percent",
+                "memory_percent",
+                "disk_percent",
+            ],
+        )
+        writer.writeheader()
+        writer.writerows(asdict(r) for r in records)
+
+    plot_path = os.path.join(cfg.reports_dir, f"health_{date}.png")
+    result = await asyncio.to_thread(r_integration.health_summary, csv_path, plot_path)
+    json_path = os.path.join(cfg.reports_dir, f"health_{date}.json")
+    with open(json_path, "w", encoding="utf-8") as fh:
+        json.dump(result, fh)
+
+
+async def check_database_health(nm: NotificationManager | None = None) -> bool:
+    """Verify database connectivity and optionally send alerts."""
+    healthy = await db_monitor.health_check()
+    if not healthy:
+        logger.warning("Database health check failed")
+        if nm is not None:
+            await nm._post({"event": "database_unhealthy"})
+    return healthy
+
+
+async def automatic_backup(dest: str | None = None) -> str:
+    """Create a backup of the database to ``dest`` and return the path."""
+    if dest is None:
+        ts = datetime.utcnow().strftime("%Y%m%d-%H%M%S")
+        dest = os.path.join(config.CONFIG_DIR, f"backup_{ts}.db")
+    await backup_database(dest)
+    return dest
+
+
+async def restore_backup(src: str) -> None:
+    """Restore the database from ``src``."""
+    await shutdown_pool()
+    shutil.copy2(src, _db_path())
+
+
+__all__ = [
+    "optimize_database_indexes",
+    "vacuum_database",
+    "archive_old_data",
+    "generate_health_reports",
+    "check_database_health",
+    "automatic_backup",
+    "restore_backup",
+]


### PR DESCRIPTION
## Summary
- add maintenance utilities for optimizing, vacuuming, archiving, backups
- schedule maintenance jobs and expose status endpoint
- register maintenance router and start/stop jobs in application

## Testing
- `pre-commit run --files src/piwardrive/services/maintenance.py src/piwardrive/jobs/maintenance_jobs.py src/piwardrive/api/maintenance_jobs.py src/piwardrive/service.py src/piwardrive/main.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'boto3')*

------
https://chatgpt.com/codex/tasks/task_e_68681248ee508333b13800f2bb03d167