### PR TITLE
Fix lint errors and add eslint globals

### DIFF
--- a/config/.flake8
+++ b/config/.flake8
@@ -1,4 +1,4 @@
 [flake8]
 max-line-length = 88
 extend-ignore = E203,W503
-exclude = tests,.gitattributes,screens,widgets,docs/conf.py
+exclude = tests,.gitattributes,screens,widgets,docs/conf.py,node_modules

--- a/src/gps_handler.py
+++ b/src/gps_handler.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 
 import logging
 import os
-import time
 from typing import Any
 
 try:  # pragma: no cover - optional dependency may be missing
@@ -28,7 +27,13 @@ logger = logging.getLogger(__name__)
 class GPSHandler:
     """Simple wrapper around :mod:`gps` providing timeout handling."""
 
-    def __init__(self, host: str | None = None, port: int | None = None, *, timeout: float = 1.0) -> None:
+    def __init__(
+        self,
+        host: str | None = None,
+        port: int | None = None,
+        *,
+        timeout: float = 1.0,
+    ) -> None:
         self.host = host or os.getenv("PW_GPSD_HOST", "127.0.0.1")
         self.port = port or int(os.getenv("PW_GPSD_PORT", 2947))
         self.timeout = timeout

--- a/src/piwardrive/__init__.py
+++ b/src/piwardrive/__init__.py
@@ -5,6 +5,8 @@ import sys
 from importlib import import_module
 from types import ModuleType
 
+from .widget_manager import LazyWidgetManager
+
 logger = logging.getLogger(__name__)
 
 sigint_suite: ModuleType | None
@@ -51,7 +53,5 @@ for _mod in (
         sys.modules.setdefault(_mod, module)
     except Exception as exc:
         logger.warning("Failed to import optional module '%s': %s", _mod, exc)
-
-from .widget_manager import LazyWidgetManager
 
 __all__ = ["sigint_suite", "LazyWidgetManager"]

--- a/src/piwardrive/analysis.py
+++ b/src/piwardrive/analysis.py
@@ -3,9 +3,13 @@
 import math
 from dataclasses import asdict
 from statistics import fmean
-from typing import Dict, List
+from typing import Callable, Dict, List
 
 from piwardrive.persistence import HealthRecord
+
+import os
+import sys
+
 
 try:  # optional dependency
     import pandas as pd
@@ -92,14 +96,16 @@ def plot_cpu_temp(
 # ─────────────────────────────────────────────────────────────
 # External ML hooks
 
-import os
-import sys
-from typing import Callable
-
 try:
     from .analytics.anomaly import HealthAnomalyDetector
 except Exception:  # pragma: no cover - optional dependency
     HealthAnomalyDetector = None
+
+
+def register_ml_hook(func: Callable[[HealthRecord], None]) -> None:
+    """Register ``func`` to be called with each new :class:`HealthRecord`."""
+    _ML_HOOKS.append(func)
+
 
 _ML_HOOKS: list[Callable[[HealthRecord], None]] = []
 
@@ -117,11 +123,6 @@ if (
 ):
     _ANOMALY_DETECTOR = HealthAnomalyDetector()
     register_ml_hook(_ANOMALY_DETECTOR)
-
-
-def register_ml_hook(func: Callable[[HealthRecord], None]) -> None:
-    """Register ``func`` to be called with each new :class:`HealthRecord`."""
-    _ML_HOOKS.append(func)
 
 
 def process_new_record(record: HealthRecord) -> None:

--- a/src/piwardrive/analysis/packet_engine.py
+++ b/src/piwardrive/analysis/packet_engine.py
@@ -6,13 +6,12 @@ Real-time protocol analysis, topology mapping, and traffic classification
 import struct
 import socket
 import time
-from typing import Dict, List, Optional, Tuple, Any, Set
+from typing import Any, Dict, List, Optional, Set
 from dataclasses import dataclass, field
 from enum import Enum
 from collections import defaultdict, deque
 import hashlib
-import ipaddress
-from datetime import datetime, timedelta
+from datetime import datetime
 import logging
 
 logger = logging.getLogger(__name__)

--- a/webui/src/btScanner.js
+++ b/webui/src/btScanner.js
@@ -1,3 +1,5 @@
+/* global global */
+
 export async function scanBluetooth(timeout = 10) {
   if (typeof global.bleakDiscover === 'function') {
     const devices = await global.bleakDiscover(timeout);

--- a/webui/src/config.js
+++ b/webui/src/config.js
@@ -1,6 +1,8 @@
 import fs from 'fs';
 import path from 'path';
 
+/* global process */
+
 export let CONFIG_DIR = process.cwd();
 export let CONFIG_PATH = path.join(CONFIG_DIR, 'config.json');
 export let PROFILES_DIR = path.join(CONFIG_DIR, 'profiles');
@@ -220,5 +222,7 @@ export function importProfile(src, name) {
 export function deleteProfile(name) {
   try {
     fs.unlinkSync(_profilePath(name));
-  } catch {}
+  } catch (e) {
+    // ignore missing file
+  }
 }

--- a/webui/src/healthMonitor.js
+++ b/webui/src/healthMonitor.js
@@ -1,4 +1,3 @@
-import { PollScheduler } from './scheduler.js';
 
 export class HealthMonitor {
   constructor(scheduler, interval = 10, collector = null) {

--- a/webui/src/kiosk.js
+++ b/webui/src/kiosk.js
@@ -2,6 +2,8 @@ import { spawn as _spawn } from 'child_process';
 import fs from 'fs';
 import path from 'path';
 
+/* global process */
+
 function which(cmd) {
   const dirs = process.env.PATH.split(path.delimiter);
   for (const d of dirs) {
@@ -9,7 +11,9 @@ function which(cmd) {
     try {
       fs.accessSync(p, fs.constants.X_OK);
       return p;
-    } catch (e) {}
+    } catch (e) {
+      // ignore missing executable
+    }
   }
   return null;
 }

--- a/webui/src/logconfig.js
+++ b/webui/src/logconfig.js
@@ -1,5 +1,7 @@
 import fs from 'fs';
 
+/* global process */
+
 const LEVELS = { DEBUG: 10, INFO: 20, WARNING: 30, ERROR: 40 };
 
 export function setupLogging({ logFile, level = 'INFO', stdout = false } = {}) {

--- a/webui/src/networkAnalytics.js
+++ b/webui/src/networkAnalytics.js
@@ -1,4 +1,5 @@
 export function cachedLookupVendor(_bssid) {
+  void _bssid;
   return 'Vendor';
 }
 

--- a/webui/src/rfUtils.js
+++ b/webui/src/rfUtils.js
@@ -7,8 +7,8 @@ export function spectrumScan(centerFreq, { sampleRate = 2.4, numSamples = 256 } 
   return [freqs, power];
 }
 
-export function demodulateFm(centerFreq, { sampleRate = 2.4, audioRate = 1.0, duration = 1.0 } = {}) {
+export function demodulateFm(centerFreq, { audioRate = 1.0, duration = 1.0 } = {}) {
   const samples = Math.floor(duration * audioRate);
   const step = Math.PI / 2;
-  return Array.from({ length: samples }, (_, i) => step);
+  return Array.from({ length: samples }, () => step);
 }

--- a/webui/src/security.js
+++ b/webui/src/security.js
@@ -1,6 +1,8 @@
 import crypto from 'crypto';
 import path from 'path';
 
+/* global Buffer */
+
 export function sanitizePath(p) {
   const normalized = path.normalize(p);
   if (normalized.split(path.sep).includes('..')) {

--- a/webui/src/sigintIntegration.js
+++ b/webui/src/sigintIntegration.js
@@ -1,5 +1,7 @@
 import fs from 'fs';
 import path from 'path';
+
+/* global process */
 import { EXPORT_DIR } from './sigintPaths.js';
 
 export function loadSigintData(name) {

--- a/webui/src/sigintPaths.js
+++ b/webui/src/sigintPaths.js
@@ -1,2 +1,3 @@
+/* global process */
 const DEFAULT_EXPORT_DIR = '/exports';
 export const EXPORT_DIR = process.env.EXPORT_DIR || DEFAULT_EXPORT_DIR;

--- a/webui/src/sigintPlugins.js
+++ b/webui/src/sigintPlugins.js
@@ -2,6 +2,8 @@ import fs from 'fs';
 import path from 'path';
 import { createRequire } from 'module';
 
+/* global process */
+
 const require = createRequire(import.meta.url);
 
 function pluginDir() {

--- a/webui/src/startKioskScript.js
+++ b/webui/src/startKioskScript.js
@@ -2,6 +2,8 @@ import { spawn as _spawn } from 'child_process';
 import { fileURLToPath } from 'url';
 import path from 'path';
 
+/* global process */
+
 export function runStartKioskScript({ args = [], env = process.env, spawnFn = _spawn } = {}) {
   const scriptPath = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', '..', 'scripts', 'start_kiosk.sh');
   return new Promise((resolve, reject) => {

--- a/webui/src/tileCache.js
+++ b/webui/src/tileCache.js
@@ -52,7 +52,9 @@ export async function prefetchTiles(bounds, zoom = 16, progressCb) {
           const buf = await resp.arrayBuffer();
           idx[key] = { time: Date.now(), size: buf.byteLength };
         }
-      } catch {}
+      } catch (e) {
+        // ignore caching failures
+      }
     } else {
       idx[key].time = Date.now();
     }

--- a/webui/src/vacuumDb.js
+++ b/webui/src/vacuumDb.js
@@ -1,5 +1,7 @@
 import { execFileSync } from 'child_process';
 
+/* global process */
+
 export function main(dbPath) {
   execFileSync('sqlite3', [dbPath, 'VACUUM']);
 }

--- a/webui/src/widgetPlugins.js
+++ b/webui/src/widgetPlugins.js
@@ -1,6 +1,8 @@
 import fs from 'fs';
 import path from 'path';
 
+/* global process, require */
+
 const PLUGIN_DIR = path.join(process.env.HOME || '', '.config', 'piwardrive', 'plugins');
 let PLUGIN_STAMP = null;
 const PLUGINS = {};
@@ -9,7 +11,8 @@ function loadPlugins() {
   let stat;
   try {
     stat = fs.statSync(PLUGIN_DIR);
-  } catch {
+  } catch (e) {
+    // ignore missing plugin directory
     return;
   }
   const stamp = stat.mtimeMs;
@@ -27,7 +30,9 @@ function loadPlugins() {
             PLUGINS[name] = obj;
           }
         }
-      } catch {}
+      } catch (e) {
+        // ignore plugin load errors
+      }
     }
   }
   PLUGIN_STAMP = stamp;


### PR DESCRIPTION
## Summary
- exclude node modules from Flake8
- address long lines and unused imports in gps handler and init modules
- reorder imports in analysis utilities
- clean up unused imports in packet engine
- fix eslint errors by declaring globals and avoiding empty blocks

## Testing
- `flake8 --config config/.flake8 src/gps_handler.py src/piwardrive/__init__.py src/piwardrive/analysis.py`
- `npx eslint src`
- `npm test` *(fails: Cannot spy on export, missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_6869867ceafc8333908b3b4bcc02c522