### PR TITLE
Add live monitoring components

### DIFF
--- a/webui/src/components/LiveMetrics.jsx
+++ b/webui/src/components/LiveMetrics.jsx
@@ -1,0 +1,41 @@
+import { useState } from 'react';
+import { Line } from 'react-chartjs-2';
+import { Chart as ChartJS, CategoryScale, LinearScale, PointElement, LineElement } from 'chart.js';
+import { useWebSocket } from '../useWebSocket.js';
+
+ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement);
+
+export default function LiveMetrics() {
+  const [labels, setLabels] = useState([]);
+  const [rates, setRates] = useState([]);
+  const [perf, setPerf] = useState(null);
+  const [alerts, setAlerts] = useState([]);
+  const [net, setNet] = useState(null);
+
+  const { status } = useWebSocket('/ws/metrics', {
+    onMessage: raw => {
+      try {
+        const data = JSON.parse(raw);
+        if (data.rate != null) {
+          setLabels(l => [...l.slice(-59), l.length]);
+          setRates(r => [...r.slice(-59), data.rate]);
+        }
+        if (data.perf) setPerf(data.perf);
+        if (data.alert) setAlerts(a => [...a.slice(-9), data.alert]);
+        if (data.net) setNet(data.net);
+      } catch (_) {}
+    }
+  });
+
+  const opts = { animation: false, scales: { y: { beginAtZero: true } } };
+
+  return (
+    <div>
+      <div>Connection: {status}</div>
+      <Line data={{ labels, datasets: [{ label: 'Detections/s', data: rates, borderColor: 'green', tension: 0.2 }] }} options={opts} />
+      {perf && <div>CPU: {perf.cpu}% RAM: {perf.ram}%</div>}
+      {net && <div>Network: {net.tx}/{net.rx}</div>}
+      {alerts.map((a, i) => <div key={i} style={{ color: 'red' }}>{a}</div>)}
+    </div>
+  );
+}

--- a/webui/src/components/LiveMonitoring.jsx
+++ b/webui/src/components/LiveMonitoring.jsx
@@ -1,0 +1,63 @@
+import { useEffect, useRef, useState } from 'react';
+import { MapContainer, TileLayer, Marker, Popup } from 'react-leaflet';
+import { useWebSocket } from '../useWebSocket.js';
+
+export default function LiveMonitoring() {
+  const [feed, setFeed] = useState([]);
+  const [stats, setStats] = useState({ total: 0 });
+  const [markers, setMarkers] = useState([]);
+  const feedRef = useRef(null);
+  const { status } = useWebSocket('/ws/live', {
+    onMessage: raw => {
+      try {
+        const data = JSON.parse(raw);
+        if (data.detection) {
+          setFeed(f => [...f.slice(-99), data.detection]);
+          if (data.detection.lat != null && data.detection.lon != null) {
+            setMarkers(m => [...m.slice(-99), {
+              lat: data.detection.lat,
+              lon: data.detection.lon,
+              text: data.detection.text
+            }]);
+          }
+        }
+        if (data.stats) setStats(data.stats);
+      } catch (_) {}
+    }
+  });
+
+  useEffect(() => {
+    if (feedRef.current) feedRef.current.scrollTop = feedRef.current.scrollHeight;
+  }, [feed]);
+
+  const quality = feed.length && feed[feed.length - 1].ts
+    ? (Date.now() - feed[feed.length - 1].ts < 10000 ? 'good' : 'stale')
+    : 'unknown';
+
+  return (
+    <div>
+      <div>Connection: {status} (data {quality})</div>
+      <div style={{ display: 'flex' }}>
+        <div
+          ref={feedRef}
+          style={{ overflowY: 'auto', maxHeight: '200px', flex: 1, border: '1px solid #ccc', padding: '4px' }}
+        >
+          {feed.map((e, i) => (
+            <div key={i}>{e.text || JSON.stringify(e)}</div>
+          ))}
+        </div>
+        <div style={{ width: '300px', height: '200px', marginLeft: '1em' }}>
+          <MapContainer center={[0, 0]} zoom={2} style={{ height: '100%' }}>
+            <TileLayer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png" />
+            {markers.map((m, idx) => (
+              <Marker key={idx} position={[m.lat, m.lon]}>
+                <Popup>{m.text}</Popup>
+              </Marker>
+            ))}
+          </MapContainer>
+        </div>
+      </div>
+      <div>Detections: {stats.total ?? 0}</div>
+    </div>
+  );
+}

--- a/webui/src/components/ScanningStatus.jsx
+++ b/webui/src/components/ScanningStatus.jsx
@@ -1,0 +1,37 @@
+import { useState } from 'react';
+import { useWebSocket } from '../useWebSocket.js';
+
+export default function ScanningStatus() {
+  const [progress, setProgress] = useState(0);
+  const [device, setDevice] = useState({});
+  const [history, setHistory] = useState([]);
+
+  const { status } = useWebSocket('/ws/scan', {
+    onMessage: raw => {
+      try {
+        const data = JSON.parse(raw);
+        if (data.progress != null) setProgress(data.progress);
+        if (data.device) setDevice(data.device);
+        if (data.history) setHistory(data.history);
+      } catch (_) {}
+    }
+  });
+
+  return (
+    <div>
+      <div>Connection: {status}</div>
+      <progress value={progress} max={100} />
+      <div>Device: {device.name || 'N/A'} health: {device.health || 'N/A'}</div>
+      {device.config && (
+        <div>Scan configuration: {JSON.stringify(device.config)}</div>
+      )}
+      {history.length > 0 && (
+        <ul>
+          {history.map((h, i) => (
+            <li key={i}>{h.scan} - {h.result}</li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/webui/src/useWebSocket.js
+++ b/webui/src/useWebSocket.js
@@ -1,0 +1,59 @@
+import { useEffect, useRef, useState } from 'react';
+
+export function useWebSocket(url, { onMessage, buffer = false, protocols } = {}) {
+  const wsRef = useRef(null);
+  const bufferRef = useRef([]);
+  const [status, setStatus] = useState('connecting');
+
+  useEffect(() => {
+    let cancelled = false;
+    let timer = null;
+
+    function connect() {
+      if (cancelled) return;
+      setStatus('connecting');
+      try {
+        const ws = new WebSocket(url, protocols);
+        wsRef.current = ws;
+        ws.onopen = () => {
+          setStatus('open');
+          if (buffer && bufferRef.current.length) {
+            bufferRef.current.forEach(msg => ws.send(msg));
+            bufferRef.current = [];
+          }
+        };
+        ws.onmessage = ev => {
+          if (onMessage) onMessage(ev.data);
+        };
+        ws.onclose = () => {
+          if (cancelled) return;
+          setStatus('closed');
+          timer = setTimeout(connect, 3000);
+        };
+        ws.onerror = () => {
+          ws.close();
+        };
+      } catch (_) {
+        timer = setTimeout(connect, 3000);
+      }
+    }
+
+    connect();
+    return () => {
+      cancelled = true;
+      if (timer) clearTimeout(timer);
+      if (wsRef.current) wsRef.current.close();
+    };
+  }, [url, protocols, onMessage, buffer]);
+
+  const send = msg => {
+    const ws = wsRef.current;
+    if (ws && ws.readyState === WebSocket.OPEN) {
+      ws.send(msg);
+    } else if (buffer) {
+      bufferRef.current.push(msg);
+    }
+  };
+
+  return { send, status };
+}

--- a/webui/tests/liveComponents.test.jsx
+++ b/webui/tests/liveComponents.test.jsx
@@ -1,0 +1,43 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import LiveMonitoring from '../src/components/LiveMonitoring.jsx';
+import LiveMetrics from '../src/components/LiveMetrics.jsx';
+import ScanningStatus from '../src/components/ScanningStatus.jsx';
+
+let socket;
+
+function mockSocket() {
+  socket = {
+    send: vi.fn(),
+    close: vi.fn(),
+    readyState: WebSocket.OPEN
+  };
+  setTimeout(() => socket.onopen && socket.onopen(), 0);
+  return socket;
+}
+
+describe('live components', () => {
+  beforeEach(() => {
+    global.WebSocket = vi.fn(() => mockSocket());
+  });
+
+  it('updates live monitoring feed', async () => {
+    render(<LiveMonitoring />);
+    socket.onmessage({ data: JSON.stringify({ detection: { text: 'd1' }, stats: { total: 1 } }) });
+    expect(await screen.findByText('d1')).toBeInTheDocument();
+    expect(screen.getByText('Detections: 1')).toBeInTheDocument();
+  });
+
+  it('shows metrics alerts', async () => {
+    render(<LiveMetrics />);
+    socket.onmessage({ data: JSON.stringify({ alert: 'ALERT' }) });
+    expect(await screen.findByText('ALERT')).toBeInTheDocument();
+  });
+
+  it('updates scanning status', async () => {
+    render(<ScanningStatus />);
+    socket.onmessage({ data: JSON.stringify({ progress: 50, device: { name: 's1', health: 'ok' } }) });
+    expect(await screen.findByText(/s1/)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add `useWebSocket` helper for reconnecting sockets
- implement `LiveMonitoring` feed with map and counters
- implement `LiveMetrics` with streaming charts
- implement `ScanningStatus` component for scanners
- test new components

## Testing
- `npm install --force` *(fails: peer dependency conflict)*
- `npm test` *(fails: missing modules and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_68681bec57788333be5b9027e2c61a13