### PR TITLE
Add predictive analytics React widgets

### DIFF
--- a/src/piwardrive/analytics/__init__.py
+++ b/src/piwardrive/analytics/__init__.py
@@ -2,7 +2,20 @@
 
 from .clustering import cluster_positions
 from .forecasting import forecast_cpu_temp
+from .predictive import (
+    capacity_planning_forecast,
+    failure_prediction,
+    identify_expansion_opportunities,
+    linear_forecast,
+    predict_network_lifecycle,
+)
 
-__all__ = ["cluster_positions", "forecast_cpu_temp"]
-
-
+__all__ = [
+    "cluster_positions",
+    "forecast_cpu_temp",
+    "linear_forecast",
+    "predict_network_lifecycle",
+    "capacity_planning_forecast",
+    "failure_prediction",
+    "identify_expansion_opportunities",
+]

--- a/src/piwardrive/analytics/predictive.py
+++ b/src/piwardrive/analytics/predictive.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+"""Predictive analytics helpers using simple ML models."""
+
+from typing import Iterable, List, Mapping, Tuple
+
+import numpy as np
+from sklearn.linear_model import LinearRegression
+
+__all__ = [
+    "linear_forecast",
+    "predict_network_lifecycle",
+    "capacity_planning_forecast",
+    "failure_prediction",
+    "identify_expansion_opportunities",
+]
+
+
+def linear_forecast(
+    values: Iterable[float], steps: int
+) -> Tuple[List[float], List[float]]:
+    """Return predictions and 95% confidence intervals for ``values``."""
+    arr = np.array(list(values), dtype=float)
+    if arr.size == 0:
+        return [float("nan")] * steps, [float("nan")] * steps
+    x = np.arange(arr.size).reshape(-1, 1)
+    model = LinearRegression().fit(x, arr)
+    future_x = np.arange(arr.size, arr.size + steps).reshape(-1, 1)
+    preds = model.predict(future_x)
+    y_pred = model.predict(x)
+    resid = arr - y_pred
+    s_err = float(np.sqrt(np.sum(resid**2) / max(arr.size - 2, 1)))
+    t_val = 1.96
+    mean_x = float(x.mean())
+    denom = float(np.sum((x.flatten() - mean_x) ** 2)) or 1.0
+    ci = (
+        t_val
+        * s_err
+        * np.sqrt(1 + 1 / arr.size + (future_x.flatten() - mean_x) ** 2 / denom)
+    )
+    return preds.tolist(), ci.tolist()
+
+
+def predict_network_lifecycle(
+    records: Iterable[Mapping[str, float]], steps: int
+) -> Tuple[List[float], List[float]]:
+    """Forecast network activity for lifecycle management."""
+    vals = [
+        r.get("total_detections")
+        for r in records
+        if isinstance(r.get("total_detections"), (int, float))
+    ]
+    return linear_forecast(vals, steps)
+
+
+def capacity_planning_forecast(
+    records: Iterable[Mapping[str, float]], steps: int
+) -> Tuple[List[float], List[float]]:
+    """Predict network capacity needs based on unique networks."""
+    vals = [
+        r.get("unique_networks")
+        for r in records
+        if isinstance(r.get("unique_networks"), (int, float))
+    ]
+    return linear_forecast(vals, steps)
+
+
+def failure_prediction(
+    records: Iterable[Mapping[str, float]], steps: int
+) -> Tuple[List[float], List[float]]:
+    """Predict failure probability from suspicious scores."""
+    vals = [
+        r.get("suspicious_score")
+        for r in records
+        if isinstance(r.get("suspicious_score"), (int, float))
+    ]
+    preds, ci = linear_forecast(vals, steps)
+    prob = [float(1 / (1 + np.exp(-p))) for p in preds]
+    return prob, ci
+
+
+def identify_expansion_opportunities(
+    records: Iterable[Mapping[str, float]],
+) -> List[str]:
+    """Return BSSIDs with large unique location counts suggesting expansion."""
+    result = []
+    for r in records:
+        locs = r.get("unique_locations")
+        if isinstance(locs, (int, float)) and locs > 100:
+            result.append(str(r.get("bssid", "")))
+    return result

--- a/src/piwardrive/api/analytics/endpoints.py
+++ b/src/piwardrive/api/analytics/endpoints.py
@@ -5,6 +5,12 @@ from typing import Any
 from fastapi import APIRouter
 
 from piwardrive import persistence, service
+from piwardrive.analytics import (
+    capacity_planning_forecast,
+    failure_prediction,
+    identify_expansion_opportunities,
+    predict_network_lifecycle,
+)
 
 router = APIRouter(prefix="/analytics", tags=["analytics"])
 
@@ -42,3 +48,42 @@ async def get_coverage_grid(
     _auth: Any = service.AUTH_DEP,
 ) -> list[dict[str, Any]]:
     return await persistence.load_network_coverage_grid(limit=limit, offset=offset)
+
+
+@router.get("/lifecycle")
+async def get_lifecycle_forecast(
+    bssid: str | None = None,
+    steps: int = 7,
+    _auth: Any = service.AUTH_DEP,
+) -> dict[str, list[float]]:
+    rows = await persistence.load_network_analytics(bssid=bssid, limit=50)
+    pred, ci = predict_network_lifecycle(rows, steps)
+    return {"forecast": pred, "confidence": ci}
+
+
+@router.get("/capacity")
+async def get_capacity_forecast(
+    steps: int = 7,
+    _auth: Any = service.AUTH_DEP,
+) -> dict[str, list[float]]:
+    rows = await persistence.load_daily_detection_stats(limit=50)
+    pred, ci = capacity_planning_forecast(rows, steps)
+    return {"forecast": pred, "confidence": ci}
+
+
+@router.get("/predictive")
+async def get_predictive_summary(
+    _auth: Any = service.AUTH_DEP,
+) -> dict[str, Any]:
+    lifecycle_rows = await persistence.load_network_analytics(limit=50)
+    daily_rows = await persistence.load_daily_detection_stats(limit=50)
+    life_pred, life_ci = predict_network_lifecycle(lifecycle_rows, 7)
+    cap_pred, cap_ci = capacity_planning_forecast(daily_rows, 7)
+    fail_pred, fail_ci = failure_prediction(lifecycle_rows, 7)
+    expansion = identify_expansion_opportunities(lifecycle_rows)
+    return {
+        "lifecycle": {"forecast": life_pred, "confidence": life_ci},
+        "capacity": {"forecast": cap_pred, "confidence": cap_ci},
+        "failure": {"forecast": fail_pred, "confidence": fail_ci},
+        "expansion": expansion,
+    }

--- a/webui/src/components/CapacityPlanner.jsx
+++ b/webui/src/components/CapacityPlanner.jsx
@@ -1,0 +1,21 @@
+import { useEffect, useState } from 'react';
+
+export default function CapacityPlanner() {
+  const [data, setData] = useState(null);
+
+  useEffect(() => {
+    fetch('/api/analytics/capacity')
+      .then((r) => r.json())
+      .then((d) => setData(d))
+      .catch(() => setData(null));
+  }, []);
+
+  if (!data) return <div>Capacity planning data unavailable</div>;
+
+  return (
+    <div>
+      <h4>Usage Forecast (95% CI)</h4>
+      <pre>{JSON.stringify(data)}</pre>
+    </div>
+  );
+}

--- a/webui/src/components/NetworkLifecycle.jsx
+++ b/webui/src/components/NetworkLifecycle.jsx
@@ -1,0 +1,24 @@
+import { useEffect, useState } from 'react';
+
+export default function NetworkLifecycle({ bssid }) {
+  const [data, setData] = useState(null);
+
+  useEffect(() => {
+    const url = bssid
+      ? `/api/analytics/lifecycle?bssid=${encodeURIComponent(bssid)}`
+      : '/api/analytics/lifecycle';
+    fetch(url)
+      .then((r) => r.json())
+      .then((d) => setData(d))
+      .catch(() => setData(null));
+  }, [bssid]);
+
+  if (!data) return <div>Network lifecycle data unavailable</div>;
+
+  return (
+    <div>
+      <h4>Upgrade Prediction Timeline (95% CI)</h4>
+      <pre>{JSON.stringify(data)}</pre>
+    </div>
+  );
+}

--- a/webui/src/components/PredictiveAnalytics.jsx
+++ b/webui/src/components/PredictiveAnalytics.jsx
@@ -1,0 +1,29 @@
+import { useEffect, useState } from 'react';
+
+export default function PredictiveAnalytics() {
+  const [data, setData] = useState(null);
+
+  useEffect(() => {
+    fetch('/api/analytics/predictive')
+      .then((r) => r.json())
+      .then((d) => setData(d))
+      .catch(() => setData(null));
+  }, []);
+
+  if (!data) return <div>Predictive analytics unavailable</div>;
+
+  const { lifecycle, capacity, failure, expansion } = data;
+
+  return (
+    <div>
+      <h4>Network Lifecycle Prediction (95% CI)</h4>
+      <pre>{JSON.stringify(lifecycle)}</pre>
+      <h4>Capacity Planning Forecast (95% CI)</h4>
+      <pre>{JSON.stringify(capacity)}</pre>
+      <h4>Failure Probability Forecast (95% CI)</h4>
+      <pre>{JSON.stringify(failure)}</pre>
+      <h4>Expansion Opportunities</h4>
+      <pre>{JSON.stringify(expansion)}</pre>
+    </div>
+  );
+}

--- a/webui/tests/capacityPlanner.test.jsx
+++ b/webui/tests/capacityPlanner.test.jsx
@@ -1,0 +1,24 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import CapacityPlanner from '../src/components/CapacityPlanner.jsx';
+
+describe('CapacityPlanner', () => {
+  let origFetch;
+  beforeEach(() => {
+    origFetch = global.fetch;
+  });
+  afterEach(() => {
+    global.fetch = origFetch;
+  });
+
+  it('fetches capacity data', async () => {
+    global.fetch = vi.fn(() =>
+      Promise.resolve({
+        json: () => Promise.resolve({ forecast: [1], confidence: [0.1] }),
+      })
+    );
+    render(<CapacityPlanner />);
+    expect(await screen.findByText(/Usage Forecast/)).toBeInTheDocument();
+  });
+});

--- a/webui/tests/networkLifecycle.test.jsx
+++ b/webui/tests/networkLifecycle.test.jsx
@@ -1,0 +1,24 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import NetworkLifecycle from '../src/components/NetworkLifecycle.jsx';
+
+describe('NetworkLifecycle', () => {
+  let origFetch;
+  beforeEach(() => {
+    origFetch = global.fetch;
+  });
+  afterEach(() => {
+    global.fetch = origFetch;
+  });
+
+  it('fetches lifecycle data', async () => {
+    global.fetch = vi.fn(() =>
+      Promise.resolve({
+        json: () => Promise.resolve({ forecast: [1], confidence: [0.1] }),
+      })
+    );
+    render(<NetworkLifecycle />);
+    expect(await screen.findByText(/Upgrade Prediction/)).toBeInTheDocument();
+  });
+});

--- a/webui/tests/predictiveAnalytics.test.jsx
+++ b/webui/tests/predictiveAnalytics.test.jsx
@@ -1,0 +1,30 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import PredictiveAnalytics from '../src/components/PredictiveAnalytics.jsx';
+
+describe('PredictiveAnalytics', () => {
+  let origFetch;
+  beforeEach(() => {
+    origFetch = global.fetch;
+  });
+  afterEach(() => {
+    global.fetch = origFetch;
+  });
+
+  it('shows forecast data', async () => {
+    global.fetch = vi.fn(() =>
+      Promise.resolve({
+        json: () =>
+          Promise.resolve({
+            lifecycle: { forecast: [1], confidence: [0.1] },
+            capacity: { forecast: [2], confidence: [0.2] },
+            failure: { forecast: [0.3], confidence: [0.05] },
+            expansion: ['ap1'],
+          }),
+      })
+    );
+    render(<PredictiveAnalytics />);
+    expect(await screen.findByText(/Lifecycle Prediction/)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- create predictive ML models for network trends
- expose lifecycle and capacity forecasting endpoints
- export new analytics utilities
- add PredictiveAnalytics, NetworkLifecycle, and CapacityPlanner components
- test predictive components

## Testing
- `pytest -q` *(fails: Unable to configure formatter)*
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68681c0f8a948333bb12e405e9b93aca