### PR TITLE
Add export and integration services

### DIFF
--- a/src/piwardrive/services/export_service.py
+++ b/src/piwardrive/services/export_service.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+"""Advanced export helpers for various formats."""
+
+import csv
+import json
+from typing import Any
+
+from piwardrive import export, persistence
+
+
+async def _fetch(query: str) -> list[dict[str, Any]]:
+    async with persistence._get_conn() as conn:
+        cur = await conn.execute(query)
+        rows = await cur.fetchall()
+    return [dict(r) for r in rows]
+
+
+async def export_to_csv(table: str, path: str) -> None:
+    """Export all rows from ``table`` to ``path`` in CSV format."""
+    rows = await _fetch(f"SELECT * FROM {table}")
+    export.export_csv(rows, path, list(rows[0].keys()) if rows else None)
+
+
+async def export_to_json(
+    table: str, path: str, *, group_by: str = "scan_session_id"
+) -> None:
+    """Export rows from ``table`` grouped by ``group_by`` to JSON."""
+    rows = await _fetch(f"SELECT * FROM {table}")
+    grouped: dict[str, list[dict[str, Any]]] = {}
+    for rec in rows:
+        key = str(rec.get(group_by, "default"))
+        grouped.setdefault(key, []).append(rec)
+    with open(path, "w", encoding="utf-8") as fh:
+        json.dump(grouped, fh)
+
+
+async def export_to_kml(path: str) -> None:
+    """Export GPS tracks and detection points to ``path`` as KML."""
+    track_rows = await _fetch(
+        "SELECT latitude AS lat, longitude AS lon "
+        "FROM gps_tracks ORDER BY timestamp"
+    )
+    aps = await _fetch(
+        "SELECT latitude AS lat, longitude AS lon, ssid, bssid, "
+        "signal_strength_dbm as rssi FROM wifi_detections"
+    )
+    bts = await _fetch(
+        "SELECT latitude AS lat, longitude AS lon, device_name as name, "
+        "mac_address as address, rssi_dbm as rssi FROM bluetooth_detections"
+    )
+    track = [
+        (r["lat"], r["lon"])
+        for r in track_rows
+        if r.get("lat") is not None and r.get("lon") is not None
+    ]
+    export.export_map_kml(track, aps, bts, path)
+
+
+async def export_to_wigle(path: str) -> None:
+    """Export Wi-Fi detections to a WiGLE compatible CSV file."""
+    rows = await _fetch(
+        "SELECT bssid, ssid, frequency_mhz, channel, first_seen, last_seen, "
+        "latitude, longitude FROM wifi_detections"
+    )
+    fieldnames = [
+        "netid",
+        "ssid",
+        "frequency_mhz",
+        "channel",
+        "last_seen",
+        "first_seen",
+        "lat",
+        "lon",
+    ]
+    with open(path, "w", newline="", encoding="utf-8") as fh:
+        writer = csv.DictWriter(fh, fieldnames=fieldnames)
+        writer.writeheader()
+        for r in rows:
+            writer.writerow(
+                {
+                    "netid": r.get("bssid"),
+                    "ssid": r.get("ssid"),
+                    "frequency_mhz": r.get("frequency_mhz"),
+                    "channel": r.get("channel"),
+                    "last_seen": r.get("last_seen"),
+                    "first_seen": r.get("first_seen"),
+                    "lat": r.get("latitude"),
+                    "lon": r.get("longitude"),
+                }
+            )
+
+
+__all__ = [
+    "export_to_csv",
+    "export_to_json",
+    "export_to_kml",
+    "export_to_wigle",
+]

--- a/src/piwardrive/services/integration_service.py
+++ b/src/piwardrive/services/integration_service.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+"""Helpers for interacting with external services."""
+
+import json
+import logging
+from datetime import datetime
+from typing import Any, Iterable, Mapping
+
+import httpx
+
+from piwardrive.logging.filters import RateLimiter
+
+logger = logging.getLogger(__name__)
+
+
+class APIClient:
+    """HTTP client with token auth and simple rate limiting."""
+
+    def __init__(
+        self, token: str | None = None, *, max_rate: int = 60, window: int = 60
+    ) -> None:
+        self.token = token
+        self.rate_limiter = RateLimiter(max_rate, window)
+
+    async def request(self, method: str, url: str, **kwargs: Any) -> httpx.Response:
+        if not self.rate_limiter.should_allow(url):
+            raise RuntimeError("rate limit exceeded")
+        headers = kwargs.pop("headers", {})
+        if self.token:
+            headers["Authorization"] = f"Bearer {self.token}"
+        async with httpx.AsyncClient() as client:
+            resp = await client.request(method, url, headers=headers, **kwargs)
+            resp.raise_for_status()
+            return resp
+
+
+async def fetch_stix_taxii(
+    url: str, collection: str, client: APIClient
+) -> list[Mapping[str, Any]]:
+    """Fetch STIX indicators from a TAXII collection."""
+    endpoint = f"{url.rstrip('/')}/collections/{collection}/objects"
+    resp = await client.request("GET", endpoint)
+    data = resp.json()
+    objects = data.get("objects", []) if isinstance(data, Mapping) else []
+    return [obj for obj in objects if isinstance(obj, Mapping)]
+
+
+async def send_to_elasticsearch(
+    url: str, index: str, records: Iterable[Mapping[str, Any]], client: APIClient
+) -> None:
+    """Send ``records`` to an Elasticsearch index."""
+    bulk_lines = []
+    for rec in records:
+        bulk_lines.append(json.dumps({"index": {"_index": index}}))
+        bulk_lines.append(json.dumps(rec))
+    payload = "\n".join(bulk_lines) + "\n"
+    await client.request(
+        "POST",
+        f"{url.rstrip('/')}/_bulk",
+        content=payload,
+        headers={"Content-Type": "application/x-ndjson"},
+    )
+
+
+async def push_metrics_to_grafana(
+    url: str, metrics: Mapping[str, Any], client: APIClient
+) -> None:
+    """Send metrics to Grafana via HTTP."""
+    await client.request("POST", url, json=dict(metrics))
+
+
+async def broadcast_webhooks(urls: Iterable[str], payload: Mapping[str, Any]) -> None:
+    """POST ``payload`` to each webhook ``url``."""
+    async with httpx.AsyncClient() as http:
+        for url in urls:
+            try:
+                await http.post(url, json=payload)
+            except Exception as exc:  # pragma: no cover - network errors
+                logger.warning("webhook %s failed: %s", url, exc)
+
+
+class IntegrationMonitor:
+    """Store last success state for integrations."""
+
+    def __init__(self) -> None:
+        self.status: dict[str, dict[str, Any]] = {}
+
+    def update(self, name: str, ok: bool, message: str | None = None) -> None:
+        self.status[name] = {
+            "ok": ok,
+            "message": message,
+            "timestamp": datetime.utcnow().isoformat(),
+        }
+
+    def get_status(self) -> dict[str, dict[str, Any]]:
+        return self.status
+
+
+__all__ = [
+    "APIClient",
+    "fetch_stix_taxii",
+    "send_to_elasticsearch",
+    "push_metrics_to_grafana",
+    "broadcast_webhooks",
+    "IntegrationMonitor",
+]


### PR DESCRIPTION
## Summary
- add `export_service` with CSV/JSON/KML/WiGLE helpers
- add `integration_service` with API client, STIX/TAXII fetch, Elasticsearch export, Grafana metrics, webhooks and monitoring

## Testing
- `pre-commit run --files src/piwardrive/services/export_service.py src/piwardrive/services/integration_service.py` *(fails: flake8/mypy/bandit/pytest/npm)*
- `pytest` *(fails: 55 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_686814f3f5488333b3b88361cb55a95f