### PR TITLE
Add geospatial analytics components

### DIFF
--- a/webui/src/components/GeospatialAnalytics.jsx
+++ b/webui/src/components/GeospatialAnalytics.jsx
@@ -1,0 +1,123 @@
+import { useEffect, useState } from 'react';
+import {
+  MapContainer,
+  TileLayer,
+  CircleMarker,
+  Marker,
+  Popup,
+  Polygon,
+} from 'react-leaflet';
+import 'leaflet/dist/leaflet.css';
+
+function haversine(p1, p2) {
+  const R = 6371000;
+  const lat1 = (p1[0] * Math.PI) / 180;
+  const lat2 = (p2[0] * Math.PI) / 180;
+  const dLat = lat2 - lat1;
+  const dLon = ((p2[1] - p1[1]) * Math.PI) / 180;
+  const a =
+    Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+    Math.cos(lat1) * Math.cos(lat2) * Math.sin(dLon / 2) * Math.sin(dLon / 2);
+  return 2 * R * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+}
+
+function predictSignal(point, aps) {
+  return aps.reduce((acc, ap) => {
+    const d = haversine(point, [ap.lat, ap.lon]);
+    return acc + (ap.power || 1) / ((d || 1) ** 2);
+  }, 0);
+}
+
+export default function GeospatialAnalytics() {
+  const [coverage, setCoverage] = useState([]);
+  const [deadZones, setDeadZones] = useState([]);
+  const [interference, setInterference] = useState([]);
+  const [optimal, setOptimal] = useState([]);
+  const [predicted, setPredicted] = useState([]);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const cov = await fetch('/api/coverage').then(r => r.json());
+        setCoverage(cov.points || []);
+      } catch {
+        setCoverage([]);
+      }
+      try {
+        const dz = await fetch('/api/dead_zones').then(r => r.json());
+        setDeadZones(dz.zones || []);
+      } catch {
+        setDeadZones([]);
+      }
+      try {
+        const intf = await fetch('/api/interference').then(r => r.json());
+        setInterference(intf.sources || []);
+      } catch {
+        setInterference([]);
+      }
+      try {
+        const opt = await fetch('/api/optimal_ap').then(r => r.json());
+        setOptimal(opt.locations || []);
+      } catch {
+        setOptimal([]);
+      }
+    };
+    load();
+  }, []);
+
+  useEffect(() => {
+    if (!optimal.length) return;
+    const grid = [];
+    const min = [-0.01, -0.01];
+    const max = [0.01, 0.01];
+    for (let i = 0; i < 10; i++) {
+      for (let j = 0; j < 10; j++) {
+        const lat = min[0] + ((max[0] - min[0]) * i) / 9;
+        const lon = min[1] + ((max[1] - min[1]) * j) / 9;
+        grid.push([lat, lon]);
+      }
+    }
+    const pred = grid.map(pt => [...pt, predictSignal(pt, optimal)]);
+    setPredicted(pred);
+  }, [optimal]);
+
+  return (
+    <MapContainer center={[0, 0]} zoom={13} style={{ height: '80vh' }}>
+      <TileLayer url="https://{s}.tile.opentopomap.org/{z}/{x}/{y}.png" />
+      {coverage.map(([lat, lon, str], idx) => (
+        <CircleMarker
+          key={`c${idx}`}
+          center={[lat, lon]}
+          radius={10}
+          pathOptions={{ color: 'blue' }}
+        >
+          <Popup>{str.toFixed(1)} dBm</Popup>
+        </CircleMarker>
+      ))}
+      {predicted.map(([lat, lon, str], idx) => (
+        <CircleMarker
+          key={`p${idx}`}
+          center={[lat, lon]}
+          radius={6}
+          pathOptions={{ color: 'green' }}
+        />
+      ))}
+      {deadZones.map((poly, idx) => (
+        <Polygon key={`d${idx}`} positions={poly} pathOptions={{ color: 'gray', dashArray: '4' }} />
+      ))}
+      {interference.map((src, idx) => (
+        <CircleMarker
+          key={`i${idx}`}
+          center={[src.lat, src.lon]}
+          radius={8}
+          pathOptions={{ color: 'red' }}
+        />
+      ))}
+      {optimal.map((pt, idx) => (
+        <Marker key={`o${idx}`} position={[pt.lat, pt.lon]}>
+          <Popup>Suggested</Popup>
+        </Marker>
+      ))}
+    </MapContainer>
+  );
+}

--- a/webui/src/components/InfrastructurePlanner.jsx
+++ b/webui/src/components/InfrastructurePlanner.jsx
@@ -1,0 +1,96 @@
+import { useEffect, useState } from 'react';
+import {
+  MapContainer,
+  TileLayer,
+  CircleMarker,
+  Marker,
+  Popup,
+  Polygon,
+} from 'react-leaflet';
+import 'leaflet/dist/leaflet.css';
+
+function haversine(p1, p2) {
+  const R = 6371000;
+  const lat1 = (p1[0] * Math.PI) / 180;
+  const lat2 = (p2[0] * Math.PI) / 180;
+  const dLat = lat2 - lat1;
+  const dLon = ((p2[1] - p1[1]) * Math.PI) / 180;
+  const a =
+    Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+    Math.cos(lat1) * Math.cos(lat2) * Math.sin(dLon / 2) * Math.sin(dLon / 2);
+  return 2 * R * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+}
+
+function predict(point, aps) {
+  return aps.reduce((acc, ap) => {
+    const d = haversine(point, [ap.lat, ap.lon]);
+    return acc + (ap.power || 1) / ((d || 1) ** 2);
+  }, 0);
+}
+
+export default function InfrastructurePlanner() {
+  const [gaps, setGaps] = useState([]);
+  const [optimal, setOptimal] = useState([]);
+  const [prediction, setPrediction] = useState([]);
+  const [roi, setRoi] = useState(null);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const g = await fetch('/api/planner/gaps').then(r => r.json());
+        setGaps(g.zones || []);
+      } catch {
+        setGaps([]);
+      }
+      try {
+        const o = await fetch('/api/planner/optimal').then(r => r.json());
+        setOptimal(o.locations || []);
+      } catch {
+        setOptimal([]);
+      }
+      try {
+        const r = await fetch('/api/planner/roi').then(r => r.json());
+        setRoi(r.roi ?? null);
+      } catch {
+        setRoi(null);
+      }
+    };
+    load();
+  }, []);
+
+  useEffect(() => {
+    if (!optimal.length) return;
+    const grid = [];
+    const min = [-0.01, -0.01];
+    const max = [0.01, 0.01];
+    for (let i = 0; i < 10; i++) {
+      for (let j = 0; j < 10; j++) {
+        const lat = min[0] + ((max[0] - min[0]) * i) / 9;
+        const lon = min[1] + ((max[1] - min[1]) * j) / 9;
+        grid.push([lat, lon]);
+      }
+    }
+    const pred = grid.map(pt => [...pt, predict(pt, optimal)]);
+    setPrediction(pred);
+  }, [optimal]);
+
+  return (
+    <div>
+      <MapContainer center={[0, 0]} zoom={13} style={{ height: '80vh' }}>
+        <TileLayer url="https://{s}.tile.opentopomap.org/{z}/{x}/{y}.png" />
+        {gaps.map((poly, idx) => (
+          <Polygon key={`g${idx}`} positions={poly} pathOptions={{ color: 'gray', dashArray: '4' }} />
+        ))}
+        {prediction.map(([lat, lon, s], idx) => (
+          <CircleMarker key={`p${idx}`} center={[lat, lon]} radius={6} pathOptions={{ color: 'green' }} />
+        ))}
+        {optimal.map((pt, idx) => (
+          <Marker key={`o${idx}`} position={[pt.lat, pt.lon]}>
+            <Popup>AP</Popup>
+          </Marker>
+        ))}
+      </MapContainer>
+      {roi != null && <div>ROI: {roi}%</div>}
+    </div>
+  );
+}

--- a/webui/src/components/RFEnvironmentMap.jsx
+++ b/webui/src/components/RFEnvironmentMap.jsx
@@ -1,0 +1,76 @@
+import { useEffect, useState } from 'react';
+import {
+  MapContainer,
+  TileLayer,
+  CircleMarker,
+  Polygon,
+  Popup,
+} from 'react-leaflet';
+import 'leaflet/dist/leaflet.css';
+
+export default function RFEnvironmentMap() {
+  const [propagation, setPropagation] = useState([]);
+  const [channels, setChannels] = useState([]);
+  const [interference, setInterference] = useState([]);
+  const [spectrum, setSpectrum] = useState([]);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const p = await fetch('/api/rf/propagation').then(r => r.json());
+        setPropagation(p.points || []);
+      } catch {
+        setPropagation([]);
+      }
+      try {
+        const c = await fetch('/api/rf/channels').then(r => r.json());
+        setChannels(c.utilization || []);
+      } catch {
+        setChannels([]);
+      }
+      try {
+        const i = await fetch('/api/rf/interference').then(r => r.json());
+        setInterference(i.sources || []);
+      } catch {
+        setInterference([]);
+      }
+      try {
+        const s = await fetch('/api/rf/spectrum').then(r => r.json());
+        setSpectrum(s.overlays || []);
+      } catch {
+        setSpectrum([]);
+      }
+    };
+    load();
+  }, []);
+
+  return (
+    <MapContainer center={[0, 0]} zoom={13} style={{ height: '80vh' }}>
+      <TileLayer url="https://{s}.tile.opentopomap.org/{z}/{x}/{y}.png" />
+      {propagation.map(([lat, lon, h], idx) => (
+        <CircleMarker
+          key={`p${idx}`}
+          center={[lat, lon]}
+          radius={Math.min(20, Math.max(2, h))}
+          pathOptions={{ color: 'blue' }}
+        />
+      ))}
+      {channels.map((poly, idx) => (
+        <Polygon key={`c${idx}`} positions={poly.points} pathOptions={{ color: 'purple' }}>
+          <Popup>Ch {poly.channel}: {poly.util}%</Popup>
+        </Polygon>
+      ))}
+      {interference.map((src, idx) => (
+        <CircleMarker
+          key={`i${idx}`}
+          center={[src.lat, src.lon]}
+          radius={8}
+          pathOptions={{ color: 'red' }}
+        />
+      ))}
+      {spectrum.map((sp, idx) => (
+        <Polygon key={`s${idx}`} positions={sp.area} pathOptions={{ color: 'orange' }} />
+      ))}
+    </MapContainer>
+  );
+}

--- a/webui/tests/geospatialComponents.test.jsx
+++ b/webui/tests/geospatialComponents.test.jsx
@@ -1,0 +1,42 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { vi, describe, it, beforeEach, afterEach } from 'vitest';
+import GeospatialAnalytics from '../src/components/GeospatialAnalytics.jsx';
+import RFEnvironmentMap from '../src/components/RFEnvironmentMap.jsx';
+import InfrastructurePlanner from '../src/components/InfrastructurePlanner.jsx';
+
+vi.mock('react-leaflet', () => ({
+  MapContainer: ({ children }) => <div data-testid="map">{children}</div>,
+  TileLayer: () => <div>tile</div>,
+  CircleMarker: ({ children }) => <div>{children}</div>,
+  Marker: ({ children }) => <div>{children}</div>,
+  Popup: ({ children }) => <div>{children}</div>,
+  Polygon: ({ children }) => <div>{children}</div>,
+}));
+
+describe('geospatial components', () => {
+  let origFetch;
+  beforeEach(() => { origFetch = global.fetch; });
+  afterEach(() => { global.fetch = origFetch; });
+
+  it('renders GeospatialAnalytics', async () => {
+    global.fetch = vi.fn(() => Promise.resolve({ json: () => Promise.resolve({}) }));
+    render(<GeospatialAnalytics />);
+    expect(screen.getByTestId('map')).toBeInTheDocument();
+    await waitFor(() => expect(global.fetch).toHaveBeenCalled());
+  });
+
+  it('renders RFEnvironmentMap', async () => {
+    global.fetch = vi.fn(() => Promise.resolve({ json: () => Promise.resolve({}) }));
+    render(<RFEnvironmentMap />);
+    expect(screen.getByTestId('map')).toBeInTheDocument();
+    await waitFor(() => expect(global.fetch).toHaveBeenCalled());
+  });
+
+  it('renders InfrastructurePlanner', async () => {
+    global.fetch = vi.fn(() => Promise.resolve({ json: () => Promise.resolve({}) }));
+    render(<InfrastructurePlanner />);
+    expect(screen.getByTestId('map')).toBeInTheDocument();
+    await waitFor(() => expect(global.fetch).toHaveBeenCalled());
+  });
+});


### PR DESCRIPTION
## Summary
- add `GeospatialAnalytics` for coverage analysis and interference mapping
- add `RFEnvironmentMap` for RF visualization
- add `InfrastructurePlanner` with predictive coverage modeling
- test render of geospatial components

## Testing
- `npm test` *(fails: server and libraries missing)*
- `pytest -q` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68681c0a6c4c8333ac72ba10e408793f