### PR TITLE
Fix analytics refresh and stabilize tests

### DIFF
--- a/src/piwardrive/logging/config.py
+++ b/src/piwardrive/logging/config.py
@@ -23,7 +23,10 @@ class LoggingConfig:
             "version": 1,
             "disable_existing_loggers": False,
             "formatters": {
-                "structured": {"()": "piwardrive.logging.structured_logger.StructuredFormatter", "include_extra": True}
+                "structured": {
+                    "()": "piwardrive.logging.structured_logger.StructuredFormatter",
+                    "include_extra": True,
+                }
             },
             "handlers": {
                 "console": {
@@ -39,7 +42,13 @@ class LoggingConfig:
                     "backupCount": 5,
                 },
             },
-            "loggers": {"piwardrive": {"level": "INFO", "handlers": ["console", "file"], "propagate": False}},
+            "loggers": {
+                "piwardrive": {
+                    "level": "INFO",
+                    "handlers": ["console", "file"],
+                    "propagate": False,
+                }
+            },
         }
 
         file_config: Dict[str, Any] = {}
@@ -64,7 +73,11 @@ class LoggingConfig:
         merged: Dict[str, Any] = {}
         for cfg in configs:
             for key, value in cfg.items():
-                if isinstance(value, dict) and key in merged and isinstance(merged[key], dict):
+                if (
+                    isinstance(value, dict)
+                    and key in merged
+                    and isinstance(merged[key], dict)
+                ):
                     merged[key] = self._merge_configs(merged[key], value)
                 else:
                     merged[key] = value
@@ -72,8 +85,10 @@ class LoggingConfig:
 
     def apply(self) -> None:
         """Apply the loaded configuration using ``logging.config``."""
+        file_handler = self.config.get("handlers", {}).get("file")
+        if file_handler and "filename" in file_handler:
+            Path(file_handler["filename"]).parent.mkdir(parents=True, exist_ok=True)
         logging.config.dictConfig(self.config)
 
 
 __all__ = ["LoggingConfig"]
-

--- a/webui/tests/liveComponents.test.jsx
+++ b/webui/tests/liveComponents.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, act } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import LiveMonitoring from '../src/components/LiveMonitoring.jsx';
@@ -20,24 +20,31 @@ function mockSocket() {
 describe('live components', () => {
   beforeEach(() => {
     global.WebSocket = vi.fn(() => mockSocket());
+    HTMLCanvasElement.prototype.getContext = vi.fn();
   });
 
   it('updates live monitoring feed', async () => {
     render(<LiveMonitoring />);
-    socket.onmessage({ data: JSON.stringify({ detection: { text: 'd1' }, stats: { total: 1 } }) });
+    act(() => {
+      socket.onmessage({ data: JSON.stringify({ detection: { text: 'd1' }, stats: { total: 1 } }) });
+    });
     expect(await screen.findByText('d1')).toBeInTheDocument();
     expect(screen.getByText('Detections: 1')).toBeInTheDocument();
   });
 
   it('shows metrics alerts', async () => {
     render(<LiveMetrics />);
-    socket.onmessage({ data: JSON.stringify({ alert: 'ALERT' }) });
+    act(() => {
+      socket.onmessage({ data: JSON.stringify({ alert: 'ALERT' }) });
+    });
     expect(await screen.findByText('ALERT')).toBeInTheDocument();
   });
 
   it('updates scanning status', async () => {
     render(<ScanningStatus />);
-    socket.onmessage({ data: JSON.stringify({ progress: 50, device: { name: 's1', health: 'ok' } }) });
+    act(() => {
+      socket.onmessage({ data: JSON.stringify({ progress: 50, device: { name: 's1', health: 'ok' } }) });
+    });
     expect(await screen.findByText(/s1/)).toBeInTheDocument();
   });
 });

--- a/webui/tests/logViewer.test.jsx
+++ b/webui/tests/logViewer.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import LogViewer from '../src/components/LogViewer.jsx';
@@ -26,10 +26,10 @@ describe('LogViewer', () => {
   it('calls fetch with params and updates path', async () => {
     global.fetch = vi.fn(() => Promise.resolve({ json: () => Promise.resolve({ lines: ['A', 'B'] }) }));
     const { unmount } = render(<LogViewer path="/a.log" lines={10} />);
-    await Promise.resolve();
+    await act(() => Promise.resolve());
     expect(global.fetch).toHaveBeenCalledWith('/logs?path=%2Fa.log&lines=10');
     fireEvent.change(screen.getByDisplayValue('/a.log'), { target: { value: '/b.log' } });
-    await Promise.resolve();
+    await act(() => Promise.resolve());
     expect(global.fetch).toHaveBeenLastCalledWith('/logs?path=%2Fb.log&lines=10');
     unmount();
   });
@@ -38,19 +38,19 @@ describe('LogViewer', () => {
     let count = 0;
     global.fetch = vi.fn(() => Promise.resolve({ json: () => Promise.resolve({ lines: [`L${++count}`] }) }));
     const { unmount } = render(<LogViewer />);
-    await Promise.resolve();
+    await act(() => Promise.resolve());
     expect(global.fetch).toHaveBeenCalledTimes(2);
     intervalFn();
-    await Promise.resolve();
+    await act(() => Promise.resolve());
     expect(global.fetch).toHaveBeenCalledTimes(3);
     unmount();
   });
   it('filters lines with regex', async () => {
     global.fetch = vi.fn(() => Promise.resolve({ json: () => Promise.resolve({ lines: ['OK', 'ERR'] }) }));
     render(<LogViewer />);
-    await Promise.resolve();
+    await act(() => Promise.resolve());
     fireEvent.change(screen.getByPlaceholderText('Filter regex'), { target: { value: 'ERR' } });
-    await Promise.resolve();
+    await act(() => Promise.resolve());
     expect(screen.getByText('ERR')).toBeInTheDocument();
     expect(screen.queryByText('OK')).toBeNull();
   });

--- a/webui/tests/vehicleSensors.test.js
+++ b/webui/tests/vehicleSensors.test.js
@@ -1,9 +1,13 @@
 import { describe, it, expect } from 'vitest';
 import * as vs from '../src/vehicleSensors.js';
 
+function setObd(value) {
+  Object.defineProperty(vs, 'obd', { value, writable: true });
+}
+
 describe('vehicleSensors', () => {
   it('returns null when obd missing', () => {
-    vs.obd = null;
+    setObd(null);
     expect(vs.readRpmObd()).toBeNull();
   });
 
@@ -15,10 +19,10 @@ describe('vehicleSensors', () => {
     class DummyConn {
       query() { return { value: new DummyVal(50) }; }
     }
-    vs.obd = {
+    setObd({
       OBD: () => new DummyConn(),
       commands: { ENGINE_LOAD: 'ENGINE_LOAD', RPM: 'RPM' }
-    };
+    });
     expect(vs.readEngineLoadObd()).toBe(50);
     expect(vs.readRpmObd()).toBe(50);
   });


### PR DESCRIPTION
## Summary
- implement `refresh_daily_detection_stats` and `refresh_network_coverage_grid`
- ensure logging directories exist when applying config
- improve JS tests to mock readonly exports and wrap state updates in `act`

## Testing
- `black --check src/piwardrive/core/persistence.py src/piwardrive/logging/config.py`
- `pytest tests/test_utils.py -k count_bettercap_handshakes -vv` *(fails: ModuleNotFoundError: No module named 'requests_cache')*

------
https://chatgpt.com/codex/tasks/task_e_686986860198833388d37dd62c266891