### PR TITLE
Add ML dashboard and training services

### DIFF
--- a/src/piwardrive/analytics/explain.py
+++ b/src/piwardrive/analytics/explain.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+"""Model explainability helpers."""
+
+from typing import Any, Iterable
+
+import numpy as np
+from sklearn.inspection import permutation_importance
+
+
+def compute_feature_importance(model: Any, X: Iterable[Any], y: Iterable[Any]) -> dict[str, float]:
+    """Return feature importance mapping for ``model``."""
+    X_arr = np.array(list(X))
+    y_arr = np.array(list(y))
+    if hasattr(model, "feature_importances_"):
+        names = getattr(model, "feature_names_in_", [str(i) for i in range(X_arr.shape[1])])
+        return {str(n): float(v) for n, v in zip(names, model.feature_importances_)}
+    result = permutation_importance(model, X_arr, y_arr, n_repeats=5, random_state=0)
+    names = getattr(model, "feature_names_in_", [str(i) for i in range(X_arr.shape[1])])
+    return {str(n): float(v) for n, v in zip(names, result.importances_mean)}
+
+
+def explain_prediction(model: Any, x: Iterable[Any]) -> dict[str, Any]:
+    """Return explanation values for a single prediction."""
+    arr = np.array([list(x)])
+    try:
+        import shap  # type: ignore
+    except Exception:
+        if hasattr(model, "predict_proba"):
+            proba = model.predict_proba(arr)[0]
+            return {"proba": [float(p) for p in proba]}
+        return {"prediction": float(model.predict(arr)[0])}
+    explainer = shap.Explainer(model)
+    vals = explainer(arr)
+    return {"values": [float(v) for v in vals.values[0]]}
+
+
+__all__ = ["compute_feature_importance", "explain_prediction"]

--- a/src/piwardrive/main.py
+++ b/src/piwardrive/main.py
@@ -29,6 +29,7 @@ from piwardrive.persistence import AppState, _db_path, load_app_state, save_app_
 from piwardrive.scheduler import AsyncScheduler, PollScheduler
 from piwardrive.security import hash_password
 from piwardrive.services.view_refresher import ViewRefresher
+from piwardrive.services.model_trainer import ModelTrainer
 from piwardrive.task_queue import BackgroundTaskQueue
 
 logging.getLogger("urllib3").setLevel(logging.WARNING)
@@ -81,6 +82,7 @@ class PiWardriveApp:
             vacuum=True,
         )
         self.view_refresher = ViewRefresher(self.scheduler)
+        self.model_trainer = ModelTrainer(self.scheduler)
         self.analytics_queue = BackgroundTaskQueue(workers=2)
         self.analytics_scheduler = AsyncScheduler()
         self.maintenance_queue = BackgroundTaskQueue()

--- a/src/piwardrive/services/model_trainer.py
+++ b/src/piwardrive/services/model_trainer.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+"""Automated ML model retraining service."""
+
+from piwardrive import analysis, persistence
+from piwardrive.scheduler import PollScheduler
+from piwardrive.utils import run_async_task
+
+
+class ModelTrainer:
+    """Periodically retrain anomaly detection models."""
+
+    def __init__(self, scheduler: PollScheduler, interval: int = 3600) -> None:
+        self._scheduler = scheduler
+        self._event = "ml_trainer"
+        scheduler.schedule(self._event, lambda _dt: run_async_task(self.run()), interval)
+        run_async_task(self.run())
+
+    async def run(self) -> None:
+        detector = getattr(analysis, "_ANOMALY_DETECTOR", None)
+        if detector is None or not hasattr(detector, "fit"):
+            return
+        records = await persistence.load_health_history(limit=500)
+        detector.fit(records)
+
+
+__all__ = ["ModelTrainer"]

--- a/tests/test_model_trainer.py
+++ b/tests/test_model_trainer.py
@@ -1,0 +1,38 @@
+import asyncio
+from types import SimpleNamespace
+
+from piwardrive.services import model_trainer
+from piwardrive import analysis, persistence
+
+
+class DummyScheduler:
+    def __init__(self) -> None:
+        self.scheduled = []
+
+    def schedule(self, name, cb, interval):
+        self.scheduled.append((name, interval))
+        cb(0)
+
+    def cancel(self, name):
+        pass
+
+
+async def _fake_load(limit=500):
+    return [1, 2, 3]
+
+
+def test_model_trainer_runs(monkeypatch):
+    dummy = SimpleNamespace(count=0)
+
+    def fit(records):
+        dummy.count = len(records)
+
+    dummy.fit = fit
+    monkeypatch.setattr(analysis, "_ANOMALY_DETECTOR", dummy, raising=False)
+    monkeypatch.setattr(persistence, "load_health_history", _fake_load)
+    monkeypatch.setattr(model_trainer, "run_async_task", lambda coro: asyncio.run(coro))
+
+    sched = DummyScheduler()
+    model_trainer.ModelTrainer(sched, interval=5)
+    assert sched.scheduled[0][0] == "ml_trainer"
+    assert dummy.count == 3

--- a/webui/src/components/AnomalyDetection.jsx
+++ b/webui/src/components/AnomalyDetection.jsx
@@ -1,0 +1,40 @@
+import { useEffect, useState } from 'react';
+
+export default function AnomalyDetection({ metrics }) {
+  const [anomalies, setAnomalies] = useState(metrics?.anomalies ?? []);
+  const [baseline, setBaseline] = useState(metrics?.baseline ?? null);
+
+  useEffect(() => {
+    if (metrics) {
+      setAnomalies(metrics.anomalies || []);
+      setBaseline(metrics.baseline ?? null);
+      return;
+    }
+    const load = () => {
+      fetch('/anomaly')
+        .then(r => r.json())
+        .then(d => {
+          setAnomalies(d.anomalies || []);
+          setBaseline(d.baseline || null);
+        })
+        .catch(() => {
+          setAnomalies([]);
+          setBaseline(null);
+        });
+    };
+    load();
+    const id = setInterval(load, 5000);
+    return () => clearInterval(id);
+  }, [metrics]);
+
+  return (
+    <div>
+      <div>Baseline: {baseline ?? 'N/A'}</div>
+      <ul>
+        {anomalies.map((a, i) => (
+          <li key={i}>{a}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/webui/src/components/DeviceFingerprinting.jsx
+++ b/webui/src/components/DeviceFingerprinting.jsx
@@ -1,0 +1,31 @@
+import { useEffect, useState } from 'react';
+
+export default function DeviceFingerprinting({ metrics }) {
+  const [devices, setDevices] = useState(metrics?.devices ?? []);
+
+  useEffect(() => {
+    if (metrics) {
+      setDevices(metrics.devices || []);
+      return;
+    }
+    const load = () => {
+      fetch('/fingerprinting')
+        .then(r => r.json())
+        .then(d => setDevices(d.devices || []))
+        .catch(() => setDevices([]));
+    };
+    load();
+    const id = setInterval(load, 10000);
+    return () => clearInterval(id);
+  }, [metrics]);
+
+  return (
+    <ul>
+      {devices.map((d, i) => (
+        <li key={i}>
+          {d.type || d.device_type}: {d.vendor} ({d.confidence != null ? (d.confidence * 100).toFixed(0) + '%' : 'N/A'})
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/webui/src/components/MLDashboard.jsx
+++ b/webui/src/components/MLDashboard.jsx
@@ -1,0 +1,50 @@
+import { useEffect, useState } from 'react';
+
+export default function MLDashboard({ metrics }) {
+  const [performance, setPerformance] = useState(metrics?.performance ?? null);
+  const [accuracy, setAccuracy] = useState(metrics?.accuracy ?? null);
+  const [features, setFeatures] = useState(metrics?.features ?? []);
+  const [progress, setProgress] = useState(metrics?.progress ?? null);
+
+  useEffect(() => {
+    if (metrics) {
+      setPerformance(metrics.performance);
+      setAccuracy(metrics.accuracy);
+      setFeatures(metrics.features || []);
+      setProgress(metrics.progress);
+      return;
+    }
+    const load = () => {
+      fetch('/ml/metrics')
+        .then(r => r.json())
+        .then(d => {
+          setPerformance(d.performance);
+          setAccuracy(d.accuracy);
+          setFeatures(d.features || []);
+          setProgress(d.progress);
+        })
+        .catch(() => {
+          setPerformance(null);
+          setAccuracy(null);
+          setFeatures([]);
+          setProgress(null);
+        });
+    };
+    load();
+    const id = setInterval(load, 10000);
+    return () => clearInterval(id);
+  }, [metrics]);
+
+  return (
+    <div>
+      <div>Performance: {performance ?? 'N/A'}</div>
+      <div>Accuracy: {accuracy ?? 'N/A'}</div>
+      <div>Training: {progress ?? 'N/A'}%</div>
+      <ul>
+        {features.map((f, idx) => (
+          <li key={idx}>{f.name || f.feature}: {f.importance}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/webui/tests/anomalyDetection.test.jsx
+++ b/webui/tests/anomalyDetection.test.jsx
@@ -1,0 +1,12 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, it, expect } from 'vitest';
+import AnomalyDetection from '../src/components/AnomalyDetection.jsx';
+
+describe('AnomalyDetection', () => {
+  it('shows anomalies from metrics', () => {
+    render(<AnomalyDetection metrics={{ baseline: 'normal', anomalies: ['cpu'] }} />);
+    expect(screen.getByText('Baseline: normal')).toBeInTheDocument();
+    expect(screen.getByText('cpu')).toBeInTheDocument();
+  });
+});

--- a/webui/tests/deviceFingerprinting.test.jsx
+++ b/webui/tests/deviceFingerprinting.test.jsx
@@ -1,0 +1,12 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, it, expect } from 'vitest';
+import DeviceFingerprinting from '../src/components/DeviceFingerprinting.jsx';
+
+describe('DeviceFingerprinting', () => {
+  it('lists device info', () => {
+    render(<DeviceFingerprinting metrics={{ devices: [{ device_type: 'phone', vendor: 'Apple', confidence: 0.8 }] }} />);
+    expect(screen.getByText(/phone/)).toBeInTheDocument();
+    expect(screen.getByText(/Apple/)).toBeInTheDocument();
+  });
+});

--- a/webui/tests/mlDashboard.test.jsx
+++ b/webui/tests/mlDashboard.test.jsx
@@ -1,0 +1,13 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, it, expect } from 'vitest';
+import MLDashboard from '../src/components/MLDashboard.jsx';
+
+describe('MLDashboard', () => {
+  it('renders metrics from props', () => {
+    render(<MLDashboard metrics={{ performance: 'ok', accuracy: 0.9, progress: 50, features: [{ name: 'a', importance: 0.5 }] }} />);
+    expect(screen.getByText('Performance: ok')).toBeInTheDocument();
+    expect(screen.getByText('Accuracy: 0.9')).toBeInTheDocument();
+    expect(screen.getByText(/a:/)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add MLDashboard, AnomalyDetection and DeviceFingerprinting components
- provide feature importance helpers and prediction explanation
- automate model retraining through ModelTrainer service
- include unit tests for new ML features

## Testing
- `npx vitest run tests/mlDashboard.test.jsx tests/anomalyDetection.test.jsx tests/deviceFingerprinting.test.jsx`
- `pytest -q tests/test_model_trainer.py`
- `npx vitest run` *(fails: orientation sensors pkg missing dbus)*

------
https://chatgpt.com/codex/tasks/task_e_68681c25b7b88333a3dd8457620429de