### PR TITLE
Add demographic analytics components and API

### DIFF
--- a/examples/demographic_data.json
+++ b/examples/demographic_data.json
@@ -1,0 +1,5 @@
+[
+  {"region": "Area1", "population": 10000, "median_income": 50000, "tech_access": 0.8, "latitude": 40.7128, "longitude": -74.0060},
+  {"region": "Area2", "population": 8000, "median_income": 42000, "tech_access": 0.6, "latitude": 40.7138, "longitude": -74.0020},
+  {"region": "Area3", "population": 12000, "median_income": 55000, "tech_access": 0.9, "latitude": 40.7158, "longitude": -74.0050}
+]

--- a/src/piwardrive/api/demographics/__init__.py
+++ b/src/piwardrive/api/demographics/__init__.py
@@ -1,0 +1,1 @@
+from .endpoints import router

--- a/src/piwardrive/api/demographics/endpoints.py
+++ b/src/piwardrive/api/demographics/endpoints.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+"""Demographic analytics API routes."""
+
+from typing import Any, Dict
+
+from fastapi import APIRouter
+
+from piwardrive.services import demographic_analytics
+from piwardrive import service
+
+router = APIRouter(prefix="/demographics", tags=["demographics"])
+
+
+@router.get("/social")
+async def get_social_insights(_auth: Any = service.AUTH_DEP) -> Dict[str, Any]:
+    """Return social analytics derived from demographic data."""
+    return {
+        "socioeconomic_correlation": demographic_analytics.socioeconomic_correlation(),
+        "technology_adoption_patterns": demographic_analytics.technology_adoption_patterns(),
+        "digital_divide": demographic_analytics.digital_divide_assessment(),
+        "community_networks": demographic_analytics.community_network_detection(),
+    }
+
+
+@router.get("/adoption")
+async def get_technology_adoption(_auth: Any = service.AUTH_DEP) -> Dict[str, Any]:
+    """Return technology adoption metrics."""
+    return demographic_analytics.adoption_summary()
+
+
+@router.get("/equity")
+async def get_digital_equity(_auth: Any = service.AUTH_DEP) -> Dict[str, Any]:
+    """Return digital equity analytics."""
+    return demographic_analytics.digital_equity_metrics()
+
+
+__all__ = ["router"]
+

--- a/src/piwardrive/service.py
+++ b/src/piwardrive/service.py
@@ -33,6 +33,7 @@ from piwardrive.api.system import collect_widget_metrics as _collect_widget_metr
 from piwardrive.api.system import router as system_router
 from piwardrive.api.websockets import router as ws_router
 from piwardrive.api.widgets import router as widgets_router
+from piwardrive.api.demographics import router as demographics_router
 from piwardrive.error_middleware import add_error_middleware
 from piwardrive.routes import analytics as analytics_routes
 from piwardrive.routes import bluetooth as bluetooth_routes
@@ -63,6 +64,7 @@ app.include_router(wifi_routes.router)
 app.include_router(bluetooth_routes.router)
 app.include_router(cellular_routes.router)
 app.include_router(analytics_routes.router)
+app.include_router(demographics_router)
 app.include_router(jobs_router)
 app.include_router(maintenance_jobs_router)
 app.include_router(monitoring_router)

--- a/src/piwardrive/services/demographic_analytics.py
+++ b/src/piwardrive/services/demographic_analytics.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+"""Simple demographic analytics using example data."""
+
+import json
+from functools import lru_cache
+from pathlib import Path
+from statistics import mean
+from typing import Any, Dict, List
+
+
+_DATA_PATH = Path(__file__).resolve().parents[2] / "examples" / "demographic_data.json"
+
+
+@lru_cache()
+def load_data() -> List[Dict[str, Any]]:
+    """Return demographic records from the example dataset."""
+    with open(_DATA_PATH, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def socioeconomic_correlation() -> Dict[str, Any]:
+    data = load_data()
+    incomes = [d.get("median_income", 0.0) for d in data]
+    access = [d.get("tech_access", 0.0) for d in data]
+    if not incomes or len(incomes) != len(access):
+        return {"correlation": 0.0}
+    avg_inc = mean(incomes)
+    avg_acc = mean(access)
+    cov = sum((i - avg_inc) * (a - avg_acc) for i, a in zip(incomes, access))
+    var_i = sum((i - avg_inc) ** 2 for i in incomes)
+    var_a = sum((a - avg_acc) ** 2 for a in access)
+    corr = cov / (var_i ** 0.5 * var_a ** 0.5) if var_i and var_a else 0.0
+    return {"correlation": corr}
+
+
+def technology_adoption_patterns() -> Dict[str, Any]:
+    data = load_data()
+    avg_access = mean(d.get("tech_access", 0.0) for d in data)
+    top = max(data, key=lambda d: d.get("tech_access", 0.0))
+    return {
+        "average_access": avg_access,
+        "top_region": top.get("region"),
+    }
+
+
+def digital_divide_assessment() -> Dict[str, Any]:
+    data = load_data()
+    values = [d.get("tech_access", 0.0) for d in data]
+    if not values:
+        return {"gap": 0.0}
+    return {"gap": max(values) - min(values)}
+
+
+def community_network_detection() -> Dict[str, Any]:
+    data = load_data()
+    clusters: Dict[str, List[str]] = {}
+    for rec in data:
+        region = rec.get("region")
+        lat = round(float(rec.get("latitude", 0.0)), 3)
+        lon = round(float(rec.get("longitude", 0.0)), 3)
+        key = f"{lat},{lon}"
+        clusters.setdefault(key, []).append(region)
+    return {"count": len(clusters), "clusters": clusters}
+
+
+def adoption_summary() -> Dict[str, Any]:
+    data = load_data()
+    avg_access = mean(d.get("tech_access", 0.0) for d in data)
+    penetration = mean(d.get("tech_access", 0.0) * d.get("population", 0) for d in data)
+    total_pop = sum(d.get("population", 0) for d in data)
+    penetration = penetration / total_pop if total_pop else 0.0
+    correlation = socioeconomic_correlation()["correlation"]
+    return {
+        "average_access": avg_access,
+        "market_penetration": penetration,
+        "demographic_correlation": correlation,
+        "top_region": max(data, key=lambda d: d.get("tech_access", 0.0)).get("region"),
+    }
+
+
+def digital_equity_metrics() -> Dict[str, Any]:
+    data = load_data()
+    values = [d.get("tech_access", 0.0) for d in data]
+    incomes = [d.get("median_income", 0.0) for d in data]
+    pop = [d.get("population", 0) for d in data]
+    gap = max(values) - min(values) if values else 0.0
+    avg_quality = mean(values) if values else 0.0
+    affordability = mean(i / p if p else 0.0 for i, p in zip(incomes, pop))
+    return {
+        "connectivity_gap": gap,
+        "avg_quality": avg_quality,
+        "avg_affordability": affordability,
+    }
+
+
+__all__ = [
+    "load_data",
+    "socioeconomic_correlation",
+    "technology_adoption_patterns",
+    "digital_divide_assessment",
+    "community_network_detection",
+    "adoption_summary",
+    "digital_equity_metrics",
+]

--- a/webui/src/components/DashboardLayout.jsx
+++ b/webui/src/components/DashboardLayout.jsx
@@ -16,6 +16,9 @@ import HealthAnalysis from './HealthAnalysis.jsx';
 import LogViewer from './LogViewer.jsx';
 import FingerprintSummary from './FingerprintSummary.jsx';
 import BaselineAnalysis from './BaselineAnalysis.jsx';
+import DemographicAnalytics from './DemographicAnalytics.jsx';
+import TechnologyAdoption from './TechnologyAdoption.jsx';
+import DigitalEquity from './DigitalEquity.jsx';
 
 const COMPONENTS = {
   BatteryStatusWidget: BatteryStatus,
@@ -35,6 +38,9 @@ const COMPONENTS = {
   LogViewer: LogViewer,
   DBStatsWidget: DBStats,
   FingerprintSummaryWidget: FingerprintSummary,
+  DemographicAnalyticsWidget: DemographicAnalytics,
+  TechnologyAdoptionWidget: TechnologyAdoption,
+  DigitalEquityWidget: DigitalEquity,
 };
 
 export default function DashboardLayout({ metrics }) {

--- a/webui/src/components/DemographicAnalytics.jsx
+++ b/webui/src/components/DemographicAnalytics.jsx
@@ -1,0 +1,28 @@
+import { useEffect, useState } from 'react';
+
+export default function DemographicAnalytics() {
+  const [data, setData] = useState(null);
+
+  useEffect(() => {
+    const load = () => {
+      fetch('/demographics/social')
+        .then(r => r.json())
+        .then(setData)
+        .catch(() => setData(null));
+    };
+    load();
+    const id = setInterval(load, 60000);
+    return () => clearInterval(id);
+  }, []);
+
+  if (!data) return <div>Demographic analytics: N/A</div>;
+
+  return (
+    <div>
+      <div>Socioeconomic Correlation: {data.socioeconomic_correlation?.correlation?.toFixed(2)}</div>
+      <div>Avg Tech Adoption: {data.technology_adoption_patterns?.average_access?.toFixed(2)}</div>
+      <div>Digital Divide Gap: {data.digital_divide?.gap?.toFixed(2)}</div>
+      <div>Community Networks Detected: {data.community_networks?.count}</div>
+    </div>
+  );
+}

--- a/webui/src/components/DigitalEquity.jsx
+++ b/webui/src/components/DigitalEquity.jsx
@@ -1,0 +1,27 @@
+import { useEffect, useState } from 'react';
+
+export default function DigitalEquity() {
+  const [metrics, setMetrics] = useState(null);
+
+  useEffect(() => {
+    const load = () => {
+      fetch('/demographics/equity')
+        .then(r => r.json())
+        .then(setMetrics)
+        .catch(() => setMetrics(null));
+    };
+    load();
+    const id = setInterval(load, 60000);
+    return () => clearInterval(id);
+  }, []);
+
+  if (!metrics) return <div>Digital Equity: N/A</div>;
+
+  return (
+    <div>
+      <div>Connectivity Gap: {metrics.connectivity_gap?.toFixed(2)}</div>
+      <div>Average Quality: {metrics.avg_quality?.toFixed(2)}</div>
+      <div>Average Affordability: {metrics.avg_affordability?.toFixed(2)}</div>
+    </div>
+  );
+}

--- a/webui/src/components/TechnologyAdoption.jsx
+++ b/webui/src/components/TechnologyAdoption.jsx
@@ -1,0 +1,28 @@
+import { useEffect, useState } from 'react';
+
+export default function TechnologyAdoption() {
+  const [stats, setStats] = useState(null);
+
+  useEffect(() => {
+    const load = () => {
+      fetch('/demographics/adoption')
+        .then(r => r.json())
+        .then(setStats)
+        .catch(() => setStats(null));
+    };
+    load();
+    const id = setInterval(load, 60000);
+    return () => clearInterval(id);
+  }, []);
+
+  if (!stats) return <div>Technology Adoption: N/A</div>;
+
+  return (
+    <div>
+      <div>Average Access: {stats.average_access?.toFixed(2)}</div>
+      <div>Top Region: {stats.top_region}</div>
+      <div>Market Penetration: {stats.market_penetration?.toFixed(2)}</div>
+      <div>Demographic Correlation: {stats.demographic_correlation?.toFixed(2)}</div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add simple demographic dataset
- implement demographic analytics service and API
- hook demographics router into FastAPI app
- create DemographicAnalytics, TechnologyAdoption, and DigitalEquity React components
- expose new components via dashboard layout

## Testing
- `pytest -q` *(fails: Unable to configure formatter)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68681c2c64048333b2c2a59a3dfdbe6e